### PR TITLE
Fix gigachat audio recording invalid opus packet

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -38,7 +38,7 @@ suspend fun main() = coroutineScope {
             .catch { System.err.println("Error in audio flow: ${it.message}") }
             .map { audioData ->
                 File("capture2.ogg").writeBytes(audioData)
-                val resp = gigaVoiceAPI.recognize(File("capture2.ogg").readBytes())
+                val resp = gigaVoiceAPI.recognize(audioData)
                 println("Recognition response: $resp")
                 resp
             }

--- a/src/main/kotlin/audio/AudioRecorder.kt
+++ b/src/main/kotlin/audio/AudioRecorder.kt
@@ -47,8 +47,9 @@ class InMemoryAudioRecorder(
         coroutineScope.launch {
             try {
                 _recordingState.value = State.Stopping
-                val audioData = InMemoryOpusRecorder.stopRecording()
-                _audioFlow.emit(audioData)
+                val wavBytes = InMemoryOpusRecorder.stopRecording()
+                val oggBytes = InMemoryOpusRecorder.wavToOpusOgg(wavBytes)
+                _audioFlow.emit(oggBytes)
                 _recordingState.value = State.Idle
             } catch (e: Exception) {
                 _recordingState.value = State.Error(e.message ?: "Failed to stop recording")


### PR DESCRIPTION
## Summary
- encode audio from InMemoryAudioRecorder to Ogg Opus before emitting
- send recorded Ogg audio bytes directly to GigaVoice API

## Testing
- `./gradlew test` *(fails: Could not resolve all files for configuration ':testCompileClasspath'. Could not resolve org.jetbrains.kotlin:kotlin-test:2.1.21)*

------
https://chatgpt.com/codex/tasks/task_e_689513c18ce8832994c9e34ca72cc76f