### PR TITLE
Add media control tool using AppleScript (only brightness and volume)

### DIFF
--- a/src/main/kotlin/giga/GigaAgent.kt
+++ b/src/main/kotlin/giga/GigaAgent.kt
@@ -10,6 +10,7 @@ import com.dumch.tool.desktop.ToolOpenFile
 import com.dumch.tool.desktop.ToolOpenFolder
 import com.dumch.tool.desktop.ToolCreateNewBrowserTab
 import com.dumch.tool.desktop.ToolHotkeyMac
+import com.dumch.tool.desktop.ToolMediaControl
 import com.dumch.tool.desktop.ToolMinimizeWindows
 import com.dumch.tool.files.*
 import kotlinx.coroutines.*
@@ -184,6 +185,7 @@ class GigaAgent(
             ToolModifyFile.toGiga(),
             ToolMouseClickMac().toGiga(),
             ToolHotkeyMac().toGiga(),
+            ToolMediaControl(ToolRunBashCommand).toGiga(),
             ToolFindTextInFiles.toGiga(),
             ToolDesktopScreenShot().toGiga(),
             ToolCreateNote(ToolRunBashCommand).toGiga(),

--- a/src/main/kotlin/tool/desktop/ToolMediaControl.kt
+++ b/src/main/kotlin/tool/desktop/ToolMediaControl.kt
@@ -4,36 +4,33 @@ import com.dumch.tool.InputParamDescription
 import com.dumch.tool.ToolRunBashCommand
 import com.dumch.tool.ToolSetup
 
-/**
- * Controls media playback, volume, and display brightness via AppleScript.
- *
- * For brightness adjustment actions, this tool invokes the `brightness` command-line
- * utility. Ensure the utility is installed and available on the system path
- * (for example, `brew install brightness` or see https://github.com/nriley/brightness).
- */
 class ToolMediaControl(private val bash: ToolRunBashCommand) : ToolSetup<ToolMediaControl.Input> {
-    override val name: String = "MediaControl"
-    override val description: String = "Controls media playback, volume, and display brightness"
+    data class Input(
+        @InputParamDescription("Action to perform: brightness_up, brightness_down, volume_up, volume_down")
+        val action: String
+    )
+
+    override val name: String = "VolumeAndBrightness"
+    override val description: String = "Controls volume and display brightness"
 
     override fun invoke(input: Input): String {
         val script = when (input.action) {
-            "next" -> """tell application \"Music\" to next track"""
-            "previous" -> """tell application \"Music\" to previous track"""
-            "play" -> """tell application \"Music\" to play"""
-            "pause" -> """tell application \"Music\" to pause"""
-            "playpause" -> """tell application \"Music\" to playpause"""
-            "volume_up" -> """set volume output volume ((output volume of (get volume settings)) + 10)"""
-            "volume_down" -> """set volume output volume ((output volume of (get volume settings)) - 10)"""
-            "brightness_up" -> """do shell script \"brightness +0.1\""""
-            "brightness_down" -> """do shell script \"brightness -0.1\""""
+            // remember to change description
+            "next" -> ""
+            "previous" -> ""
+            "playpause" -> ""
+            "volume_up" -> "set volume output volume ((output volume of (get volume settings)) + 10)"   // works
+            "volume_down" -> "set volume output volume ((output volume of (get volume settings)) - 10)" // works
+            "brightness_down" -> "tell application \"System Events\" to key code 145"
+            "brightness_up" -> "tell application \"System Events\" to key code 144"
             else -> throw IllegalArgumentException("Unknown action: ${input.action}")
         }
         bash.apple(script)
         return "Done"
     }
+}
 
-    class Input(
-        @InputParamDescription("Action to perform: next, previous, play, pause, playpause, brightness_up, brightness_down, volume_up, volume_down")
-        val action: String
-    )
+fun main() {
+    val r = ToolMediaControl(ToolRunBashCommand).invoke(ToolMediaControl.Input("playpause"))
+    println(r)
 }


### PR DESCRIPTION
## Summary
- add ToolMediaControl to manage playback, brightness and volume via AppleScript

## Testing
- `./gradlew test` *(fails: Could not resolve org.jetbrains.kotlin:kotlin-test:2.1.21; HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_6899c77f51c88329862830fa76ef75a0