### PR TITLE
feat: add tool for mac fn keys

### DIFF
--- a/src/main/kotlin/giga/GigaAgent.kt
+++ b/src/main/kotlin/giga/GigaAgent.kt
@@ -10,6 +10,7 @@ import com.dumch.tool.desktop.ToolOpenFile
 import com.dumch.tool.desktop.ToolOpenFolder
 import com.dumch.tool.desktop.ToolCreateNewBrowserTab
 import com.dumch.tool.desktop.ToolHotkeyMac
+import com.dumch.tool.desktop.ToolFnKeyMac
 import com.dumch.tool.desktop.ToolMinimizeWindows
 import com.dumch.tool.files.*
 import kotlinx.coroutines.*
@@ -184,6 +185,7 @@ class GigaAgent(
             ToolModifyFile.toGiga(),
             ToolMouseClickMac().toGiga(),
             ToolHotkeyMac().toGiga(),
+            ToolFnKeyMac().toGiga(),
             ToolFindTextInFiles.toGiga(),
             ToolDesktopScreenShot().toGiga(),
             ToolCreateNote(ToolRunBashCommand).toGiga(),

--- a/src/main/kotlin/tool/desktop/ToolFnKeyMac.kt
+++ b/src/main/kotlin/tool/desktop/ToolFnKeyMac.kt
@@ -1,0 +1,49 @@
+package com.dumch.tool.desktop
+
+import com.dumch.tool.InputParamDescription
+import com.dumch.tool.ToolRunBashCommand
+import com.dumch.tool.ToolSetup
+
+/**
+ * Sends macOS special function keys like brightness, volume, and media controls
+ * using AppleScript.
+ */
+class ToolFnKeyMac(
+    private val bash: ToolRunBashCommand = ToolRunBashCommand
+) : ToolSetup<ToolFnKeyMac.Input> {
+
+    override val name: String = "FnKey"
+    override val description: String = "Presses special function keys (brightness, volume, media) on macOS"
+
+    override fun invoke(input: Input): String {
+        val code = when (input.key.lowercase()) {
+            "brightness_down" -> 122 // F1
+            "brightness_up" -> 120   // F2
+            "previous" -> 98         // F7
+            "play_pause" -> 100      // F8
+            "next" -> 101            // F9
+            "mute" -> 109            // F10
+            "volume_down" -> 103     // F11
+            "volume_up" -> 111       // F12
+            else -> error("Unknown key: ${input.key}")
+        }
+        val script = """
+            osascript -e 'tell application "System Events" to key code $code'
+        """.trimIndent()
+        bash.script(script)
+        return "Pressed ${input.key}"
+    }
+
+    data class Input(
+        @InputParamDescription(
+            "Key to press. Options: brightness_down, brightness_up, volume_up, volume_down, mute, play_pause, next, previous"
+        )
+        val key: String
+    )
+}
+
+fun main() {
+    val tool = ToolFnKeyMac()
+    println(tool.invoke(ToolFnKeyMac.Input("volume_up")))
+}
+


### PR DESCRIPTION
## Summary
- add Fn key tool using AppleScript to trigger brightness, volume, and media keys on macOS
- register Fn key tool within GigaAgent

## Testing
- `./gradlew test` *(fails: Could not resolve org.jetbrains.kotlin:kotlin-test:2.1.21, status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_6899bc142ac88329b22d89b624dc5163