### PR TITLE
Replace println with Logback logging

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -13,8 +13,11 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import org.slf4j.LoggerFactory
 
 private const val AGENT_ALIAS = ""
+
+private val l = LoggerFactory.getLogger("Main")
 
 suspend fun main() = coroutineScope {
     val appScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
@@ -22,7 +25,7 @@ suspend fun main() = coroutineScope {
         coroutineScope = appScope
     )
     val hotkeyListener = HotkeyListener { pressed ->
-        println(if (pressed) "onStart" else "onStop")
+        l.info(if (pressed) "onStart" else "onStop")
         when {
             pressed -> audioRecorder.start()
             else -> audioRecorder.stop()
@@ -33,16 +36,16 @@ suspend fun main() = coroutineScope {
     val gigaChatAPI  = GigaChatAPI(GigaAuth)
     withNativeHook(hotkeyListener) {
         val userInputFlow = audioRecorder.audioFlow
-            .onEach { println("\n$AGENT_ALIAS: [Received audio data: ${it.size} bytes]") }
-            .catch { System.err.println("Error in audio flow: ${it.message}") }
+            .onEach { l.info("\n$AGENT_ALIAS: [Received audio data: ${it.size} bytes]") }
+            .catch { l.error("Error in audio flow: ${it.message}") }
             .map { audioData ->
                 val resp = gigaVoiceAPI.recognize(audioData)
-                println("Recognition response: $resp")
+                l.info("Recognition response: $resp")
                 resp.result.joinToString("\n")
             }
 
         GigaAgent.instance(userInputFlow, gigaChatAPI).run().collect { text ->
-            print("AI text: $text")
+            l.info("AI text: $text")
             playText(text)
         }
     }
@@ -51,14 +54,14 @@ suspend fun main() = coroutineScope {
 private suspend fun InMemoryAudioRecorder.logState(): Nothing {
     recordingState.collect { state ->
         when (state) {
-            is InMemoryAudioRecorder.State.Starting -> println("Recording state: Starting audio recording...")
-            is InMemoryAudioRecorder.State.Recording -> println("Recording state: Recording... (press Option + 2 to stop)")
-            is InMemoryAudioRecorder.State.Stopping -> println("Recording state: Stopping recording...")
+            is InMemoryAudioRecorder.State.Starting -> l.info("Recording state: Starting audio recording...")
+            is InMemoryAudioRecorder.State.Recording -> l.info("Recording state: Recording... (press Option + 2 to stop)")
+            is InMemoryAudioRecorder.State.Stopping -> l.info("Recording state: Stopping recording...")
             is InMemoryAudioRecorder.State.Idle -> {
-                println("Recording state: Idle")
+                l.info("Recording state: Idle")
             }
 
-            is InMemoryAudioRecorder.State.Error -> println("Recording state: Error: ${state.message}")
+            is InMemoryAudioRecorder.State.Error -> l.error("Recording state: Error: ${state.message}")
         }
     }
 }
@@ -69,7 +72,7 @@ private suspend fun withNativeHook(hotkeyListener: HotkeyListener, block: suspen
         GlobalScreen.addNativeKeyListener(hotkeyListener)
         block()
     } catch (e: NativeHookException) {
-        System.err.println("Failed to initialize hotkey listener: ${e.message}")
+        l.error("Failed to initialize hotkey listener: ${e.message}")
     } finally {
         GlobalScreen.unregisterNativeHook()
     }

--- a/src/main/kotlin/TextMain.kt
+++ b/src/main/kotlin/TextMain.kt
@@ -7,15 +7,15 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import org.slf4j.LoggerFactory
 
-private val l = LoggerFactory.getLogger("TextMain")
+private val logAgent = LoggerFactory.getLogger("Agent")
 
 suspend fun main() {
     val agent = GigaAgent.instance(userInputFlow(), GigaChatAPI(GigaAuth))
-    agent.run().collect { text -> l.info("agent: $text") }
+    agent.run().collect { text -> logAgent.info(text) }
 }
 
 private fun userInputFlow(): Flow<String> = flow {
-    l.info("\nType your message or `exit` to quit")
+    logAgent.info("\nType your message or `exit` to quit")
     while (true) {
         print("> ")
         val input = readlnOrNull() ?: break

--- a/src/main/kotlin/TextMain.kt
+++ b/src/main/kotlin/TextMain.kt
@@ -5,14 +5,17 @@ import com.dumch.giga.GigaAuth
 import com.dumch.giga.GigaChatAPI
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import org.slf4j.LoggerFactory
+
+private val l = LoggerFactory.getLogger("TextMain")
 
 suspend fun main() {
     val agent = GigaAgent.instance(userInputFlow(), GigaChatAPI(GigaAuth))
-    agent.run().collect { text -> println("agent: $text") }
+    agent.run().collect { text -> l.info("agent: $text") }
 }
 
 private fun userInputFlow(): Flow<String> = flow {
-    println("\nType your message or `exit` to quit")
+    l.info("\nType your message or `exit` to quit")
     while (true) {
         print("> ")
         val input = readlnOrNull() ?: break

--- a/src/main/kotlin/audio/AudioPlay.kt
+++ b/src/main/kotlin/audio/AudioPlay.kt
@@ -2,9 +2,9 @@ package com.dumch.audio
 
 fun playText(text: String) {
     val saveEnding = "$text р"
-    ProcessBuilder("say", saveEnding).start().waitFor()
+    ProcessBuilder("say", "-r", "230", saveEnding).start().waitFor()
 }
 
 fun main() {
-    playText("Привет, мир!")
+    playText("Можешь оценить скорость моей речи, она достаточно быстрая?")
 }

--- a/src/main/kotlin/audio/RecordUtils.kt
+++ b/src/main/kotlin/audio/RecordUtils.kt
@@ -8,12 +8,13 @@ import kotlinx.coroutines.*
 import ws.schild.jave.*
 import ws.schild.jave.encode.AudioAttributes
 import ws.schild.jave.encode.EncodingAttributes
+import org.slf4j.LoggerFactory
 
 /**
  * Simple utility that records the microphone, encodes to Ogg/Opus and returns the result as ByteArray.
  */
 object InMemoryOpusRecorder {
-
+    private val l = LoggerFactory.getLogger(InMemoryOpusRecorder::class.java)
     private var line: TargetDataLine? = null
     private var format: AudioFormat? = null
     private var rawOut: ByteArrayOutputStream? = null
@@ -28,7 +29,7 @@ object InMemoryOpusRecorder {
         val fmt = AudioFormat(sampleRate, sampleSizeBits, channels, true, false)
         val info = DataLine.Info(TargetDataLine::class.java, fmt)
         if (!AudioSystem.isLineSupported(info)) {
-            println("ERROR: Line not supported for format: $fmt")
+            l.error("Line not supported for format: $fmt")
             throw LineUnavailableException("Line not supported for format: $fmt")
         }
 
@@ -66,7 +67,7 @@ object InMemoryOpusRecorder {
             target?.close()
             target?.flush()
         } catch (e: Exception) {
-            println("Error while closing audio line: ${e.message}")
+            l.error("Error while closing audio line: ${e.message}")
         }
 
         line = null
@@ -133,20 +134,21 @@ object InMemoryOpusRecorder {
 }
 
 fun main() = runBlocking {
-    println("Starting audio recording test...")
-    println("Make sure your microphone is properly connected and has the necessary permissions.")
+    val l = LoggerFactory.getLogger("RecordUtils")
+    l.info("Starting audio recording test...")
+    l.info("Make sure your microphone is properly connected and has the necessary permissions.")
 
     try {
-        println("Will record for 5 seconds. Speak into your microphone...")
+        l.info("Will record for 5 seconds. Speak into your microphone...")
         // Record audio
         val wav = InMemoryOpusRecorder.recordPcm(seconds = 5)
-        println("Converting to Opus format...")
+        l.info("Converting to Opus format...")
         val oggOpus = InMemoryOpusRecorder.wavToOpusOgg(wav)
         val opusFile = File("capture.ogg")
         opusFile.writeBytes(oggOpus)
-        println("Successfully saved ${oggOpus.size} bytes of Opus audio to ${opusFile.absolutePath}")
+        l.info("Successfully saved ${oggOpus.size} bytes of Opus audio to ${opusFile.absolutePath}")
     } catch (e: Exception) {
-        println("\nERROR: ${e.message}")
+        l.error("\nERROR: ${e.message}")
         exitProcess(1)
     }
 }

--- a/src/main/kotlin/giga/GigaAgent.kt
+++ b/src/main/kotlin/giga/GigaAgent.kt
@@ -11,12 +11,14 @@ import com.dumch.tool.files.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
+import org.slf4j.LoggerFactory
 
 class GigaAgent(
     private val userMessages: Flow<String>,
     private val api: GigaChatAPI,
     private val tools: Map<String, GigaToolSetup>,
 ) {
+    private val l = LoggerFactory.getLogger(GigaAgent::class.java)
     private val functions: List<GigaRequest.Function> = tools.map { it.value.fn }
 
     fun run(): Flow<String> = channelFlow {
@@ -78,7 +80,7 @@ class GigaAgent(
             is GigaResponse.Chat.Error -> throw CancellationException("Can't summarize the conversation")
             is GigaResponse.Chat.Ok -> response.toRequestMessages().last()
         }
-        println("Summarizing the conversation... $msg")
+        l.info("Summarizing the conversation... $msg")
         val lastMsg = conversation.last()
         conversation.clear()
         conversation.add(msg)
@@ -109,7 +111,7 @@ class GigaAgent(
         val fn = tools[functionCall.name] ?: return GigaRequest.Message(
             GigaMessageRole.function, """{"result":"no such function ${functionCall.name}"}"""
         )
-        println("Executing tool: ${fn.fn.name}, arguments: ${functionCall.arguments}")
+        l.info("Executing tool: ${fn.fn.name}, arguments: ${functionCall.arguments}")
         return fn.invoke(functionCall)
     }
 

--- a/src/main/kotlin/giga/GigaChatAPI.kt
+++ b/src/main/kotlin/giga/GigaChatAPI.kt
@@ -13,6 +13,7 @@ import io.ktor.client.plugins.logging.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import java.io.File
+import org.slf4j.LoggerFactory
 
 class GigaChatAPI(private val auth: GigaAuth) {
     private val client = HttpClient(CIO) {
@@ -72,5 +73,5 @@ class GigaChatAPI(private val auth: GigaAuth) {
 suspend fun main() {
     val f = File("/Users/m1/Pictures/portrait.jpeg")
     val resp = GigaChatAPI(GigaAuth).uploadImage(f)
-    println(resp)
+    LoggerFactory.getLogger("GigaChatAPI").info("$resp")
 }

--- a/src/main/kotlin/giga/GigaVoiceAPI.kt
+++ b/src/main/kotlin/giga/GigaVoiceAPI.kt
@@ -8,6 +8,9 @@ import io.ktor.client.plugins.auth.providers.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import java.io.File
+import org.slf4j.LoggerFactory
+
+private val l = LoggerFactory.getLogger("GigaVoiceAPI")
 
 class GigaVoiceAPI(private val auth: GigaAuth) {
     private val client = HttpClient(CIO) {
@@ -51,5 +54,5 @@ class GigaVoiceAPI(private val auth: GigaAuth) {
 suspend fun main() {
     val api = GigaVoiceAPI(GigaAuth)
     val result = api.recognize(File("capture2.ogg").readBytes())
-    println(result)
+    l.info("$result")
 }

--- a/src/main/kotlin/keys/KeyListener.kt
+++ b/src/main/kotlin/keys/KeyListener.kt
@@ -7,6 +7,7 @@ import com.github.kwhat.jnativehook.keyboard.NativeKeyListener
 import jdk.jfr.RecordingState
 import kotlinx.coroutines.*
 import kotlin.system.exitProcess
+import org.slf4j.LoggerFactory
 
 class HotkeyListener(
     private val onPressed: (Boolean) -> Unit
@@ -44,16 +45,17 @@ class HotkeyListener(
 }
 
 fun main() {
+    val l = LoggerFactory.getLogger("HotkeyListener")
     val hotkeyListener = HotkeyListener { pressed ->
         val msg = if (pressed) "onStart" else "onStop"
-        println(msg)
+        l.info(msg)
     }
 
     try {
         GlobalScreen.registerNativeHook()
         GlobalScreen.addNativeKeyListener(hotkeyListener)
     } catch (e: NativeHookException) {
-        System.err.println("Failed to register native hook: ${e.message}")
+        l.error("Failed to register native hook: ${e.message}")
         exitProcess(1)
     }
 

--- a/src/main/kotlin/tool/desktop/ToolDesktopScreenShot.kt
+++ b/src/main/kotlin/tool/desktop/ToolDesktopScreenShot.kt
@@ -49,6 +49,7 @@ class ToolDesktopScreenShot(
 }
 
 fun main() {
+    val l = LoggerFactory.getLogger(ToolDesktopScreenShot::class.java)
     val id = ToolDesktopScreenShot().invoke(ToolDesktopScreenShot.Input("1"))
-    println(id)
+    l.info(id)
 }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -2,7 +2,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%logger{0}: %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/src/test/kotlin/giga/GigaToolTest.kt
+++ b/src/test/kotlin/giga/GigaToolTest.kt
@@ -9,6 +9,7 @@ import com.dumch.giga.toGiga
 import com.dumch.tool.files.ToolListFiles
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import org.slf4j.LoggerFactory
 
 class GigaToolTest {
     @Test
@@ -33,8 +34,9 @@ class GigaToolTest {
             arguments = mapOf("path" to "src/test/resources"),
         )
 
+        val l = LoggerFactory.getLogger(GigaToolTest::class.java)
         val result = toolsMap[functionCall.name]!!.invoke(functionCall)
-        println(result)
+        l.info("$result")
         assertEquals(
             GigaRequest.Message(
                 role = GigaMessageRole.function,

--- a/src/test/kotlin/giga/GigaVoiceApiTest.kt
+++ b/src/test/kotlin/giga/GigaVoiceApiTest.kt
@@ -4,11 +4,13 @@ import com.dumch.giga.GigaAuth
 import com.dumch.giga.GigaVoiceAPI
 import java.io.File
 import kotlin.test.assertTrue
+import org.slf4j.LoggerFactory
 
 suspend fun main () {
+    val l = LoggerFactory.getLogger("GigaVoiceApiTest")
     val key = System.getenv("VOICE_KEY")
     if (key.isNullOrBlank()) {
-        println("VOICE_KEY not set; skipping real API test")
+        l.info("VOICE_KEY not set; skipping real API test")
         return
     }
 

--- a/src/test/kotlin/giga/GigaVoiceRecognizeTest.kt
+++ b/src/test/kotlin/giga/GigaVoiceRecognizeTest.kt
@@ -5,11 +5,13 @@ import com.dumch.giga.GigaVoiceAPI
 import com.dumch.audio.InMemoryOpusRecorder
 import java.io.File
 import kotlin.test.assertTrue
+import org.slf4j.LoggerFactory
 
 suspend fun main() {
+    val l = LoggerFactory.getLogger("GigaVoiceRecognizeTest")
     val key = System.getenv("VOICE_KEY")
     if (key.isNullOrBlank()) {
-        println("VOICE_KEY not set; skipping real API test")
+        l.info("VOICE_KEY not set; skipping real API test")
         return
     }
 

--- a/src/test/kotlin/tool/files/ToolTest.kt
+++ b/src/test/kotlin/tool/files/ToolTest.kt
@@ -12,12 +12,14 @@ import java.io.File
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import org.slf4j.LoggerFactory
 
 class ToolTest {
 
     @Test
     fun `test ToolReadFile`() {
-        println(File("src/test/resources/test.txt").readText())
+        val l = LoggerFactory.getLogger(ToolTest::class.java)
+        l.info(File("src/test/resources/test.txt").readText())
         val result = ToolReadFile(ToolReadFile.Input("src/test/resources/test.txt"))
         assertEquals("Test content\n", result)
     }
@@ -29,7 +31,8 @@ class ToolTest {
 
         val resources = ToolListFiles(ToolListFiles.Input("src/test/resources"))
         assertEquals("[directory/,directory/file.txt,test.txt]", resources)
-        println(resources)
+        val l = LoggerFactory.getLogger(ToolTest::class.java)
+        l.info(resources)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Configure Logback to prefix logs with the logger name
- Replace println calls with SLF4J logging across the codebase
- Rename logger variables from `log`/`logger` to short `l`

## Testing
- `./gradlew test` *(fails: Could not resolve org.jetbrains.kotlin:kotlin-test:2.1.21)*

------
https://chatgpt.com/codex/tasks/task_e_689669e922a88329affb4dc65793c4bb