### PR TITLE
Add desktop screenshot tool that uploads to GigaChat

### DIFF
--- a/src/main/kotlin/giga/GigaAgent.kt
+++ b/src/main/kotlin/giga/GigaAgent.kt
@@ -6,6 +6,7 @@ import com.dumch.tool.desktop.ToolOpenApp
 import com.dumch.tool.desktop.ToolOpenBrowser
 import com.dumch.tool.desktop.ToolOpenFolder
 import com.dumch.tool.desktop.ToolOpenPhoto
+import com.dumch.tool.desktop.ToolDesktopScreenShot
 import com.dumch.tool.files.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.Flow
@@ -135,6 +136,7 @@ class GigaAgent(
             ToolOpenPhoto(ToolRunBashCommand).toGiga(),
             ToolOpenFolder(ToolRunBashCommand).toGiga(),
             ToolOpenApp(ToolRunBashCommand).toGiga(),
+            ToolDesktopScreenShot(ToolRunBashCommand, GigaChatAPI(GigaAuth)).toGiga(),
         ).associateBy { it.fn.name }
 
         fun instance(userMessages: Flow<String>, api: GigaChatAPI): GigaAgent {

--- a/src/main/kotlin/giga/GigaToolSetup.kt
+++ b/src/main/kotlin/giga/GigaToolSetup.kt
@@ -2,6 +2,7 @@ package com.dumch.giga
 
 import com.dumch.tool.InputParamDescription
 import com.dumch.tool.ToolSetup
+import com.dumch.tool.desktop.ToolDesktopScreenShot
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import kotlin.reflect.KCallable
 import kotlin.reflect.full.declaredMembers
@@ -48,6 +49,45 @@ inline fun <reified Input> ToolSetup<Input>.toGiga(): GigaToolSetup {
                 GigaRequest.Message(
                     role = GigaMessageRole.function,
                     content = gigaResult,
+                )
+            } catch (e: Exception) {
+                e.toGigaToolMessage()
+            }
+        }
+    }
+}
+
+fun ToolDesktopScreenShot.toGiga(): GigaToolSetup {
+    val toolSetup = this
+    return object : GigaToolSetup {
+        override val fn: GigaRequest.Function = GigaRequest.Function(
+            name = toolSetup.name,
+            description = toolSetup.description,
+            parameters = GigaRequest.Parameters(
+                "object",
+                properties = HashMap<String, GigaRequest.Property>().apply {
+                    val clazz = ToolDesktopScreenShot.Input::class
+                    for (kProperty: KCallable<*> in clazz.declaredMembers) {
+                        val annotation = kProperty.findAnnotation<InputParamDescription>() ?: continue
+                        val description = annotation.value
+                        val type = kProperty.returnType.toString().substringAfterLast(".").lowercase()
+                        val gigaProperty = GigaRequest.Property(type, description)
+                        put(kProperty.name, gigaProperty)
+                    }
+                },
+            ),
+        )
+
+        override fun invoke(functionCall: GigaResponse.FunctionCall): GigaRequest.Message {
+            return try {
+                val input: ToolDesktopScreenShot.Input =
+                    gigaJsonMapper.convertValue(functionCall.arguments, ToolDesktopScreenShot.Input::class.java)
+                val id = toolSetup.invoke(input)
+                val gigaResult = gigaJsonMapper.writeValueAsString(mapOf("result" to id))
+                GigaRequest.Message(
+                    role = GigaMessageRole.function,
+                    content = gigaResult,
+                    attachments = listOf(id),
                 )
             } catch (e: Exception) {
                 e.toGigaToolMessage()

--- a/src/main/kotlin/tool/desktop/ToolDesktopScreenShot.kt
+++ b/src/main/kotlin/tool/desktop/ToolDesktopScreenShot.kt
@@ -1,0 +1,38 @@
+package com.dumch.tool.desktop
+
+import com.dumch.giga.GigaAuth
+import com.dumch.giga.GigaChatAPI
+import com.dumch.tool.InputParamDescription
+import com.dumch.tool.ToolRunBashCommand
+import com.dumch.tool.ToolSetup
+import kotlinx.coroutines.runBlocking
+import java.io.File
+
+class ToolDesktopScreenShot(
+    private val bash: ToolRunBashCommand,
+    private val api: GigaChatAPI = GigaChatAPI(GigaAuth)
+) : ToolSetup<ToolDesktopScreenShot.Input> {
+
+    override val name: String = "DesktopScreenShot"
+    override val description: String = "Takes a screenshot of selected desktop and uploads it to GigaChat"
+
+    override fun invoke(input: Input): String {
+        val file = File.createTempFile("screenshot", ".jpg")
+        try {
+            bash.invoke(
+                ToolRunBashCommand.Input(
+                    """screencapture -x -D ${input.path} -t jpg ${file.absolutePath}""".trimIndent()
+                )
+            )
+            val resp = runBlocking { api.uploadImage(file) }
+            return resp.id
+        } finally {
+            file.delete()
+        }
+    }
+
+    data class Input(
+        @InputParamDescription("Desktop number to capture, e.g., '1' for the primary display by default")
+        val path: String = "1"
+    )
+}


### PR DESCRIPTION
## Summary
- add DesktopScreenShot tool capturing a display and uploading via GigaChat API
- convert screenshot tool into Giga function with attachment support
- register the new tool within GigaAgent

## Testing
- `./gradlew test` *(fails: Entry russian_trusted_sub_ca_gost_2025.cer is a duplicate)*

------
https://chatgpt.com/codex/tasks/task_e_68964e2e7148832981c4e117fce4ad94