### PR TITLE
Add metadata and enums for ToolSetup functions

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -20,8 +20,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import org.slf4j.LoggerFactory
 
-private const val AGENT_ALIAS = ""
-
 private val l = LoggerFactory.getLogger("AI")
 
 suspend fun main() = coroutineScope {
@@ -54,7 +52,7 @@ suspend fun main() = coroutineScope {
     val gigaChatAPI  = GigaChatAPI.INSTANCE
     withNativeHook(hotkeyListener) {
         val userInputFlow = audioRecorder.audioFlow
-            .onEach { l.info("\n$AGENT_ALIAS: [Received audio data: ${it.size} bytes]") }
+            .onEach { l.info("[Received audio data: ${it.size} bytes]") }
             .catch { l.error("Error in audio flow: ${it.message}") }
             .map { audioData -> rawToOpusOgg(rawData = audioData) }
             .map { audioData ->

--- a/src/main/kotlin/giga/DTO.kt
+++ b/src/main/kotlin/giga/DTO.kt
@@ -98,17 +98,26 @@ object GigaRequest {
     data class Function(
         val name: String,
         val description: String,
-        val parameters: Parameters
+        val parameters: Parameters,
+        @JsonProperty("few_shot_examples") val fewShotExamples: List<FewShotExample> = emptyList(),
+        @JsonProperty("return_parameters") val returnParameters: Parameters
     )
 
     data class Parameters(
         val type: String,
-        val properties: Map<String, Property>
+        val properties: Map<String, Property>,
+        val required: List<String> = emptyList()
     )
 
     data class Property(
         val type: String,
-        val description: String? = null
+        val description: String? = null,
+        @JsonProperty("enum") val enum: List<String>? = null
+    )
+
+    data class FewShotExample(
+        val request: String,
+        val params: Map<String, Any>
     )
 }
 

--- a/src/main/kotlin/giga/GigaToolSetup.kt
+++ b/src/main/kotlin/giga/GigaToolSetup.kt
@@ -14,6 +14,7 @@ import kotlin.reflect.KClass
 import kotlin.reflect.full.declaredMembers
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.isSubclassOf
+import kotlin.reflect.full.primaryConstructor
 
 
 interface GigaToolSetup {
@@ -23,35 +24,48 @@ interface GigaToolSetup {
 
 val gigaJsonMapper = jacksonObjectMapper()
 
-inline fun <reified Input> ToolSetup<Input>.toGiga(): GigaToolSetup {
+inline fun <reified Input : Any> ToolSetup<Input>.toGiga(): GigaToolSetup {
     val toolSetup = this
     return object : GigaToolSetup {
         override val fn: GigaRequest.Function = GigaRequest.Function(
             name = toolSetup.name,
             description = toolSetup.description,
             parameters = GigaRequest.Parameters(
-                "object",
+                type = "object",
                 properties = HashMap<String, GigaRequest.Property>().apply {
                     val clazz = Input::class
                     for (kProperty: KCallable<*> in clazz.declaredMembers) {
                         val annotation = kProperty.findAnnotation<InputParamDescription>() ?: continue
                         val description = annotation.value
-                        val type = when (val classifier = kProperty.returnType.classifier) {
+                        val classifier = kProperty.returnType.classifier
+                        val enumValues: List<String>? = if (classifier is KClass<*> && classifier.isSubclassOf(Enum::class)) {
+                            (classifier.java.enumConstants as Array<out Enum<*>>).map { it.name }
+                        } else null
+                        val type = when (classifier) {
                             String::class -> "string"
                             Boolean::class -> "boolean"
                             Int::class, Long::class, Double::class -> "number"
                             List::class, Set::class, Array::class -> "array"
-                            Map::class -> "object" // or you could have a special "map" type if needed
-                            else -> if (classifier is KClass<*> && classifier.isSubclassOf(Collection::class)) {
-                                "array"
-                            } else {
-                                "object"
+                            Map::class -> "object"
+                            else -> when {
+                                classifier is KClass<*> && classifier.isSubclassOf(Collection::class) -> "array"
+                                classifier is KClass<*> && classifier.isSubclassOf(Enum::class) -> "string"
+                                else -> "object"
                             }
-
                         }
-                        val gigaProperty = GigaRequest.Property(type, description)
+                        val gigaProperty = GigaRequest.Property(type, description, enumValues)
                         put(kProperty.name, gigaProperty)
                     }
+                },
+                required = Input::class.primaryConstructor?.parameters
+                    ?.filter { !it.isOptional && !it.type.isMarkedNullable }
+                    ?.mapNotNull { it.name } ?: emptyList()
+            ),
+            fewShotExamples = toolSetup.fewShotExamples.map { GigaRequest.FewShotExample(it.request, it.params) },
+            returnParameters = GigaRequest.Parameters(
+                type = toolSetup.returnParameters.type,
+                properties = toolSetup.returnParameters.properties.mapValues {
+                    GigaRequest.Property(it.value.type, it.value.description)
                 }
             )
         )
@@ -76,7 +90,7 @@ inline fun <reified Input> ToolSetup<Input>.toGiga(): GigaToolSetup {
     }
 }
 
-inline fun <reified Input> ToolSetupWithAttachments<Input>.toGiga(): GigaToolSetup {
+inline fun <reified Input : Any> ToolSetupWithAttachments<Input>.toGiga(): GigaToolSetup {
     val toolSetup = this
     val gigaToolSetup = (toolSetup as ToolSetup<Input>).toGiga()
     return object : GigaToolSetup by gigaToolSetup {

--- a/src/main/kotlin/tool/ToolRunBashCommand.kt
+++ b/src/main/kotlin/tool/ToolRunBashCommand.kt
@@ -5,6 +5,17 @@ import java.io.BufferedReader
 object ToolRunBashCommand : ToolSetup<ToolRunBashCommand.Input> {
     override val name = "RunBashCommand"
     override val description = "Executes a bash command and returns its output"
+    override val fewShotExamples = listOf(
+        FewShotExample(
+            request = "List files in the current directory",
+            params = mapOf("command" to "ls")
+        )
+    )
+    override val returnParameters = ReturnParameters(
+        properties = mapOf(
+            "result" to ReturnProperty("string", "Command output")
+        )
+    )
 
     override fun invoke(input: Input): String {
         val process = ProcessBuilder("bash", "-c", input.command)

--- a/src/main/kotlin/tool/ToolSetup.kt
+++ b/src/main/kotlin/tool/ToolSetup.kt
@@ -4,6 +4,15 @@ package com.dumch.tool
 @Retention(AnnotationRetention.RUNTIME)
 annotation class InputParamDescription(val value: String)
 
+data class FewShotExample(val request: String, val params: Map<String, Any>)
+
+data class ReturnProperty(val type: String, val description: String? = null)
+
+data class ReturnParameters(
+    val type: String = "object",
+    val properties: Map<String, ReturnProperty>
+)
+
 /**
  * [Input] should be a data class with all the properties annotated with the [InputParamDescription]
  * TODO: add compile time check for the above rule
@@ -12,6 +21,9 @@ interface ToolSetup<Input> {
 
     val name: String
     val description: String
+
+    val fewShotExamples: List<FewShotExample>
+    val returnParameters: ReturnParameters
 
     operator fun invoke(input: Input): String
     suspend fun suspendInvoke(input: Input): String = invoke(input)

--- a/src/main/kotlin/tool/desktop/ToolCollectButtons.kt
+++ b/src/main/kotlin/tool/desktop/ToolCollectButtons.kt
@@ -3,9 +3,7 @@ package com.dumch.tool.desktop
 import com.dumch.audio.playText
 import com.dumch.giga.objectMapper
 import com.dumch.image.ImageUtils
-import com.dumch.tool.InputParamDescription
-import com.dumch.tool.ToolRunBashCommand
-import com.dumch.tool.ToolSetup
+import com.dumch.tool.*
 import com.fasterxml.jackson.module.kotlin.readValue
 import kotlinx.coroutines.*
 import org.slf4j.LoggerFactory
@@ -20,6 +18,17 @@ class ToolCollectButtons(
     override val name: String = "CollectButtons"
     override val description: String = "Collects buttons from the frontmost application window and returns JSON with buttons description and coordinates," +
             "e.g., [{\"x\": 100, \"y\": 200, \"name\": \"Button 1\"}, {\"x\": 300, \"y\": 400, \"name\": \"Button 2\"}]"
+    override val fewShotExamples = listOf(
+        FewShotExample(
+            request = "Collect first five buttons on the screen",
+            params = mapOf("buttonsCount" to "5")
+        )
+    )
+    override val returnParameters = ReturnParameters(
+        properties = mapOf(
+            "result" to ReturnProperty("string", "JSON array of buttons")
+        )
+    )
 
     override fun invoke(input: Input): String = runBlocking { suspendInvoke(input) }
 

--- a/src/main/kotlin/tool/desktop/ToolCollectButtons.kt
+++ b/src/main/kotlin/tool/desktop/ToolCollectButtons.kt
@@ -165,7 +165,7 @@ class ToolCollectButtons(
     data class OutButton(val x: Int, val y: Int, val name: String)
 }
 
-suspend fun main() {
+fun main() {
     val tool = ToolCollectButtons(ToolRunBashCommand)
     println(tool.invoke(ToolCollectButtons.Input("3")))
     println(tool.toGiga().fn)

--- a/src/main/kotlin/tool/desktop/ToolCollectButtons.kt
+++ b/src/main/kotlin/tool/desktop/ToolCollectButtons.kt
@@ -2,6 +2,7 @@ package com.dumch.tool.desktop
 
 import com.dumch.audio.playText
 import com.dumch.giga.objectMapper
+import com.dumch.giga.toGiga
 import com.dumch.image.ImageUtils
 import com.dumch.tool.*
 import com.fasterxml.jackson.module.kotlin.readValue
@@ -15,12 +16,18 @@ class ToolCollectButtons(
 ) : ToolSetup<ToolCollectButtons.Input> {
     private val l = LoggerFactory.getLogger(ToolCollectButtons::class.java)
 
+    data class Input(
+        @InputParamDescription("Default buttons count is 7. If you want to return more, send a number, e.g., 15")
+        val buttonsCount: String = "7"
+    )
+
     override val name: String = "CollectButtons"
-    override val description: String = "Collects buttons from the frontmost application window and returns JSON with buttons description and coordinates," +
+    override val description: String = "Collects buttons from the frontmost application window " +
+            "and returns JSON with buttons description and coordinates," +
             "e.g., [{\"x\": 100, \"y\": 200, \"name\": \"Button 1\"}, {\"x\": 300, \"y\": 400, \"name\": \"Button 2\"}]"
     override val fewShotExamples = listOf(
         FewShotExample(
-            request = "Collect first five buttons on the screen",
+            request = "Какие кнопки на экране, перечисли несколько?",
             params = mapOf("buttonsCount" to "5")
         )
     )
@@ -145,11 +152,6 @@ class ToolCollectButtons(
         return objectMapper.writeValueAsString(outButtons)
     }
 
-    data class Input(
-        @InputParamDescription("Default buttons count is 7. If you want to return more, send a number, e.g., 15")
-        val buttonsCount: String = "7"
-    )
-
     data class OsxButton(
         val buttonName: String,
         val role: String,
@@ -166,4 +168,5 @@ class ToolCollectButtons(
 suspend fun main() {
     val tool = ToolCollectButtons(ToolRunBashCommand)
     println(tool.invoke(ToolCollectButtons.Input("3")))
+    println(tool.toGiga().fn)
 }

--- a/src/main/kotlin/tool/desktop/ToolCreateNewBrowserTab.kt
+++ b/src/main/kotlin/tool/desktop/ToolCreateNewBrowserTab.kt
@@ -1,13 +1,22 @@
 package com.dumch.tool.desktop
 
-import com.dumch.tool.InputParamDescription
-import com.dumch.tool.ToolRunBashCommand
-import com.dumch.tool.ToolSetup
+import com.dumch.tool.*
 
 class ToolCreateNewBrowserTab(private val bash: ToolRunBashCommand) : ToolSetup<ToolCreateNewBrowserTab.Input> {
 
     override val name: String = "CreateNewBrowserTab"
     override val description: String = "Opens the given url in the new tab if Safari is running or opens the url in the default browser"
+    override val fewShotExamples = listOf(
+        FewShotExample(
+            request = "Open google in a new tab",
+            params = mapOf("url" to "https://www.google.com")
+        )
+    )
+    override val returnParameters = ReturnParameters(
+        properties = mapOf(
+            "result" to ReturnProperty("string", "Operation status")
+        )
+    )
     override fun invoke(input: Input): String {
         if (input.url.isBlank()) return "The url is empty. Can't open it"
         bash.invoke(

--- a/src/main/kotlin/tool/desktop/ToolCreateNewBrowserTab.kt
+++ b/src/main/kotlin/tool/desktop/ToolCreateNewBrowserTab.kt
@@ -3,18 +3,22 @@ package com.dumch.tool.desktop
 import com.dumch.tool.*
 
 class ToolCreateNewBrowserTab(private val bash: ToolRunBashCommand) : ToolSetup<ToolCreateNewBrowserTab.Input> {
-
+    data class Input(
+        @InputParamDescription("The url to open, e.g., 'https://www.sberbank.ru'")
+        val url: String
+    )
     override val name: String = "CreateNewBrowserTab"
-    override val description: String = "Opens the given url in the new tab if Safari is running or opens the url in the default browser"
+    override val description: String = "Opens the given url in the new tab if Safari is running " +
+            "or opens the url in the default browser"
     override val fewShotExamples = listOf(
         FewShotExample(
-            request = "Open google in a new tab",
+            request = "Открой google в новой вкладке",
             params = mapOf("url" to "https://www.google.com")
         )
     )
     override val returnParameters = ReturnParameters(
         properties = mapOf(
-            "result" to ReturnProperty("string", "Operation status")
+            "result" to ReturnProperty("string", "Operation status, e.g., 'Done'")
         )
     )
     override fun invoke(input: Input): String {
@@ -41,9 +45,4 @@ class ToolCreateNewBrowserTab(private val bash: ToolRunBashCommand) : ToolSetup<
         )
         return "Done"
     }
-
-    class Input(
-        @InputParamDescription("The url to open, e.g., 'https://www.sberbank.ru'")
-        val url: String
-    )
 }

--- a/src/main/kotlin/tool/desktop/ToolCreateNote.kt
+++ b/src/main/kotlin/tool/desktop/ToolCreateNote.kt
@@ -3,13 +3,16 @@ package com.dumch.tool.desktop
 import com.dumch.tool.*
 
 class ToolCreateNote(private val bash: ToolRunBashCommand) : ToolSetup<ToolCreateNote.Input> {
-
+    data class Input(
+        @InputParamDescription("Text of note")
+        val noteText: String
+    )
     override val name: String = "CreateNote"
     override val description: String = "Opens Notes and create new note with text"
     override val fewShotExamples = listOf(
         FewShotExample(
-            request = "Create a note to buy milk",
-            params = mapOf("noteText" to "Buy milk")
+            request = "Создай заметку, чтобы купить молоко в субботу",
+            params = mapOf("noteText" to "Купить молоко в субботу")
         )
     )
     override val returnParameters = ReturnParameters(
@@ -32,9 +35,4 @@ class ToolCreateNote(private val bash: ToolRunBashCommand) : ToolSetup<ToolCreat
         )
         return "Done"
     }
-
-    class Input(
-        @InputParamDescription("Text of note")
-        val noteText: String
-    )
 }

--- a/src/main/kotlin/tool/desktop/ToolCreateNote.kt
+++ b/src/main/kotlin/tool/desktop/ToolCreateNote.kt
@@ -1,13 +1,22 @@
 package com.dumch.tool.desktop
 
-import com.dumch.tool.InputParamDescription
-import com.dumch.tool.ToolRunBashCommand
-import com.dumch.tool.ToolSetup
+import com.dumch.tool.*
 
 class ToolCreateNote(private val bash: ToolRunBashCommand) : ToolSetup<ToolCreateNote.Input> {
 
     override val name: String = "CreateNote"
     override val description: String = "Opens Notes and create new note with text"
+    override val fewShotExamples = listOf(
+        FewShotExample(
+            request = "Create a note to buy milk",
+            params = mapOf("noteText" to "Buy milk")
+        )
+    )
+    override val returnParameters = ReturnParameters(
+        properties = mapOf(
+            "result" to ReturnProperty("string", "Operation status")
+        )
+    )
     override fun invoke(input: Input): String {
         bash.invoke(
             ToolRunBashCommand.Input(

--- a/src/main/kotlin/tool/desktop/ToolDesktopScreenShot.kt
+++ b/src/main/kotlin/tool/desktop/ToolDesktopScreenShot.kt
@@ -2,8 +2,7 @@ package com.dumch.tool.desktop
 
 import com.dumch.giga.GigaChatAPI
 import com.dumch.image.ImageUtils
-import com.dumch.tool.InputParamDescription
-import com.dumch.tool.ToolSetupWithAttachments
+import com.dumch.tool.*
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
 import java.io.File
@@ -16,6 +15,17 @@ class ToolDesktopScreenShot(
     override val name: String = "DesktopScreenShot"
     override val description: String = "Captures desktop screenshot and uploads it to GigaChat, returning image id. " +
             "Use it to see what's on desktop"
+    override val fewShotExamples = listOf(
+        FewShotExample(
+            request = "Take a screenshot of the first desktop",
+            params = mapOf("path" to "1")
+        )
+    )
+    override val returnParameters = ReturnParameters(
+        properties = mapOf(
+            "result" to ReturnProperty("string", "Uploaded image id")
+        )
+    )
 
     private val lastAttachments = ArrayList<String>()
     override val attachments: List<String>

--- a/src/main/kotlin/tool/desktop/ToolDesktopScreenShot.kt
+++ b/src/main/kotlin/tool/desktop/ToolDesktopScreenShot.kt
@@ -12,13 +12,26 @@ class ToolDesktopScreenShot(
 ) : ToolSetupWithAttachments<ToolDesktopScreenShot.Input> {
     private val l = LoggerFactory.getLogger(ToolDesktopScreenShot::class.java)
 
+    data class Input(
+        @InputParamDescription("Desktop number to capture, e.g., '1' for the primary display by default")
+        val path: String = "1"
+    )
+
     override val name: String = "DesktopScreenShot"
     override val description: String = "Captures desktop screenshot and uploads it to GigaChat, returning image id. " +
             "Use it to see what's on desktop"
     override val fewShotExamples = listOf(
         FewShotExample(
-            request = "Take a screenshot of the first desktop",
+            request = "Сделай скриншот",
             params = mapOf("path" to "1")
+        ),
+        FewShotExample(
+            request = "Что видишь на экране?",
+            params = mapOf("path" to "1")
+        ),
+        FewShotExample(
+            request = "Что видишь на третьем экране?",
+            params = mapOf("path" to "3")
         )
     )
     override val returnParameters = ReturnParameters(
@@ -48,11 +61,6 @@ class ToolDesktopScreenShot(
                 .also { l.error(it, e) }
         }
     }
-
-    data class Input(
-        @InputParamDescription("Desktop number to capture, e.g., '1' for the primary display by default")
-        val path: String = "1"
-    )
 }
 
 fun main() {

--- a/src/main/kotlin/tool/desktop/ToolHotkeyPress.kt
+++ b/src/main/kotlin/tool/desktop/ToolHotkeyPress.kt
@@ -1,8 +1,7 @@
 package com.dumch.tool.desktop
 
 import com.dumch.keys.*
-import com.dumch.tool.InputParamDescription
-import com.dumch.tool.ToolSetup
+import com.dumch.tool.*
 import java.lang.Thread.sleep
 
 class ToolHotkeyMac : ToolSetup<ToolHotkeyMac.Input> {
@@ -11,6 +10,17 @@ class ToolHotkeyMac : ToolSetup<ToolHotkeyMac.Input> {
 
     override val name = "Hotkey"
     override val description = "Press keys provided in a list like [\"space\", \"close_tab\"]"
+    override val fewShotExamples = listOf(
+        FewShotExample(
+            request = "Close the current tab",
+            params = mapOf("keys" to listOf("close_tab"))
+        )
+    )
+    override val returnParameters = ReturnParameters(
+        properties = mapOf(
+            "result" to ReturnProperty("string", "Pressed keys description")
+        )
+    )
 
     class Input(
         @InputParamDescription(

--- a/src/main/kotlin/tool/desktop/ToolHotkeyPress.kt
+++ b/src/main/kotlin/tool/desktop/ToolHotkeyPress.kt
@@ -8,21 +8,7 @@ class ToolHotkeyMac : ToolSetup<ToolHotkeyMac.Input> {
     private val cg = CoreGraphics.INSTANCE
     private val cf = CoreFoundation.INSTANCE
 
-    override val name = "Hotkey"
-    override val description = "Press keys provided in a list like [\"space\", \"close_tab\"]"
-    override val fewShotExamples = listOf(
-        FewShotExample(
-            request = "Close the current tab",
-            params = mapOf("keys" to listOf("close_tab"))
-        )
-    )
-    override val returnParameters = ReturnParameters(
-        properties = mapOf(
-            "result" to ReturnProperty("string", "Pressed keys description")
-        )
-    )
-
-    class Input(
+    data class Input(
         @InputParamDescription(
             """Return a list of strings to press a hotkey. Example ["full_screen_toggle"]. Keys options:
             "arrow_left"           -> left arrow
@@ -46,6 +32,36 @@ class ToolHotkeyMac : ToolSetup<ToolHotkeyMac.Input> {
             "cancel_last_action"   -> cmd+z"""
         )
         val keys: List<String>
+    )
+
+    override val name = "Hotkey"
+    override val description = "Press keys provided in a list like [\"space\", \"close_tab\"]"
+    override val fewShotExamples = listOf(
+        FewShotExample(
+            request = "Отмени действие",
+            params = mapOf("keys" to listOf("cancel_last_action"))
+        ),
+        FewShotExample(
+            request = "Доскроль страницу до низа",
+            params = mapOf("keys" to listOf("page_down"))
+        ),
+        FewShotExample(
+            request = "Отскроль страницу совсем немного",
+            params = mapOf("keys" to listOf("arrow_down", "arrow_down"))
+        ),
+        FewShotExample(
+            request = "Проскроль страницу на 2 экрана",
+            params = mapOf("keys" to listOf("space", "space", "space"))
+        ),
+        FewShotExample(
+            request = "Закрой 3 вкладки",
+            params = mapOf("keys" to listOf("close_tab", "close_tab", "close_tab"))
+        ),
+    )
+    override val returnParameters = ReturnParameters(
+        properties = mapOf(
+            "result" to ReturnProperty("string", "Pressed keys description")
+        )
     )
 
     override fun invoke(input: Input): String {

--- a/src/main/kotlin/tool/desktop/ToolMediaControl.kt
+++ b/src/main/kotlin/tool/desktop/ToolMediaControl.kt
@@ -1,5 +1,7 @@
 package com.dumch.tool.desktop
 
+import com.dumch.giga.objectMapper
+import com.dumch.giga.toGiga
 import com.dumch.tool.*
 
 class ToolMediaControl(private val bash: ToolRunBashCommand) : ToolSetup<ToolMediaControl.Input> {
@@ -16,7 +18,7 @@ class ToolMediaControl(private val bash: ToolRunBashCommand) : ToolSetup<ToolMed
     override val description: String = "Controls volume and display brightness"
     override val fewShotExamples = listOf(
         FewShotExample(
-            request = "Turn the volume up",
+            request = "Сделай громкость повыше",
             params = mapOf("action" to Action.volume_up)
         )
     )
@@ -42,6 +44,7 @@ class ToolMediaControl(private val bash: ToolRunBashCommand) : ToolSetup<ToolMed
 }
 
 fun main() {
-    val r = ToolMediaControl(ToolRunBashCommand).invoke(ToolMediaControl.Input(ToolMediaControl.Action.playpause))
-    println(r)
+    val t = ToolMediaControl(ToolRunBashCommand)
+    // t.invoke(ToolMediaControl.Input(ToolMediaControl.Action.brightness_up))
+    println(objectMapper.writeValueAsString(t.toGiga().fn))
 }

--- a/src/main/kotlin/tool/desktop/ToolMediaControl.kt
+++ b/src/main/kotlin/tool/desktop/ToolMediaControl.kt
@@ -1,29 +1,40 @@
 package com.dumch.tool.desktop
 
-import com.dumch.tool.InputParamDescription
-import com.dumch.tool.ToolRunBashCommand
-import com.dumch.tool.ToolSetup
+import com.dumch.tool.*
 
 class ToolMediaControl(private val bash: ToolRunBashCommand) : ToolSetup<ToolMediaControl.Input> {
+    enum class Action {
+        next, previous, playpause, volume_up, volume_down, brightness_down, brightness_up
+    }
+
     data class Input(
-        @InputParamDescription("Action to perform: brightness_up, brightness_down, volume_up, volume_down")
-        val action: String
+        @InputParamDescription("Action to perform")
+        val action: Action
     )
 
     override val name: String = "VolumeAndBrightness"
     override val description: String = "Controls volume and display brightness"
+    override val fewShotExamples = listOf(
+        FewShotExample(
+            request = "Turn the volume up",
+            params = mapOf("action" to Action.volume_up)
+        )
+    )
+    override val returnParameters = ReturnParameters(
+        properties = mapOf(
+            "result" to ReturnProperty("string", "Operation status")
+        )
+    )
 
     override fun invoke(input: Input): String {
         val script = when (input.action) {
-            // remember to change description
-            "next" -> ""
-            "previous" -> ""
-            "playpause" -> ""
-            "volume_up" -> "set volume output volume ((output volume of (get volume settings)) + 10)"   // works
-            "volume_down" -> "set volume output volume ((output volume of (get volume settings)) - 10)" // works
-            "brightness_down" -> "tell application \"System Events\" to key code 145"
-            "brightness_up" -> "tell application \"System Events\" to key code 144"
-            else -> throw IllegalArgumentException("Unknown action: ${input.action}")
+            Action.next -> ""
+            Action.previous -> ""
+            Action.playpause -> ""
+            Action.volume_up -> "set volume output volume ((output volume of (get volume settings)) + 10)"
+            Action.volume_down -> "set volume output volume ((output volume of (get volume settings)) - 10)"
+            Action.brightness_down -> "tell application \"System Events\" to key code 145"
+            Action.brightness_up -> "tell application \"System Events\" to key code 144"
         }
         bash.apple(script)
         return "Done"
@@ -31,6 +42,6 @@ class ToolMediaControl(private val bash: ToolRunBashCommand) : ToolSetup<ToolMed
 }
 
 fun main() {
-    val r = ToolMediaControl(ToolRunBashCommand).invoke(ToolMediaControl.Input("playpause"))
+    val r = ToolMediaControl(ToolRunBashCommand).invoke(ToolMediaControl.Input(ToolMediaControl.Action.playpause))
     println(r)
 }

--- a/src/main/kotlin/tool/desktop/ToolMinimizeWindows.kt
+++ b/src/main/kotlin/tool/desktop/ToolMinimizeWindows.kt
@@ -1,8 +1,6 @@
 package com.dumch.tool.desktop
 
 import com.dumch.tool.*
-import java.awt.SystemColor.window
-import java.lang.ProcessBuilder.Redirect.to
 
 class ToolMinimizeWindows(private val bash: ToolRunBashCommand) : ToolSetup<ToolMinimizeWindows.Input> {
 

--- a/src/main/kotlin/tool/desktop/ToolMinimizeWindows.kt
+++ b/src/main/kotlin/tool/desktop/ToolMinimizeWindows.kt
@@ -6,12 +6,23 @@ import java.lang.ProcessBuilder.Redirect.to
 
 class ToolMinimizeWindows(private val bash: ToolRunBashCommand) : ToolSetup<ToolMinimizeWindows.Input> {
 
+    enum class WindowTarget { all, current }
+
+    data class Input(
+        @InputParamDescription("send \"all\" to minimize all windows or \"current\" to minimize the current window")
+        val minimizeOption: WindowTarget
+    )
+
     override val name: String = "MinimizeWindows"
     override val description: String = "Collapses desktop windows according to the given parameter: all windows or just the active window"
     override val fewShotExamples = listOf(
         FewShotExample(
-            request = "Minimize all windows",
+            request = "Сверни все окна",
             params = mapOf("minimizeOption" to WindowTarget.all)
+        ),
+        FewShotExample(
+            request = "Скрой текущее окно",
+            params = mapOf("minimizeOption" to WindowTarget.current)
         )
     )
     override val returnParameters = ReturnParameters(
@@ -71,11 +82,4 @@ class ToolMinimizeWindows(private val bash: ToolRunBashCommand) : ToolSetup<Tool
         )
         return "Done"
     }
-
-    enum class WindowTarget { all, current }
-
-    class Input(
-        @InputParamDescription("send \"all\" to minimize all windows or \"current\" to minimize the current window")
-        val minimizeOption: WindowTarget
-    )
 }

--- a/src/main/kotlin/tool/desktop/ToolMinimizeWindows.kt
+++ b/src/main/kotlin/tool/desktop/ToolMinimizeWindows.kt
@@ -1,8 +1,6 @@
 package com.dumch.tool.desktop
 
-import com.dumch.tool.InputParamDescription
-import com.dumch.tool.ToolRunBashCommand
-import com.dumch.tool.ToolSetup
+import com.dumch.tool.*
 import java.awt.SystemColor.window
 import java.lang.ProcessBuilder.Redirect.to
 
@@ -10,6 +8,17 @@ class ToolMinimizeWindows(private val bash: ToolRunBashCommand) : ToolSetup<Tool
 
     override val name: String = "MinimizeWindows"
     override val description: String = "Collapses desktop windows according to the given parameter: all windows or just the active window"
+    override val fewShotExamples = listOf(
+        FewShotExample(
+            request = "Minimize all windows",
+            params = mapOf("minimizeOption" to WindowTarget.all)
+        )
+    )
+    override val returnParameters = ReturnParameters(
+        properties = mapOf(
+            "result" to ReturnProperty("string", "Operation status")
+        )
+    )
     override fun invoke(input: Input): String {
         bash.invoke(
             ToolRunBashCommand.Input(
@@ -63,8 +72,10 @@ class ToolMinimizeWindows(private val bash: ToolRunBashCommand) : ToolSetup<Tool
         return "Done"
     }
 
+    enum class WindowTarget { all, current }
+
     class Input(
-        @InputParamDescription("""send "all" to minimize all windows or send "current" to minimize the current window""")
-        val minimizeOption: String
+        @InputParamDescription("send \"all\" to minimize all windows or \"current\" to minimize the current window")
+        val minimizeOption: WindowTarget
     )
 }

--- a/src/main/kotlin/tool/desktop/ToolMouseClick.kt
+++ b/src/main/kotlin/tool/desktop/ToolMouseClick.kt
@@ -3,7 +3,6 @@ package com.dumch.tool.desktop
 import com.dumch.image.ImageUtils
 import com.dumch.keys.*
 import com.dumch.tool.*
-import org.slf4j.LoggerFactory
 
 private object CG {
     const val kCGHIDEventTap = 0
@@ -19,7 +18,6 @@ private object CG {
 }
 
 class ToolMouseClickMac : ToolSetup<ToolMouseClickMac.Input> {
-    private val l = LoggerFactory.getLogger(ToolMouseClickMac::class.java)
     private val cg = CoreGraphics.INSTANCE
     private val cf = CoreFoundation.INSTANCE
 

--- a/src/main/kotlin/tool/desktop/ToolMouseClick.kt
+++ b/src/main/kotlin/tool/desktop/ToolMouseClick.kt
@@ -2,8 +2,7 @@ package com.dumch.tool.desktop
 
 import com.dumch.image.ImageUtils
 import com.dumch.keys.*
-import com.dumch.tool.InputParamDescription
-import com.dumch.tool.ToolSetup
+import com.dumch.tool.*
 import org.slf4j.LoggerFactory
 
 private object CG {
@@ -26,6 +25,17 @@ class ToolMouseClickMac : ToolSetup<ToolMouseClickMac.Input> {
 
     override val name = "MouseClick"
     override val description = "Clicks the mouse at the given coordinates (macOS)."
+    override val fewShotExamples = listOf(
+        FewShotExample(
+            request = "Click at coordinates 100,200",
+            params = mapOf("x" to 100, "y" to 200, "button" to MouseButton.left)
+        )
+    )
+    override val returnParameters = ReturnParameters(
+        properties = mapOf(
+            "result" to ReturnProperty("string", "Information about the click")
+        )
+    )
 
     override fun invoke(input: Input): String {
         require(System.getProperty("os.name").contains("Mac", ignoreCase = true)) {
@@ -35,11 +45,10 @@ class ToolMouseClickMac : ToolSetup<ToolMouseClickMac.Input> {
         val x = input.x.toDouble() / ImageUtils.DESKTOP_SCREENSHOT_QUALITY
         val y = input.y.toDouble() / ImageUtils.DESKTOP_SCREENSHOT_QUALITY
 
-        val (btnIdx, downType, upType) = when (input.button.toInt()) {
-            1 -> Triple(CG.kCGMouseButtonLeft, CG.kCGEventLeftMouseDown, CG.kCGEventLeftMouseUp)
-            2 -> Triple(CG.kCGMouseButtonRight, CG.kCGEventRightMouseDown, CG.kCGEventRightMouseUp)
-            3 -> Triple(CG.kCGMouseButtonCenter, CG.kCGEventOtherMouseDown, CG.kCGEventOtherMouseUp)
-            else -> error("button must be 1(left), 2(right) or 3(middle)")
+        val (btnIdx, downType, upType) = when (input.button) {
+            MouseButton.left -> Triple(CG.kCGMouseButtonLeft, CG.kCGEventLeftMouseDown, CG.kCGEventLeftMouseUp)
+            MouseButton.right -> Triple(CG.kCGMouseButtonRight, CG.kCGEventRightMouseDown, CG.kCGEventRightMouseUp)
+            MouseButton.middle -> Triple(CG.kCGMouseButtonCenter, CG.kCGEventOtherMouseDown, CG.kCGEventOtherMouseUp)
         }
 
         val pt = CGPoint(x, y)
@@ -57,14 +66,16 @@ class ToolMouseClickMac : ToolSetup<ToolMouseClickMac.Input> {
         return "Mouse clicked at ($x, $y) with button $btnIdx"
     }
 
+    enum class MouseButton { left, right, middle }
+
     class Input(
         @InputParamDescription("The x coordinate of the mouse click") val x: Int,
         @InputParamDescription("The y coordinate of the mouse click") val y: Int,
-        @InputParamDescription("The button to click. 1 means left, 2 means right, 3 means middle") val button: Int = 1
+        @InputParamDescription("The button to click") val button: MouseButton = MouseButton.left
     )
 }
 
 fun main() {
     val tool = ToolMouseClickMac()
-    println(tool.invoke(ToolMouseClickMac.Input(0, 0, 1)))
+    println(tool.invoke(ToolMouseClickMac.Input(0, 0, ToolMouseClickMac.MouseButton.left)))
 }

--- a/src/main/kotlin/tool/desktop/ToolMouseClick.kt
+++ b/src/main/kotlin/tool/desktop/ToolMouseClick.kt
@@ -23,11 +23,19 @@ class ToolMouseClickMac : ToolSetup<ToolMouseClickMac.Input> {
     private val cg = CoreGraphics.INSTANCE
     private val cf = CoreFoundation.INSTANCE
 
+    enum class MouseButton { left, right, middle }
+
+    data class Input(
+        @InputParamDescription("The x coordinate of the mouse click") val x: Int,
+        @InputParamDescription("The y coordinate of the mouse click") val y: Int,
+        @InputParamDescription("The button to click") val button: MouseButton = MouseButton.left
+    )
+
     override val name = "MouseClick"
     override val description = "Clicks the mouse at the given coordinates (macOS)."
     override val fewShotExamples = listOf(
         FewShotExample(
-            request = "Click at coordinates 100,200",
+            request = "Нажми кнопку мыши в точке 100,200",
             params = mapOf("x" to 100, "y" to 200, "button" to MouseButton.left)
         )
     )
@@ -65,14 +73,6 @@ class ToolMouseClickMac : ToolSetup<ToolMouseClickMac.Input> {
 
         return "Mouse clicked at ($x, $y) with button $btnIdx"
     }
-
-    enum class MouseButton { left, right, middle }
-
-    class Input(
-        @InputParamDescription("The x coordinate of the mouse click") val x: Int,
-        @InputParamDescription("The y coordinate of the mouse click") val y: Int,
-        @InputParamDescription("The button to click") val button: MouseButton = MouseButton.left
-    )
 }
 
 fun main() {

--- a/src/main/kotlin/tool/desktop/ToolOpenApp.kt
+++ b/src/main/kotlin/tool/desktop/ToolOpenApp.kt
@@ -1,13 +1,22 @@
 package com.dumch.tool.desktop
 
-import com.dumch.tool.InputParamDescription
-import com.dumch.tool.ToolRunBashCommand
-import com.dumch.tool.ToolSetup
+import com.dumch.tool.*
 
 class ToolOpenApp(private val bash: ToolRunBashCommand) : ToolSetup<ToolOpenApp.Input> {
     override val name: String
         get() = "OpenApp"
     override val description: String = "Opens the given app"
+    override val fewShotExamples = listOf(
+        FewShotExample(
+            request = "Launch Calculator",
+            params = mapOf("appName" to "Calculator")
+        )
+    )
+    override val returnParameters = ReturnParameters(
+        properties = mapOf(
+            "result" to ReturnProperty("string", "Operation status")
+        )
+    )
 
     override fun invoke(input: Input): String {
         bash.invoke(

--- a/src/main/kotlin/tool/desktop/ToolOpenApp.kt
+++ b/src/main/kotlin/tool/desktop/ToolOpenApp.kt
@@ -1,14 +1,22 @@
 package com.dumch.tool.desktop
 
 import com.dumch.tool.*
+import org.slf4j.LoggerFactory
 
 class ToolOpenApp(private val bash: ToolRunBashCommand) : ToolSetup<ToolOpenApp.Input> {
-    override val name: String
-        get() = "OpenApp"
+    private val l = LoggerFactory.getLogger(ToolOpenApp::class.java)
+
+    data class Input(
+        @InputParamDescription("The name of the app to open, e.g., 'Safari', 'Calendar', 'Telegram'")
+        val appName: String
+    )
+
+    override val name: String = "OpenApp"
     override val description: String = "Opens the given app"
+
     override val fewShotExamples = listOf(
         FewShotExample(
-            request = "Launch Calculator",
+            request = "Запусти калькулятор",
             params = mapOf("appName" to "Calculator")
         )
     )
@@ -19,16 +27,14 @@ class ToolOpenApp(private val bash: ToolRunBashCommand) : ToolSetup<ToolOpenApp.
     )
 
     override fun invoke(input: Input): String {
-        bash.invoke(
-            ToolRunBashCommand.Input("""open -a "${input.appName}"""")
-        )
+        try {
+            bash.sh("""open -a "${input.appName}"""")
+        } catch (e: Exception) {
+            return "Error in ToolOpenApp: ${e.message}"
+                .also { l.error(it, e) }
+        }
         return "Done"
     }
-
-    class Input(
-        @InputParamDescription("The name of the app to open, e.g., 'Safari', 'Calendar', 'Telegram'")
-        val appName: String
-    )
 }
 
 fun main() {

--- a/src/main/kotlin/tool/desktop/ToolOpenFile.kt
+++ b/src/main/kotlin/tool/desktop/ToolOpenFile.kt
@@ -8,13 +8,22 @@ import kotlin.text.replace
 class ToolOpenFile(private val bash: ToolRunBashCommand) : ToolSetup<ToolOpenFile.Input> {
     private val l = LoggerFactory.getLogger(ToolOpenFile::class.java)
 
+    data class Input(
+        @InputParamDescription("The full path to the file to open, e.g., '\$HOME/Pictures/портрет.jpeg'")
+        val filePath: String,
+    )
+    
     override val name: String = "OpenFile"
     override val description: String = "Opens the file at the given path in the default app. Use it to open photos as well"
     override val fewShotExamples = listOf(
         FewShotExample(
-            request = "Open my profile picture",
+            request = "Покажи profile",
             params = mapOf("filePath" to "\$HOME/Pictures/profile.jpg")
-        )
+        ),
+        FewShotExample(
+            request = "Открой пэдеэфку в загрузках",
+            params = mapOf("filePath" to "\$HOME/Downloads/*.pdf")
+        ),
     )
     override val returnParameters = ReturnParameters(
         properties = mapOf(
@@ -37,11 +46,6 @@ class ToolOpenFile(private val bash: ToolRunBashCommand) : ToolSetup<ToolOpenFil
         }
         return "Done"
     }
-
-    data class Input(
-        @InputParamDescription("The full path to the file to open, e.g., '\$HOME/Pictures/портрет.jpeg'")
-        val filePath: String,
-    )
 }
 
 fun main() {

--- a/src/main/kotlin/tool/desktop/ToolOpenFile.kt
+++ b/src/main/kotlin/tool/desktop/ToolOpenFile.kt
@@ -1,8 +1,6 @@
 package com.dumch.tool.desktop
 
-import com.dumch.tool.InputParamDescription
-import com.dumch.tool.ToolRunBashCommand
-import com.dumch.tool.ToolSetup
+import com.dumch.tool.*
 import org.slf4j.LoggerFactory
 import java.io.File
 import kotlin.text.replace
@@ -12,6 +10,17 @@ class ToolOpenFile(private val bash: ToolRunBashCommand) : ToolSetup<ToolOpenFil
 
     override val name: String = "OpenFile"
     override val description: String = "Opens the file at the given path in the default app. Use it to open photos as well"
+    override val fewShotExamples = listOf(
+        FewShotExample(
+            request = "Open my profile picture",
+            params = mapOf("filePath" to "\$HOME/Pictures/profile.jpg")
+        )
+    )
+    override val returnParameters = ReturnParameters(
+        properties = mapOf(
+            "result" to ReturnProperty("string", "Operation status")
+        )
+    )
 
     override fun invoke(input: Input): String {
         val fixedPath = input.filePath.replace("\$HOME", System.getenv("HOME"))

--- a/src/main/kotlin/tool/desktop/ToolOpenFolder.kt
+++ b/src/main/kotlin/tool/desktop/ToolOpenFolder.kt
@@ -11,8 +11,12 @@ class ToolOpenFolder(private val bash: ToolRunBashCommand) : ToolSetup<ToolOpenF
     override val description: String = "Opens Folder by its name, returns the path and the list of files inside"
     override val fewShotExamples = listOf(
         FewShotExample(
-            request = "Open Downloads folder",
+            request = "Открой загрузки",
             params = mapOf("name" to "Downloads")
+        ),
+        FewShotExample(
+            request = "Открой папку 'Семья'",
+            params = mapOf("name" to "Семья")
         )
     )
     override val returnParameters = ReturnParameters(

--- a/src/main/kotlin/tool/desktop/ToolOpenFolder.kt
+++ b/src/main/kotlin/tool/desktop/ToolOpenFolder.kt
@@ -1,8 +1,6 @@
 package com.dumch.tool.desktop
 
-import com.dumch.tool.InputParamDescription
-import com.dumch.tool.ToolRunBashCommand
-import com.dumch.tool.ToolSetup
+import com.dumch.tool.*
 import com.dumch.tool.files.ToolListFiles
 import org.slf4j.LoggerFactory
 
@@ -11,6 +9,17 @@ class ToolOpenFolder(private val bash: ToolRunBashCommand) : ToolSetup<ToolOpenF
 
     override val name: String = "OpenFolder"
     override val description: String = "Opens Folder by its name, returns the path and the list of files inside"
+    override val fewShotExamples = listOf(
+        FewShotExample(
+            request = "Open Downloads folder",
+            params = mapOf("name" to "Downloads")
+        )
+    )
+    override val returnParameters = ReturnParameters(
+        properties = mapOf(
+            "result" to ReturnProperty("string", "JSON string with path and files")
+        )
+    )
 
     data class Input(
         @InputParamDescription("Folder name")

--- a/src/main/kotlin/tool/desktop/ToolSafariInfo.kt
+++ b/src/main/kotlin/tool/desktop/ToolSafariInfo.kt
@@ -14,26 +14,31 @@ import org.xml.sax.InputSource
  * Works on macOS only and uses system tools such as `sqlite3`, `plutil` and AppleScript.
  */
 class ToolSafariInfo(private val bash: ToolRunBashCommand) : ToolSetup<ToolSafariInfo.Input> {
-
+    enum class InfoType { history, bookmarks, tabs }
+    data class Input(
+        @InputParamDescription("Type of information to fetch")
+        val type: InfoType,
+    )
     override val name: String = "SafariInfo"
     override val description: String = "Returns Safari history, bookmarks or open tabs"
     override val fewShotExamples = listOf(
         FewShotExample(
-            request = "Show my Safari history",
+            request = "Покажи историю браузера",
             params = mapOf("type" to InfoType.history)
-        )
+        ),
+        FewShotExample(
+            request = "Найди закладку про фильмы в Safari",
+            params = mapOf("type" to InfoType.bookmarks)
+        ),
+        FewShotExample(
+            request = "Покажи открытые вкладки в Safari",
+            params = mapOf("type" to InfoType.tabs)
+        ),
     )
     override val returnParameters = ReturnParameters(
         properties = mapOf(
             "result" to ReturnProperty("string", "Information from Safari")
         )
-    )
-
-    enum class InfoType { history, bookmarks, tabs }
-
-    class Input(
-        @InputParamDescription("Type of information to fetch")
-        val type: InfoType,
     )
 
     override fun invoke(input: Input): String {

--- a/src/main/kotlin/tool/desktop/ToolSafariInfo.kt
+++ b/src/main/kotlin/tool/desktop/ToolSafariInfo.kt
@@ -1,9 +1,7 @@
 package com.dumch.tool.desktop
 
 import com.dumch.giga.objectMapper
-import com.dumch.tool.InputParamDescription
-import com.dumch.tool.ToolRunBashCommand
-import com.dumch.tool.ToolSetup
+import com.dumch.tool.*
 import org.w3c.dom.Element
 import org.w3c.dom.Node
 import java.io.StringReader
@@ -19,20 +17,32 @@ class ToolSafariInfo(private val bash: ToolRunBashCommand) : ToolSetup<ToolSafar
 
     override val name: String = "SafariInfo"
     override val description: String = "Returns Safari history, bookmarks or open tabs"
+    override val fewShotExamples = listOf(
+        FewShotExample(
+            request = "Show my Safari history",
+            params = mapOf("type" to InfoType.history)
+        )
+    )
+    override val returnParameters = ReturnParameters(
+        properties = mapOf(
+            "result" to ReturnProperty("string", "Information from Safari")
+        )
+    )
+
+    enum class InfoType { history, bookmarks, tabs }
 
     class Input(
-        @InputParamDescription("Type of information to fetch: 'history', 'bookmarks', or 'tabs'")
-        val type: String,
+        @InputParamDescription("Type of information to fetch")
+        val type: InfoType,
     )
 
     override fun invoke(input: Input): String {
-        return when (input.type.lowercase()) {
-            "history" -> bash.sh(historyCommand())
-            "bookmarks" -> parseSafariBookmarks(bash.sh(bookmarksCommand())).let {
+        return when (input.type) {
+            InfoType.history -> bash.sh(historyCommand())
+            InfoType.bookmarks -> parseSafariBookmarks(bash.sh(bookmarksCommand())).let {
                 objectMapper.writeValueAsString(it)
             }
-            "tabs" -> bash.sh(tabsCommand())
-            else -> "Unknown type: ${input.type}"
+            InfoType.tabs -> bash.sh(tabsCommand())
         }
     }
 
@@ -172,6 +182,6 @@ private fun processArrayElement(array: Element, bookmarks: MutableMap<String, St
 
 fun main() {
     val tool = ToolSafariInfo(ToolRunBashCommand)
-    val result = tool.invoke(ToolSafariInfo.Input("history"))
+    val result = tool.invoke(ToolSafariInfo.Input(ToolSafariInfo.InfoType.history))
     println(result)
 }

--- a/src/main/kotlin/tool/files/ToolDeleteFile.kt
+++ b/src/main/kotlin/tool/files/ToolDeleteFile.kt
@@ -1,13 +1,22 @@
 package com.dumch.tool.files
 
-import com.dumch.tool.BadInputException
-import com.dumch.tool.InputParamDescription
-import com.dumch.tool.ToolSetup
+import com.dumch.tool.*
 import java.io.File
 
 object ToolDeleteFile : ToolSetup<ToolDeleteFile.Input> {
     override val name = "DeleteFile"
     override val description = "Deletes a file at the given path."
+    override val fewShotExamples = listOf(
+        FewShotExample(
+            request = "Remove temp.txt",
+            params = mapOf("path" to "temp.txt")
+        )
+    )
+    override val returnParameters = ReturnParameters(
+        properties = mapOf(
+            "result" to ReturnProperty("string", "Deletion status")
+        )
+    )
 
     override fun invoke(input: Input): String {
         val file = File(input.path)

--- a/src/main/kotlin/tool/files/ToolDeleteFile.kt
+++ b/src/main/kotlin/tool/files/ToolDeleteFile.kt
@@ -4,11 +4,15 @@ import com.dumch.tool.*
 import java.io.File
 
 object ToolDeleteFile : ToolSetup<ToolDeleteFile.Input> {
+    data class Input(
+        @InputParamDescription("The path of the file to delete")
+        val path: String
+    )
     override val name = "DeleteFile"
     override val description = "Deletes a file at the given path."
     override val fewShotExamples = listOf(
         FewShotExample(
-            request = "Remove temp.txt",
+            request = "Удали temp.txt",
             params = mapOf("path" to "temp.txt")
         )
     )
@@ -27,9 +31,4 @@ object ToolDeleteFile : ToolSetup<ToolDeleteFile.Input> {
         file.delete()
         return "File deleted at ${input.path}"
     }
-
-    data class Input(
-        @InputParamDescription("The path of the file to delete")
-        val path: String
-    )
 }

--- a/src/main/kotlin/tool/files/ToolFindTextInFiles.kt
+++ b/src/main/kotlin/tool/files/ToolFindTextInFiles.kt
@@ -4,6 +4,12 @@ import com.dumch.tool.*
 import java.io.File
 
 object ToolFindTextInFiles : ToolSetup<ToolFindTextInFiles.Input> {
+    data class Input(
+        @InputParamDescription("Directory path to search in (recursive)")
+        val path: String = ".",
+        @InputParamDescription("Text to search for inside files")
+        val text: String
+    )
     override val name = "FindTextInFiles"
     override val description = "Search for a specific text across all files in a directory (recursively) " +
             "and return matching file paths."
@@ -11,6 +17,10 @@ object ToolFindTextInFiles : ToolSetup<ToolFindTextInFiles.Input> {
         FewShotExample(
             request = "Find TODO markers",
             params = mapOf("path" to ".", "text" to "TODO")
+        ),
+        FewShotExample(
+            request = "Сколько main функций в проекте",
+            params = mapOf("path" to ".", "text" to "fun main(")
         )
     )
     override val returnParameters = ReturnParameters(
@@ -31,11 +41,4 @@ object ToolFindTextInFiles : ToolSetup<ToolFindTextInFiles.Input> {
 
         return matchedFiles.joinToString(",", prefix = "[", postfix = "]")
     }
-
-    data class Input(
-        @InputParamDescription("Directory path to search in (recursive)")
-        val path: String = ".",
-        @InputParamDescription("Text to search for inside files")
-        val text: String
-    )
 }

--- a/src/main/kotlin/tool/files/ToolFindTextInFiles.kt
+++ b/src/main/kotlin/tool/files/ToolFindTextInFiles.kt
@@ -1,14 +1,23 @@
 package com.dumch.tool.files
 
-import com.dumch.tool.BadInputException
-import com.dumch.tool.InputParamDescription
-import com.dumch.tool.ToolSetup
+import com.dumch.tool.*
 import java.io.File
 
 object ToolFindTextInFiles : ToolSetup<ToolFindTextInFiles.Input> {
     override val name = "FindTextInFiles"
     override val description = "Search for a specific text across all files in a directory (recursively) " +
             "and return matching file paths."
+    override val fewShotExamples = listOf(
+        FewShotExample(
+            request = "Find TODO markers",
+            params = mapOf("path" to ".", "text" to "TODO")
+        )
+    )
+    override val returnParameters = ReturnParameters(
+        properties = mapOf(
+            "result" to ReturnProperty("string", "Array of matching file paths")
+        )
+    )
 
     override fun invoke(input: Input): String {
         val baseDir = File(input.path)

--- a/src/main/kotlin/tool/files/ToolListFiles.kt
+++ b/src/main/kotlin/tool/files/ToolListFiles.kt
@@ -1,13 +1,22 @@
 package com.dumch.tool.files
 
-import com.dumch.tool.BadInputException
-import com.dumch.tool.InputParamDescription
-import com.dumch.tool.ToolSetup
+import com.dumch.tool.*
 import java.io.File
 
 object ToolListFiles : ToolSetup<ToolListFiles.Input> {
     override val name = "ListFiles"
     override val description = "Runs bash ls command at a given path. Dot (.) means current directory"
+    override val fewShotExamples = listOf(
+        FewShotExample(
+            request = "List files in current folder",
+            params = mapOf("path" to ".")
+        )
+    )
+    override val returnParameters = ReturnParameters(
+        properties = mapOf(
+            "result" to ReturnProperty("string", "Array of file paths")
+        )
+    )
 
     override fun invoke(input: Input): String {
         val dirPath = input.path

--- a/src/main/kotlin/tool/files/ToolListFiles.kt
+++ b/src/main/kotlin/tool/files/ToolListFiles.kt
@@ -4,6 +4,10 @@ import com.dumch.tool.*
 import java.io.File
 
 object ToolListFiles : ToolSetup<ToolListFiles.Input> {
+    data class Input(
+        @InputParamDescription("Relative path to list files from")
+        val path: String = "."
+    )
     override val name = "ListFiles"
     override val description = "Runs bash ls command at a given path. Dot (.) means current directory"
     override val fewShotExamples = listOf(
@@ -33,9 +37,4 @@ object ToolListFiles : ToolSetup<ToolListFiles.Input> {
 
         return files.joinToString(",", prefix = "[", postfix = "]")
     }
-
-    data class Input(
-        @InputParamDescription("Relative path to list files from")
-        val path: String = "."
-    )
 }

--- a/src/main/kotlin/tool/files/ToolModifyFile.kt
+++ b/src/main/kotlin/tool/files/ToolModifyFile.kt
@@ -4,6 +4,14 @@ import com.dumch.tool.*
 import java.io.File
 
 object ToolModifyFile : ToolSetup<ToolModifyFile.Input> {
+    data class Input(
+        @InputParamDescription("The path to the file, including file name")
+        val path: String,
+        @InputParamDescription("Exact text to find in the file - must occur exactly once")
+        val oldText: String,
+        @InputParamDescription("Replacement text for the specified old_text")
+        val newText: String,
+    )
     override val name = "EditFile"
     override val description = "Replace text in a file. Replaces 'old_text' with 'new_text' in the specified file. "
     override val fewShotExamples = listOf(
@@ -31,13 +39,4 @@ object ToolModifyFile : ToolSetup<ToolModifyFile.Input> {
         file.writeText(newContent)
         return "OK"
     }
-
-    data class Input(
-        @InputParamDescription("The path to the file, including file name")
-        val path: String,
-        @InputParamDescription("Exact text to find in the file - must occur exactly once")
-        val oldText: String,
-        @InputParamDescription("Replacement text for the specified old_text")
-        val newText: String,
-    )
 }

--- a/src/main/kotlin/tool/files/ToolModifyFile.kt
+++ b/src/main/kotlin/tool/files/ToolModifyFile.kt
@@ -1,13 +1,22 @@
 package com.dumch.tool.files
 
-import com.dumch.tool.BadInputException
-import com.dumch.tool.InputParamDescription
-import com.dumch.tool.ToolSetup
+import com.dumch.tool.*
 import java.io.File
 
 object ToolModifyFile : ToolSetup<ToolModifyFile.Input> {
     override val name = "EditFile"
     override val description = "Replace text in a file. Replaces 'old_text' with 'new_text' in the specified file. "
+    override val fewShotExamples = listOf(
+        FewShotExample(
+            request = "Replace foo with bar in notes.txt",
+            params = mapOf("path" to "notes.txt", "oldText" to "foo", "newText" to "bar")
+        )
+    )
+    override val returnParameters = ReturnParameters(
+        properties = mapOf(
+            "result" to ReturnProperty("string", "Operation status")
+        )
+    )
 
     override fun invoke(input: Input): String {
         val file = File(input.path)

--- a/src/main/kotlin/tool/files/ToolNewFile.kt
+++ b/src/main/kotlin/tool/files/ToolNewFile.kt
@@ -1,13 +1,22 @@
 package com.dumch.tool.files
 
-import com.dumch.tool.BadInputException
-import com.dumch.tool.InputParamDescription
-import com.dumch.tool.ToolSetup
+import com.dumch.tool.*
 import java.io.File
 
 object ToolNewFile : ToolSetup<ToolNewFile.Input> {
     override val name = "NewFile"
     override val description = "Creates a new file at the given path with the provided content."
+    override val fewShotExamples = listOf(
+        FewShotExample(
+            request = "Create notes.txt with greeting",
+            params = mapOf("path" to "notes.txt", "text" to "Hello")
+        )
+    )
+    override val returnParameters = ReturnParameters(
+        properties = mapOf(
+            "result" to ReturnProperty("string", "Creation status")
+        )
+    )
 
     override fun invoke(input: Input): String {
         val file = File(input.path)

--- a/src/main/kotlin/tool/files/ToolNewFile.kt
+++ b/src/main/kotlin/tool/files/ToolNewFile.kt
@@ -4,12 +4,18 @@ import com.dumch.tool.*
 import java.io.File
 
 object ToolNewFile : ToolSetup<ToolNewFile.Input> {
+    data class Input(
+        @InputParamDescription("The path where the file will be created, including filename")
+        val path: String,
+        @InputParamDescription("The content to be written to the new file")
+        val text: String
+    )
     override val name = "NewFile"
     override val description = "Creates a new file at the given path with the provided content."
     override val fewShotExamples = listOf(
         FewShotExample(
             request = "Create notes.txt with greeting",
-            params = mapOf("path" to "notes.txt", "text" to "Hello")
+            params = mapOf("path" to "notes.txt", "text" to "Hello!\n")
         )
     )
     override val returnParameters = ReturnParameters(
@@ -27,11 +33,4 @@ object ToolNewFile : ToolSetup<ToolNewFile.Input> {
         file.writeText(input.text)
         return "File created at ${input.path}"
     }
-
-    data class Input(
-        @InputParamDescription("The path where the file will be created, including filename")
-        val path: String,
-        @InputParamDescription("The content to be written to the new file")
-        val text: String
-    )
 }

--- a/src/main/kotlin/tool/files/ToolReadFile.kt
+++ b/src/main/kotlin/tool/files/ToolReadFile.kt
@@ -4,12 +4,16 @@ import com.dumch.tool.*
 import java.io.File
 
 object ToolReadFile : ToolSetup<ToolReadFile.Input> {
+    data class Input(
+        @InputParamDescription("A relative path pointing to a file in the project directory")
+        val path: String
+    )
     override val name = "ReadFile"
     override val description = "Retrieve the contents of a specified file using a relative path. " +
             "Use this to read a file's contents. Avoid using it with directory paths"
     override val fewShotExamples = listOf(
         FewShotExample(
-            request = "Read the README file",
+            request = "Прочти README",
             params = mapOf("path" to "README.md")
         )
     )
@@ -27,9 +31,4 @@ object ToolReadFile : ToolSetup<ToolReadFile.Input> {
         }
         return file.readText()
     }
-
-    data class Input(
-        @InputParamDescription("A relative path pointing to a file in the project directory")
-        val path: String
-    )
 }

--- a/src/main/kotlin/tool/files/ToolReadFile.kt
+++ b/src/main/kotlin/tool/files/ToolReadFile.kt
@@ -1,14 +1,23 @@
 package com.dumch.tool.files
 
-import com.dumch.tool.BadInputException
-import com.dumch.tool.InputParamDescription
-import com.dumch.tool.ToolSetup
+import com.dumch.tool.*
 import java.io.File
 
 object ToolReadFile : ToolSetup<ToolReadFile.Input> {
     override val name = "ReadFile"
     override val description = "Retrieve the contents of a specified file using a relative path. " +
             "Use this to read a file's contents. Avoid using it with directory paths"
+    override val fewShotExamples = listOf(
+        FewShotExample(
+            request = "Read the README file",
+            params = mapOf("path" to "README.md")
+        )
+    )
+    override val returnParameters = ReturnParameters(
+        properties = mapOf(
+            "result" to ReturnProperty("string", "File contents")
+        )
+    )
 
     override fun invoke(input: Input): String {
         val path = input.path


### PR DESCRIPTION
## Summary
- add `FewShotExample` and `ReturnParameters` support to `ToolSetup`
- expose function schemas including few-shot examples and return parameters
- add enums to tool inputs and wire enum/required handling in tool generation

## Testing
- `./gradlew test` *(fails: Could not resolve org.jetbrains.kotlin:kotlin-test:2.1.21, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689a63ca24688329a51af9ee7b0c2134