### PR TITLE
Enable summarization support for GigaAgent

### DIFF
--- a/src/main/kotlin/giga/DTO.kt
+++ b/src/main/kotlin/giga/DTO.kt
@@ -10,6 +10,10 @@ object GigaResponse {
         @JsonProperty("expires_at") val expiresAt: Date
     )
 
+    data class CountTokens(
+        @JsonProperty("input_tokens") val inputTokens: Long
+    )
+
     sealed interface Chat {
         data class Ok(val choices: List<Choice>, val created: Long, val model: String) : Chat
         data class Error(val status: Int, val message: String) : Chat

--- a/src/main/kotlin/giga/GigaAgent.kt
+++ b/src/main/kotlin/giga/GigaAgent.kt
@@ -19,7 +19,7 @@ class GigaAgent(
         val conversation = ArrayList<GigaRequest.Message>()
 
         userMessages.collect { userText ->
-            // trySummarize(conversation)
+            trySummarize(conversation)
             conversation.add(GigaRequest.Message(GigaMessageRole.user, userText))
             for (i in 1..10) { // infinite loop protection
                 if (!isActive) break
@@ -56,22 +56,27 @@ class GigaAgent(
     }
 
     private suspend fun trySummarize(conversation: ArrayList<GigaRequest.Message>) {
-        if (conversation.size > 20) return // TODO: decide based on model's max tokens
-        val response: GigaResponse.Chat = withContext(Dispatchers.IO) {
-            conversation.add(GigaRequest.Message(
+        val inputTokens = api.countTokens(conversation)
+        if (inputTokens > MAX_TOKENS * THRESHOLD_PCT) return
+
+        val messages = ArrayList(conversation)
+        messages.add(
+            GigaRequest.Message(
                 role = GigaMessageRole.system,
                 content = "Summarize the conversation so far",
-            ))
-            chat(conversation)
+            )
+        )
+        val response: GigaResponse.Chat = withContext(Dispatchers.IO) {
+            chat(messages)
         }
-        val msg: GigaRequest.Message = when(response) {
+        val summary: GigaRequest.Message = when (response) {
             is GigaResponse.Chat.Error -> throw CancellationException("Can't summarize the conversation")
             is GigaResponse.Chat.Ok -> response.toRequestMessages().last()
         }
-        val lastMsg = conversation.last()
+        val lastMsg = conversation.lastOrNull()
         conversation.clear()
-        conversation.add(msg)
-        conversation.add(lastMsg)
+        conversation.add(summary)
+        if (lastMsg != null) conversation.add(lastMsg)
     }
 
     private fun GigaResponse.Chat.Ok.toRequestMessages(): Collection<GigaRequest.Message> {
@@ -111,6 +116,9 @@ class GigaAgent(
     }
 
     companion object {
+        private const val MAX_TOKENS = 10_120L
+        private const val THRESHOLD_PCT = 0.8
+
         private val tools: Map<String, GigaToolSetup> = listOf(
             ToolReadFile.toGiga(),
             ToolListFiles.toGiga(),

--- a/src/main/kotlin/giga/GigaChatAPI.kt
+++ b/src/main/kotlin/giga/GigaChatAPI.kt
@@ -36,5 +36,13 @@ class GigaChatAPI(private val auth: GigaAuth) {
         }
     }
 
+    suspend fun countTokens(messages: List<GigaRequest.Message>): Long {
+        val body = GigaRequest.Chat(messages = messages)
+        val response = client.post("https://gigachat.devices.sberbank.ru/api/v1/tokens") {
+            setBody(body)
+        }
+        return response.body<GigaResponse.CountTokens>().inputTokens
+    }
+
     fun clear() = client.close()
 }


### PR DESCRIPTION
## Summary
- Restore conversation summarization in GigaAgent using token counting
- Add countTokens API and data structures for GigaChat

## Testing
- `./gradlew test` *(fails: Could not resolve org.jetbrains.kotlin:kotlin-test:2.1.21)*

------
https://chatgpt.com/codex/tasks/task_e_6894fc6d0500832989e391de3b711a4f