### PR TITLE
Add real voice synthesis test

### DIFF
--- a/src/test/kotlin/giga/GigaVoiceApiTest.kt
+++ b/src/test/kotlin/giga/GigaVoiceApiTest.kt
@@ -1,0 +1,29 @@
+package giga
+
+import com.dumch.giga.GigaAuth
+import com.dumch.giga.GigaVoiceAPI
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class GigaVoiceApiTest {
+    @Test
+    fun `synthesize small text`() = runBlocking {
+        val key = System.getenv("VOICE_KEY")
+        if (key.isNullOrBlank()) {
+            println("VOICE_KEY not set; skipping real API test")
+            return@runBlocking
+        }
+
+        val api = GigaVoiceAPI(GigaAuth)
+        try {
+            val audio = api.synthesize("<speak>Hello</speak>")
+            assertTrue(audio.isNotEmpty())
+            val header = audio.copyOfRange(0, 4).decodeToString()
+            assertEquals("RIFF", header)
+        } finally {
+            api.clear()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a new test that exercises GigaVoiceAPI against the live service

## Testing
- `./gradlew test` *(fails: Could not resolve org.jetbrains.kotlin:kotlin-test:2.1.21 - Received status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_6893c3631270832986adb3cdd740ff3b