### PR TITLE
Add recognition test for GigaVoiceAPI using Opus conversion

### DIFF
--- a/src/test/kotlin/giga/GigaVoiceRecognizeTest.kt
+++ b/src/test/kotlin/giga/GigaVoiceRecognizeTest.kt
@@ -1,0 +1,25 @@
+package giga
+
+import com.dumch.giga.GigaAuth
+import com.dumch.giga.GigaVoiceAPI
+import com.dumch.audio.InMemoryOpusRecorder
+import java.io.File
+import kotlin.test.assertTrue
+
+suspend fun main() {
+    val key = System.getenv("VOICE_KEY")
+    if (key.isNullOrBlank()) {
+        println("VOICE_KEY not set; skipping real API test")
+        return
+    }
+
+    val api = GigaVoiceAPI(GigaAuth)
+    try {
+        val wavBytes = File("Generated.wav").readBytes()
+        val oggBytes = InMemoryOpusRecorder.wavToOpusOgg(wavBytes)
+        val text = api.recognize(oggBytes)
+        assertTrue(text.contains("hello", ignoreCase = true))
+    } finally {
+        api.clear()
+    }
+}


### PR DESCRIPTION
## Summary
- Add test verifying GigaVoiceAPI.recognize after converting generated WAV to Opus Ogg

## Testing
- `./gradlew test` *(fails: Could not resolve org.jetbrains.kotlin:kotlin-test:2.1.21, status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_6894df064c808329bca02801cfedc80d