### PR TITLE
Silence JAVE ConversionOutputAnalyzer logs

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -6,6 +6,9 @@
         </encoder>
     </appender>
 
+    <!-- Mute verbose ffmpeg output parsed by JAVE -->
+    <logger name="ws.schild.jave.process.ffmpeg.ConversionOutputAnalyzer" level="OFF"/>
+
     <root level="debug">
         <appender-ref ref="STDOUT"/>
     </root>


### PR DESCRIPTION
## Summary
- disable verbose ffmpeg logs from ws.schild.jave.process.ffmpeg.ConversionOutputAnalyzer via logback configuration

## Testing
- `./gradlew test` *(fails: Could not resolve org.jetbrains.kotlin:kotlin-test:2.1.21, status 403)*

------
https://chatgpt.com/codex/tasks/task_e_689763d36f6483299a6a6107ed5c80bb