### PR TITLE
Add macOS function key tool

### DIFF
--- a/src/main/kotlin/keys/NativeKeys.kt
+++ b/src/main/kotlin/keys/NativeKeys.kt
@@ -73,6 +73,20 @@ object VK {
     const val ESC = 53
     const val SPACE = 49
 
+    // Function keys
+    const val F1 = 122
+    const val F2 = 120
+    const val F3 = 99
+    const val F4 = 118
+    const val F5 = 96
+    const val F6 = 97
+    const val F7 = 98
+    const val F8 = 100
+    const val F9 = 101
+    const val F10 = 109
+    const val F11 = 103
+    const val F12 = 111
+
     // Letters
     const val T = 17
     const val Q = 12

--- a/src/main/kotlin/tool/desktop/ToolFunctionKeyPress.kt
+++ b/src/main/kotlin/tool/desktop/ToolFunctionKeyPress.kt
@@ -1,0 +1,58 @@
+package com.dumch.tool.desktop
+
+import com.dumch.keys.*
+import com.dumch.tool.InputParamDescription
+import com.dumch.tool.ToolSetup
+
+class ToolFnKeyMac : ToolSetup<ToolFnKeyMac.Input> {
+    private val cg = CoreGraphics.INSTANCE
+    private val cf = CoreFoundation.INSTANCE
+
+    override val name = "FnKey"
+    override val description = "Presses special function keys like brightness, volume, or media controls (macOS)."
+
+    class Input(
+        @InputParamDescription("""Options:
+            "brightness_down" -> F1
+            "brightness_up"   -> F2
+            "prev_track"      -> F7
+            "play_pause"      -> F8
+            "next_track"      -> F9
+            "volume_mute"     -> F10
+            "volume_down"     -> F11
+            "volume_up"       -> F12""")
+        val key: String
+    )
+
+    override fun invoke(input: Input): String {
+        require(System.getProperty("os.name").contains("Mac", ignoreCase = true)) {
+            "This implementation supports macOS only."
+        }
+
+        fun post(key: Int, down: Boolean) {
+            val evt = cg.CGEventCreateKeyboardEvent(null, key, down)
+            cg.CGEventPost(CG.kCGHIDEventTap, evt)
+            cf.CFRelease(evt)
+        }
+        fun press(k: Int) { post(k, true); post(k, false) }
+
+        when (input.key.lowercase()) {
+            "brightness_down" -> press(VK.F1)
+            "brightness_up"   -> press(VK.F2)
+            "prev_track"      -> press(VK.F7)
+            "play_pause"      -> press(VK.F8)
+            "next_track"      -> press(VK.F9)
+            "volume_mute"     -> press(VK.F10)
+            "volume_down"     -> press(VK.F11)
+            "volume_up"       -> press(VK.F12)
+            else -> error("Unknown fn key: ${input.key}")
+        }
+
+        return "Pressed ${input.key}"
+    }
+}
+
+suspend fun main() {
+    val tool = ToolFnKeyMac()
+    println(tool.invoke(ToolFnKeyMac.Input("volume_up")))
+}


### PR DESCRIPTION
## Summary
- add key codes for macOS function keys F1-F12
- implement FnKey tool to press brightness, volume, and media controls

## Testing
- `./gradlew test` *(fails: Could not resolve org.jetbrains.kotlin:kotlin-test:2.1.21, Received status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_6898f8dfed088329a9987b07c842cb44