### PR TITLE
feat: pre-buffer microphone audio before recording

### DIFF
--- a/src/main/kotlin/audio/AudioRecorder.kt
+++ b/src/main/kotlin/audio/AudioRecorder.kt
@@ -2,7 +2,6 @@ package com.dumch.audio
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -18,25 +17,29 @@ class InMemoryAudioRecorder(
 ) {
     private val _audioFlow = MutableSharedFlow<ByteArray>()
 
-    private var recordingJob: Job? = null
     private val _recordingState = MutableStateFlow<State>(State.Idle)
     val recordingState = _recordingState.asStateFlow()
 
     val audioFlow: Flow<ByteArray> = _audioFlow
 
+    init {
+        // Warm up the microphone so the first spoken words are captured
+        InMemoryOpusRecorder.prepare(
+            scope = coroutineScope,
+            sampleRate = sampleRate,
+            channels = channels,
+            sampleSizeBits = sampleSizeBits
+        )
+    }
+
     fun start() {
-        if (recordingJob?.isActive == true) {
+        if (_recordingState.value == State.Recording || _recordingState.value == State.Starting) {
             throw IllegalStateException("Recording is already in progress")
         }
 
         _recordingState.value = State.Starting
         try {
-            recordingJob = InMemoryOpusRecorder.startRecording(
-                scope = coroutineScope,
-                sampleRate = sampleRate,
-                channels = channels,
-                sampleSizeBits = sampleSizeBits
-            )
+            InMemoryOpusRecorder.startRecording()
             _recordingState.value = State.Recording
         } catch (e: Exception) {
             _recordingState.value = State.Error(e.message ?: "Error during audio recording")
@@ -53,8 +56,6 @@ class InMemoryAudioRecorder(
                 _recordingState.value = State.Idle
             } catch (e: Exception) {
                 _recordingState.value = State.Error(e.message ?: "Failed to stop recording")
-            } finally {
-                recordingJob = null
             }
         }
     }

--- a/src/main/kotlin/audio/RecordUtils.kt
+++ b/src/main/kotlin/audio/RecordUtils.kt
@@ -1,11 +1,27 @@
 package com.dumch.audio
 
-import java.io.*
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
 import java.nio.file.Files
-import javax.sound.sampled.*
+import javax.sound.sampled.AudioFileFormat
+import javax.sound.sampled.AudioFormat
+import javax.sound.sampled.AudioInputStream
+import javax.sound.sampled.AudioSystem
+import javax.sound.sampled.DataLine
+import javax.sound.sampled.LineUnavailableException
+import javax.sound.sampled.TargetDataLine
 import kotlin.system.exitProcess
-import kotlinx.coroutines.*
-import ws.schild.jave.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import ws.schild.jave.Encoder
+import ws.schild.jave.MultimediaObject
 import ws.schild.jave.encode.AudioAttributes
 import ws.schild.jave.encode.EncodingAttributes
 
@@ -17,14 +33,24 @@ object InMemoryOpusRecorder {
     private var line: TargetDataLine? = null
     private var format: AudioFormat? = null
     private var rawOut: ByteArrayOutputStream? = null
-    private var recordingJob: Job? = null
+    private var preBuffer: CircularByteBuffer? = null
+    private var captureJob: Job? = null
+    @Volatile private var isRecording: Boolean = false
 
-    fun startRecording(
+    /**
+     * Open the microphone line and begin continuously capturing audio into a
+     * small circular buffer. Call this once at start-up or shortly before the
+     * user is expected to trigger recording.
+     */
+    fun prepare(
         scope: CoroutineScope,
         sampleRate: Float = 44_100f,
         channels: Int = 1,
-        sampleSizeBits: Int = 16
-    ): Job {
+        sampleSizeBits: Int = 16,
+        preBufferMillis: Int = 2_000
+    ) {
+        if (line != null) return
+
         val fmt = AudioFormat(sampleRate, sampleSizeBits, channels, true, false)
         val info = DataLine.Info(TargetDataLine::class.java, fmt)
         if (!AudioSystem.isLineSupported(info)) {
@@ -38,41 +64,59 @@ object InMemoryOpusRecorder {
 
         line = target
         format = fmt
-        rawOut = ByteArrayOutputStream()
 
-        recordingJob = scope.launch(Dispatchers.IO) {
+        val bytesPerSecond = (fmt.frameSize * fmt.sampleRate).toInt()
+        preBuffer = CircularByteBuffer(bytesPerSecond * preBufferMillis / 1_000)
+
+        captureJob = scope.launch(Dispatchers.IO) {
             val buffer = ByteArray(4096)
             while (isActive) {
                 val read = target.read(buffer, 0, buffer.size)
                 if (read > 0) {
-                    rawOut?.write(buffer, 0, read)
+                    preBuffer?.write(buffer, 0, read)
+                    if (isRecording) {
+                        rawOut?.write(buffer, 0, read)
+                    }
                 }
             }
         }
+    }
 
-        return recordingJob as Job
+    /** Begin writing audio data (including pre-buffered audio) to the main stream. */
+    fun startRecording() {
+        if (line == null) {
+            throw IllegalStateException("Recorder not prepared")
+        }
+        if (isRecording) return
+
+        rawOut = ByteArrayOutputStream()
+        preBuffer?.toByteArray()?.let { rawOut?.write(it) }
+        isRecording = true
     }
 
     suspend fun stopRecording(): ByteArray {
-        delay(2_000)
-        recordingJob?.cancelAndJoin()
-
         val target = line
-        val fmt = format
-        val bos = rawOut
-
-        try {
-            target?.stop()
-            target?.close()
-            target?.flush()
-        } catch (e: Exception) {
-            println("Error while closing audio line: ${e.message}")
+        if (target != null) {
+            target.stop()
+            val buffer = ByteArray(4096)
+            var available = target.available()
+            while (available > 0) {
+                val toRead = minOf(buffer.size, available)
+                val read = target.read(buffer, 0, toRead)
+                if (read > 0) {
+                    rawOut?.write(buffer, 0, read)
+                }
+                available = target.available()
+            }
+            isRecording = false
+            target.start()
+        } else {
+            isRecording = false
         }
 
-        line = null
-        recordingJob = null
-
-        val rawBytes = bos?.toByteArray() ?: ByteArray(0)
+        val fmt = format
+        val rawBytes = rawOut?.toByteArray() ?: ByteArray(0)
+        rawOut = null
         if (fmt == null) return rawBytes
 
         val frames = rawBytes.size / fmt.frameSize
@@ -93,52 +137,65 @@ object InMemoryOpusRecorder {
         sampleSizeBits: Int = 16
     ): ByteArray {
         val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
-        startRecording(scope, sampleRate, channels, sampleSizeBits)
+        prepare(scope, sampleRate, channels, sampleSizeBits)
+        startRecording()
         delay(seconds * 1_000L)
         val data = stopRecording()
         scope.cancel()
         return data
     }
 
-    /** Encode the given WAV bytes to Ogg/Opus and return the compressed bytes. */
-    fun wavToOpusOgg(wavBytes: ByteArray,
-                     bitRate: Int = 64_000,
-                     sampleRate: Int = 48_000,
-                     channels: Int = 2): ByteArray {
+    /** Stop capturing and close the microphone line. */
+    fun shutdown() {
+        captureJob?.cancel()
+        captureJob = null
+        line?.stop()
+        line?.close()
+        line = null
+    }
 
-        /* JAVE2 works on java.io.File – we therefore use tmp files but keep all
-           data in RAM visible to the caller. */
-        val inFile  = Files.createTempFile("jave-input",  ".wav").toFile()
-        val outFile = Files.createTempFile("jave-output", ".ogg").toFile()
-        inFile.writeBytes(wavBytes)
+    /** Simple byte-based circular buffer. */
+    private class CircularByteBuffer(private val capacity: Int) {
+        private val buffer = ByteArray(capacity)
+        private var writePos = 0
+        private var filled = 0
 
-        val audioAttr = AudioAttributes().apply {
-            setCodec("libopus")                // Opus encoder in FFmpeg
-            setBitRate(bitRate)
-            setSamplingRate(sampleRate)
-            setChannels(channels)
+        fun write(data: ByteArray, off: Int, len: Int) {
+            var remaining = len
+            var src = off
+            while (remaining > 0) {
+                val chunk = minOf(remaining, capacity - writePos)
+                System.arraycopy(data, src, buffer, writePos, chunk)
+                writePos = (writePos + chunk) % capacity
+                if (filled < capacity) {
+                    filled = minOf(capacity, filled + chunk)
+                }
+                remaining -= chunk
+                src += chunk
+            }
         }
 
-        val encAttr = EncodingAttributes().apply {
-            setOutputFormat("ogg")                   // container
-            setAudioAttributes(audioAttr)
+        fun toByteArray(): ByteArray {
+            val out = ByteArray(filled)
+            val start = (writePos - filled + capacity) % capacity
+            if (start + filled <= capacity) {
+                System.arraycopy(buffer, start, out, 0, filled)
+            } else {
+                val firstLen = capacity - start
+                System.arraycopy(buffer, start, out, 0, firstLen)
+                System.arraycopy(buffer, 0, out, firstLen, filled - firstLen)
+            }
+            return out
         }
-
-        Encoder().encode(MultimediaObject(inFile), outFile, encAttr)   // synchronous
-
-        val encoded = outFile.readBytes()
-        inFile.delete(); outFile.delete()
-        return encoded
     }
 }
 
-fun main() = runBlocking {
+fun main() = kotlinx.coroutines.runBlocking {
     println("Starting audio recording test...")
     println("Make sure your microphone is properly connected and has the necessary permissions.")
 
     try {
         println("Will record for 5 seconds. Speak into your microphone...")
-        // Record audio
         val wav = InMemoryOpusRecorder.recordPcm(seconds = 5)
         println("Converting to Opus format...")
         val oggOpus = InMemoryOpusRecorder.wavToOpusOgg(wav)
@@ -150,3 +207,34 @@ fun main() = runBlocking {
         exitProcess(1)
     }
 }
+
+/** Encode the given WAV bytes to Ogg/Opus and return the compressed bytes. */
+fun InMemoryOpusRecorder.wavToOpusOgg(
+    wavBytes: ByteArray,
+    bitRate: Int = 64_000,
+    sampleRate: Int = 48_000,
+    channels: Int = 2
+): ByteArray {
+    val inFile = Files.createTempFile("jave-input", ".wav").toFile()
+    val outFile = Files.createTempFile("jave-output", ".ogg").toFile()
+    inFile.writeBytes(wavBytes)
+
+    val audioAttr = AudioAttributes().apply {
+        setCodec("libopus")
+        setBitRate(bitRate)
+        setSamplingRate(sampleRate)
+        setChannels(channels)
+    }
+
+    val encAttr = EncodingAttributes().apply {
+        setOutputFormat("ogg")
+        setAudioAttributes(audioAttr)
+    }
+
+    Encoder().encode(MultimediaObject(inFile), outFile, encAttr)
+
+    val encoded = outFile.readBytes()
+    inFile.delete(); outFile.delete()
+    return encoded
+}
+

--- a/src/main/kotlin/audio/RecordUtils.kt
+++ b/src/main/kotlin/audio/RecordUtils.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -35,6 +36,7 @@ object InMemoryOpusRecorder {
     private var rawOut: ByteArrayOutputStream? = null
     private var preBuffer: CircularByteBuffer? = null
     private var captureJob: Job? = null
+    private var scope: CoroutineScope? = null
     @Volatile private var isRecording: Boolean = false
 
     /**
@@ -64,6 +66,7 @@ object InMemoryOpusRecorder {
 
         line = target
         format = fmt
+        this.scope = scope
 
         val bytesPerSecond = (fmt.frameSize * fmt.sampleRate).toInt()
         preBuffer = CircularByteBuffer(bytesPerSecond * preBufferMillis / 1_000)
@@ -97,6 +100,7 @@ object InMemoryOpusRecorder {
     suspend fun stopRecording(): ByteArray {
         val target = line
         if (target != null) {
+            captureJob?.cancelAndJoin()
             target.stop()
             val buffer = ByteArray(4096)
             var available = target.available()
@@ -110,6 +114,18 @@ object InMemoryOpusRecorder {
             }
             isRecording = false
             target.start()
+            captureJob = scope?.launch(Dispatchers.IO) {
+                val buf = ByteArray(4096)
+                while (isActive) {
+                    val read = target.read(buf, 0, buf.size)
+                    if (read > 0) {
+                        preBuffer?.write(buf, 0, read)
+                        if (isRecording) {
+                            rawOut?.write(buf, 0, read)
+                        }
+                    }
+                }
+            }
         } else {
             isRecording = false
         }


### PR DESCRIPTION
## Summary
- warm up microphone line during recorder init
- continuously capture audio into a small circular buffer
- prepend buffered audio when hotkey recording starts
- drain any remaining microphone data when stopping to avoid cutting off the tail

## Testing
- `./gradlew test` *(fails: Could not resolve org.jetbrains.kotlin:kotlin-test:2.1.21. Received status code 403 from server)*

------
https://chatgpt.com/codex/tasks/task_e_68966b7b469483299fa217db297143cf