### PR TITLE
Add desktop screenshot tool with image attachments

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.api.file.DuplicatesStrategy
+
 plugins {
     kotlin("jvm") version Versions.Kotlin
 }
@@ -41,4 +43,8 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform()
+}
+
+tasks.processResources {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
-import java.io.File
 
 private const val AGENT_ALIAS = ""
 

--- a/src/main/kotlin/giga/GigaAgent.kt
+++ b/src/main/kotlin/giga/GigaAgent.kt
@@ -105,7 +105,7 @@ class GigaAgent(
         }
     }
 
-    private fun executeTool(functionCall: GigaResponse.FunctionCall): GigaRequest.Message {
+    private suspend fun executeTool(functionCall: GigaResponse.FunctionCall): GigaRequest.Message {
         val fn = tools[functionCall.name] ?: return GigaRequest.Message(
             GigaMessageRole.function, """{"result":"no such function ${functionCall.name}"}"""
         )
@@ -131,12 +131,12 @@ class GigaAgent(
             ToolDeleteFile.toGiga(),
             ToolModifyFile.toGiga(),
             ToolFindTextInFiles.toGiga(),
+            ToolDesktopScreenShot().toGiga(),
             ToolOpenBrowser(ToolRunBashCommand).toGiga(),
             ToolCreateNote(ToolRunBashCommand).toGiga(),
             ToolOpenPhoto(ToolRunBashCommand).toGiga(),
             ToolOpenFolder(ToolRunBashCommand).toGiga(),
             ToolOpenApp(ToolRunBashCommand).toGiga(),
-            ToolDesktopScreenShot().toGiga(),
         ).associateBy { it.fn.name }
 
         fun instance(userMessages: Flow<String>, api: GigaChatAPI): GigaAgent {

--- a/src/main/kotlin/giga/GigaAgent.kt
+++ b/src/main/kotlin/giga/GigaAgent.kt
@@ -6,6 +6,7 @@ import com.dumch.tool.desktop.ToolOpenApp
 import com.dumch.tool.desktop.ToolOpenBrowser
 import com.dumch.tool.desktop.ToolOpenFolder
 import com.dumch.tool.desktop.ToolOpenPhoto
+import com.dumch.tool.desktop.ToolDesktopScreenShot
 import com.dumch.tool.files.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.Flow
@@ -135,6 +136,7 @@ class GigaAgent(
             ToolOpenPhoto(ToolRunBashCommand).toGiga(),
             ToolOpenFolder(ToolRunBashCommand).toGiga(),
             ToolOpenApp(ToolRunBashCommand).toGiga(),
+            ToolDesktopScreenShot().toGiga(),
         ).associateBy { it.fn.name }
 
         fun instance(userMessages: Flow<String>, api: GigaChatAPI): GigaAgent {

--- a/src/main/kotlin/giga/GigaToolSetup.kt
+++ b/src/main/kotlin/giga/GigaToolSetup.kt
@@ -2,6 +2,7 @@ package com.dumch.giga
 
 import com.dumch.tool.InputParamDescription
 import com.dumch.tool.ToolSetup
+import com.dumch.tool.ToolSetupWithAttachments
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import kotlin.reflect.KCallable
 import kotlin.reflect.full.declaredMembers
@@ -48,6 +49,48 @@ inline fun <reified Input> ToolSetup<Input>.toGiga(): GigaToolSetup {
                 GigaRequest.Message(
                     role = GigaMessageRole.function,
                     content = gigaResult,
+                )
+            } catch (e: Exception) {
+                e.toGigaToolMessage()
+            }
+        }
+    }
+}
+
+inline fun <reified Input> ToolSetupWithAttachments<Input>.toGiga(): GigaToolSetup {
+    val toolSetup = this
+    return object : GigaToolSetup {
+        override val fn: GigaRequest.Function = GigaRequest.Function(
+            name = toolSetup.name,
+            description = toolSetup.description,
+            parameters = GigaRequest.Parameters(
+                "object",
+                properties = HashMap<String, GigaRequest.Property>().apply {
+                    val clazz = Input::class
+                    for (kProperty: KCallable<*> in clazz.declaredMembers) {
+                        val annotation = kProperty.findAnnotation<InputParamDescription>() ?: continue
+                        val description = annotation.value
+                        val type = kProperty.returnType.toString().substringAfterLast(".").lowercase()
+                        val gigaProperty = GigaRequest.Property(type, description)
+                        put(kProperty.name, gigaProperty)
+                    }
+                }
+            )
+        )
+
+        override fun invoke(
+            functionCall: GigaResponse.FunctionCall,
+        ): GigaRequest.Message {
+            return try {
+                val input: Input = gigaJsonMapper.convertValue(functionCall.arguments, Input::class.java)
+                val toolResult = toolSetup.invoke(input)
+                val gigaResult = gigaJsonMapper.writeValueAsString(
+                    mapOf("result" to toolResult)
+                )
+                GigaRequest.Message(
+                    role = GigaMessageRole.function,
+                    content = gigaResult,
+                    attachments = toolSetup.attachments
                 )
             } catch (e: Exception) {
                 e.toGigaToolMessage()

--- a/src/main/kotlin/giga/GigaToolSetup.kt
+++ b/src/main/kotlin/giga/GigaToolSetup.kt
@@ -11,7 +11,7 @@ import kotlin.reflect.full.findAnnotation
 
 interface GigaToolSetup {
     val fn: GigaRequest.Function
-    operator fun invoke(functionCall: GigaResponse.FunctionCall): GigaRequest.Message
+    suspend operator fun invoke(functionCall: GigaResponse.FunctionCall): GigaRequest.Message
 }
 
 val gigaJsonMapper = jacksonObjectMapper()
@@ -37,7 +37,7 @@ inline fun <reified Input> ToolSetup<Input>.toGiga(): GigaToolSetup {
             )
         )
 
-        override fun invoke(
+        override suspend fun invoke(
             functionCall: GigaResponse.FunctionCall,
         ): GigaRequest.Message {
             return try {
@@ -78,12 +78,12 @@ inline fun <reified Input> ToolSetupWithAttachments<Input>.toGiga(): GigaToolSet
             )
         )
 
-        override fun invoke(
+        override suspend fun invoke(
             functionCall: GigaResponse.FunctionCall,
         ): GigaRequest.Message {
             return try {
                 val input: Input = gigaJsonMapper.convertValue(functionCall.arguments, Input::class.java)
-                val toolResult = toolSetup.invoke(input)
+                val toolResult = toolSetup.suspendInvoke(input)
                 val gigaResult = gigaJsonMapper.writeValueAsString(
                     mapOf("result" to toolResult)
                 )

--- a/src/main/kotlin/image/ImageUtils.kt
+++ b/src/main/kotlin/image/ImageUtils.kt
@@ -15,10 +15,10 @@ import javax.imageio.ImageWriteParam
  */
 object ImageUtils {
     /** Capture the entire desktop and return the image as JPEG bytes. */
-    fun captureDesktop(): ByteArray {
+    fun captureDesktop(robot: Robot): ByteArray {
         val screenSize = Toolkit.getDefaultToolkit().screenSize
         val captureRect = Rectangle(screenSize)
-        val image = Robot().createScreenCapture(captureRect)
+        val image = robot.createScreenCapture(captureRect)
         val output = ByteArrayOutputStream()
         val writer = ImageIO.getImageWritersByFormatName("jpg").next()
         val ios = ImageIO.createImageOutputStream(output)
@@ -57,7 +57,7 @@ object ImageUtils {
 }
 
 fun main() {
-    val screenshot = ImageUtils.captureDesktop()
+    val screenshot = ImageUtils.captureDesktop(Robot())
     val jpeg = ImageUtils.compressJpeg(screenshot)
     File("desktop.jpg").writeBytes(jpeg)
 }

--- a/src/main/kotlin/tool/ToolSetup.kt
+++ b/src/main/kotlin/tool/ToolSetup.kt
@@ -16,4 +16,8 @@ interface ToolSetup<Input> {
     operator fun invoke(input: Input): String
 }
 
+interface ToolSetupWithAttachments<Input> : ToolSetup<Input> {
+    val attachments: List<String>
+}
+
 class BadInputException(msg: String) : Exception(msg)

--- a/src/main/kotlin/tool/ToolSetup.kt
+++ b/src/main/kotlin/tool/ToolSetup.kt
@@ -14,6 +14,7 @@ interface ToolSetup<Input> {
     val description: String
 
     operator fun invoke(input: Input): String
+    suspend fun suspendInvoke(input: Input): String = invoke(input)
 }
 
 interface ToolSetupWithAttachments<Input> : ToolSetup<Input> {

--- a/src/main/kotlin/tool/desktop/ToolDesktopScreenShot.kt
+++ b/src/main/kotlin/tool/desktop/ToolDesktopScreenShot.kt
@@ -6,26 +6,37 @@ import com.dumch.image.ImageUtils
 import com.dumch.tool.InputParamDescription
 import com.dumch.tool.ToolSetupWithAttachments
 import kotlinx.coroutines.runBlocking
+import java.awt.Robot
 import java.io.File
 
 class ToolDesktopScreenShot(
-    private val api: GigaChatAPI = GigaChatAPI(GigaAuth)
+    private val api: GigaChatAPI = GigaChatAPI(GigaAuth),
+    private val robot: Robot = Robot(),
 ) : ToolSetupWithAttachments<ToolDesktopScreenShot.Input> {
 
     override val name: String = "DesktopScreenShot"
-    override val description: String = "Captures desktop screenshot and uploads it to GigaChat, returning image id"
+    override val description: String = "Captures desktop screenshot and uploads it to GigaChat, returning image id. " +
+            "Use it to see what's on desktop"
 
-    private var lastAttachments: List<String> = emptyList()
+    private val lastAttachments = ArrayList<String>()
     override val attachments: List<String>
         get() = lastAttachments
 
-    override fun invoke(input: Input): String {
-        val screenshot = ImageUtils.captureDesktop()
-        val file = File.createTempFile("screenshot", ".jpg")
-        file.writeBytes(ImageUtils.compressJpeg(screenshot))
-        val upload = runBlocking { api.uploadImage(file) }
-        lastAttachments = listOf(upload.id)
-        return upload.id
+    override fun invoke(input: Input): String = runBlocking { suspendInvoke(input) }
+
+    override suspend fun suspendInvoke(input: Input): String {
+        try {
+            val screenshot = ImageUtils.captureDesktop(robot)
+            val file = File.createTempFile("screenshot", ".jpg")
+            file.writeBytes(ImageUtils.compressJpeg(screenshot))
+            val upload = api.uploadImage(file)
+            lastAttachments.clear()
+            lastAttachments.add(upload.id)
+            return upload.id
+        } catch (e: Exception) {
+            return "Error in DesktopScreenShot: ${e.message}"
+                .also { println(it) }
+        }
     }
 
     data class Input(
@@ -34,3 +45,7 @@ class ToolDesktopScreenShot(
     )
 }
 
+fun main() {
+    val id = ToolDesktopScreenShot().invoke(ToolDesktopScreenShot.Input("1"))
+    println(id)
+}

--- a/src/main/kotlin/tool/desktop/ToolDesktopScreenShot.kt
+++ b/src/main/kotlin/tool/desktop/ToolDesktopScreenShot.kt
@@ -1,0 +1,36 @@
+package com.dumch.tool.desktop
+
+import com.dumch.giga.GigaAuth
+import com.dumch.giga.GigaChatAPI
+import com.dumch.image.ImageUtils
+import com.dumch.tool.InputParamDescription
+import com.dumch.tool.ToolSetupWithAttachments
+import kotlinx.coroutines.runBlocking
+import java.io.File
+
+class ToolDesktopScreenShot(
+    private val api: GigaChatAPI = GigaChatAPI(GigaAuth)
+) : ToolSetupWithAttachments<ToolDesktopScreenShot.Input> {
+
+    override val name: String = "DesktopScreenShot"
+    override val description: String = "Captures desktop screenshot and uploads it to GigaChat, returning image id"
+
+    private var lastAttachments: List<String> = emptyList()
+    override val attachments: List<String>
+        get() = lastAttachments
+
+    override fun invoke(input: Input): String {
+        val screenshot = ImageUtils.captureDesktop()
+        val file = File.createTempFile("screenshot", ".jpg")
+        file.writeBytes(ImageUtils.compressJpeg(screenshot))
+        val upload = runBlocking { api.uploadImage(file) }
+        lastAttachments = listOf(upload.id)
+        return upload.id
+    }
+
+    data class Input(
+        @InputParamDescription("Desktop number to capture, e.g., '1' for the primary display by default")
+        val path: String = "1"
+    )
+}
+


### PR DESCRIPTION
## Summary
- Introduce `ToolSetupWithAttachments` and extend tool-to-Giga conversion to include message attachments.
- Implement a desktop screenshot tool that captures the screen, uploads it to GigaChat, and exposes the uploaded image ID.
- Register the screenshot tool with the agent so it can be invoked by the model.

## Testing
- `./gradlew test` *(fails: Could not resolve org.jetbrains.kotlin:kotlin-test:2.1.21; status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68964e2e7148832981c4e117fce4ad94