### PR TITLE
Refresh token on auth errors and convert gRPC response

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,6 +61,7 @@ dependencies {
     implementation("ws.schild:jave-nativebin-osxm1:3.5.0")
 
     testImplementation(kotlin("test"))
+    testImplementation("io.mockk:mockk:1.13.11")
 }
 
 protobuf {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,7 +60,6 @@ dependencies {
     implementation("ws.schild:jave-core:3.5.0")
     implementation("ws.schild:jave-nativebin-osxm1:3.5.0")
 
-    testImplementation(kotlin("test"))
     testImplementation("io.mockk:mockk:1.13.11")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,10 @@ java {
     targetCompatibility = JavaVersion.VERSION_23
 }
 
+tasks.test {
+    useJUnitPlatform()
+}
+
 dependencies {
     implementation(kotlin("reflect"))
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.Coroutines}")
@@ -60,6 +64,7 @@ dependencies {
     implementation("ws.schild:jave-core:3.5.0")
     implementation("ws.schild:jave-nativebin-osxm1:3.5.0")
 
+    testImplementation(kotlin("test"))
     testImplementation("io.mockk:mockk:1.13.11")
 }
 

--- a/src/main/kotlin/giga/GRPCGigaChatAPI.kt
+++ b/src/main/kotlin/giga/GRPCGigaChatAPI.kt
@@ -4,11 +4,14 @@ import gigachat.v1.ChatServiceGrpcKt
 import gigachat.v1.Gigachatv1
 import io.grpc.ManagedChannel
 import io.grpc.Metadata
+import io.grpc.Status
+import io.grpc.StatusRuntimeException
 import org.slf4j.LoggerFactory
 import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext
 import java.io.File
+import com.fasterxml.jackson.module.kotlin.readValue
 
 /**
  * Simple gRPC client for GigaChat ChatService.
@@ -24,13 +27,7 @@ class GRPCGigaChatAPI(private val auth: GigaAuth) {
     private val stub: ChatServiceGrpcKt.ChatServiceCoroutineStub =
         ChatServiceGrpcKt.ChatServiceCoroutineStub(channel)
 
-    suspend fun message(body: GigaRequest.Chat): Gigachatv1.ChatResponse {
-        val token = loadAccessToken()
-        val headers = Metadata().apply {
-            val key = Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER)
-            put(key, "Bearer $token")
-        }
-
+    suspend fun message(body: GigaRequest.Chat): GigaResponse.Chat {
         val request = Gigachatv1.ChatRequest.newBuilder()
             .setModel(body.model)
             .setOptions(
@@ -52,7 +49,17 @@ class GRPCGigaChatAPI(private val auth: GigaAuth) {
             })
             .build()
 
-        return stub.chat(request, headers)
+        val token = loadAccessToken()
+        return try {
+            stub.chat(request, authHeaders(token)).toGigaResponse()
+        } catch (e: StatusRuntimeException) {
+            if (e.status.code == Status.Code.UNAUTHENTICATED) {
+                val newToken = refreshAccessToken()
+                stub.chat(request, authHeaders(newToken)).toGigaResponse()
+            } else {
+                throw e
+            }
+        }
     }
 
     private fun GigaRequest.Function.toGRPC(): Gigachatv1.Function? {
@@ -92,6 +99,50 @@ class GRPCGigaChatAPI(private val auth: GigaAuth) {
         val newToken = auth.requestToken(apiKey, "GIGACHAT_API_PERS")
         System.setProperty("GIGA_ACCESS_TOKEN", newToken)
         return newToken
+    }
+
+    private fun authHeaders(token: String): Metadata = Metadata().apply {
+        val key = Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER)
+        put(key, "Bearer $token")
+    }
+
+    private fun Gigachatv1.ChatResponse.toGigaResponse(): GigaResponse.Chat {
+        val choices = alternativesList.map { alt ->
+            val msg = alt.message
+            val functionCall = if (msg.hasFunctionCall()) {
+                val args: Map<String, Any> = objectMapper.readValue(msg.functionCall.arguments)
+                GigaResponse.FunctionCall(
+                    name = msg.functionCall.name,
+                    arguments = args
+                )
+            } else null
+
+            GigaResponse.Choice(
+                message = GigaResponse.Message(
+                    content = msg.content,
+                    role = GigaMessageRole.valueOf(msg.role),
+                    functionCall = functionCall,
+                    functionsStateId = if (msg.hasFunctionsStateId()) msg.functionsStateId else null,
+                ),
+                index = alt.index,
+                finishReason = alt.finishReason,
+            )
+        }
+
+        val u = usage
+        val usageDto = GigaResponse.Usage(
+            promptTokens = u.promptTokens,
+            completionTokens = u.completionTokens,
+            totalTokens = u.totalTokens,
+            precachedTokens = 0,
+        )
+
+        return GigaResponse.Chat.Ok(
+            choices = choices,
+            created = timestamp,
+            model = modelInfo.name,
+            usage = usageDto,
+        )
     }
 
     companion object {

--- a/src/main/kotlin/giga/GRPCGigaChatAPI.kt
+++ b/src/main/kotlin/giga/GRPCGigaChatAPI.kt
@@ -161,7 +161,7 @@ class GRPCGigaChatAPI(private val auth: GigaAuth) {
 
 suspend fun main() {
     val api = GRPCGigaChatAPI.INSTANCE
-    val result = api.message(GigaRequest.Chat(
+    val result: GigaResponse.Chat = api.message(GigaRequest.Chat(
         model = "GigaChat-Pro",
         messages = listOf(
             GigaRequest.Message(

--- a/src/test/kotlin/giga/GRPCGigaChatAPITest.kt
+++ b/src/test/kotlin/giga/GRPCGigaChatAPITest.kt
@@ -1,5 +1,10 @@
 package giga
 
+import com.dumch.giga.GRPCGigaChatAPI
+import com.dumch.giga.GigaAuth
+import com.dumch.giga.GigaMessageRole
+import com.dumch.giga.GigaRequest
+import com.dumch.giga.GigaResponse
 import gigachat.v1.ChatServiceGrpcKt
 import gigachat.v1.Gigachatv1
 import io.grpc.Metadata
@@ -12,7 +17,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
-class GRPCGigaChatAPI_Test {
+class GRPCGigaChatAPITest {
     private val authKey = Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER)
 
     private fun sampleResponse(): Gigachatv1.ChatResponse {

--- a/src/test/kotlin/giga/GRPCGigaChatAPI_Test.kt
+++ b/src/test/kotlin/giga/GRPCGigaChatAPI_Test.kt
@@ -1,6 +1,5 @@
 package giga
 
-import com.dumch.giga.*
 import gigachat.v1.ChatServiceGrpcKt
 import gigachat.v1.Gigachatv1
 import io.grpc.Metadata
@@ -21,7 +20,7 @@ class GRPCGigaChatAPI_Test {
             .setRole("assistant")
             .setContent("response")
             .build()
-        val alt = Gigachatv1.ChatResponse.Alternative.newBuilder()
+        val alt = Gigachatv1.Alternative.newBuilder()
             .setMessage(msg)
             .setIndex(0)
             .setFinishReason("stop")

--- a/src/test/kotlin/giga/GRPCGigaChatAPI_Test.kt
+++ b/src/test/kotlin/giga/GRPCGigaChatAPI_Test.kt
@@ -1,0 +1,135 @@
+package giga
+
+import com.dumch.giga.*
+import gigachat.v1.ChatServiceGrpcKt
+import gigachat.v1.Gigachatv1
+import io.grpc.Metadata
+import io.grpc.Status
+import io.grpc.StatusRuntimeException
+import io.mockk.*
+import kotlinx.coroutines.runBlocking
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class GRPCGigaChatAPI_Test {
+    private val authKey = Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER)
+
+    private fun sampleResponse(): Gigachatv1.ChatResponse {
+        val msg = Gigachatv1.Message.newBuilder()
+            .setRole("assistant")
+            .setContent("response")
+            .build()
+        val alt = Gigachatv1.ChatResponse.Alternative.newBuilder()
+            .setMessage(msg)
+            .setIndex(0)
+            .setFinishReason("stop")
+            .build()
+        val usage = Gigachatv1.Usage.newBuilder()
+            .setPromptTokens(1)
+            .setCompletionTokens(2)
+            .setTotalTokens(3)
+            .build()
+        return Gigachatv1.ChatResponse.newBuilder()
+            .addAlternatives(alt)
+            .setTimestamp(123L)
+            .setModelInfo(Gigachatv1.ModelInfo.newBuilder().setName("GigaChat-Pro").build())
+            .setUsage(usage)
+            .build()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+        System.clearProperty("GIGA_ACCESS_TOKEN")
+    }
+
+    @Test
+    fun `retries once on UNAUTHENTICATED and returns mapped response`() = runBlocking {
+        mockkObject(GigaAuth)
+        coEvery { GigaAuth.requestToken(any(), any()) } returns "token2"
+
+        val stub = mockk<ChatServiceGrpcKt.ChatServiceCoroutineStub>()
+        val headers = mutableListOf<Metadata>()
+        val response = sampleResponse()
+        var calls = 0
+        coEvery { stub.chat(any(), capture(headers)) } answers {
+            calls++
+            if (calls == 1) throw StatusRuntimeException(Status.UNAUTHENTICATED)
+            response
+        }
+
+        val api = GRPCGigaChatAPI(GigaAuth)
+        val field = GRPCGigaChatAPI::class.java.getDeclaredField("stub").apply { isAccessible = true }
+        field.set(api, stub)
+
+        System.setProperty("GIGA_ACCESS_TOKEN", "token1")
+        val body = GigaRequest.Chat(
+            model = "GigaChat-Pro",
+            messages = listOf(GigaRequest.Message(GigaMessageRole.user, "hi"))
+        )
+
+        val result = api.message(body) as GigaResponse.Chat.Ok
+
+        assertEquals(2, calls)
+        assertEquals("Bearer token1", headers[0].get(authKey))
+        assertEquals("Bearer token2", headers[1].get(authKey))
+        assertEquals("response", result.choices.first().message.content)
+    }
+
+    @Test
+    fun `propagates after second UNAUTHENTICATED`() = runBlocking {
+        mockkObject(GigaAuth)
+        coEvery { GigaAuth.requestToken(any(), any()) } returns "token2"
+
+        val stub = mockk<ChatServiceGrpcKt.ChatServiceCoroutineStub>()
+        var calls = 0
+        coEvery { stub.chat(any(), any()) } answers {
+            calls++
+            throw StatusRuntimeException(Status.UNAUTHENTICATED)
+        }
+
+        val api = GRPCGigaChatAPI(GigaAuth)
+        val field = GRPCGigaChatAPI::class.java.getDeclaredField("stub").apply { isAccessible = true }
+        field.set(api, stub)
+
+        System.setProperty("GIGA_ACCESS_TOKEN", "token1")
+        val body = GigaRequest.Chat(
+            model = "GigaChat-Pro",
+            messages = listOf(GigaRequest.Message(GigaMessageRole.user, "hi"))
+        )
+
+        assertFailsWith<StatusRuntimeException> { api.message(body) }
+        assertEquals(2, calls)
+    }
+
+    @Test
+    fun `returns mapped response`() = runBlocking {
+        mockkObject(GigaAuth)
+        val stub = mockk<ChatServiceGrpcKt.ChatServiceCoroutineStub>()
+        val headers = mutableListOf<Metadata>()
+        val response = sampleResponse()
+        coEvery { stub.chat(any(), capture(headers)) } returns response
+
+        val api = GRPCGigaChatAPI(GigaAuth)
+        val field = GRPCGigaChatAPI::class.java.getDeclaredField("stub").apply { isAccessible = true }
+        field.set(api, stub)
+
+        System.setProperty("GIGA_ACCESS_TOKEN", "token1")
+        val body = GigaRequest.Chat(
+            model = "GigaChat-Pro",
+            messages = listOf(GigaRequest.Message(GigaMessageRole.user, "hi"))
+        )
+
+        val result = api.message(body) as GigaResponse.Chat.Ok
+
+        assertEquals("response", result.choices.first().message.content)
+        assertEquals(GigaMessageRole.assistant, result.choices.first().message.role)
+        assertEquals(123L, result.created)
+        assertEquals("GigaChat-Pro", result.model)
+        assertEquals(1, result.usage.promptTokens)
+        assertEquals("Bearer token1", headers[0].get(authKey))
+        coVerify(exactly = 0) { GigaAuth.requestToken(any(), any()) }
+    }
+}


### PR DESCRIPTION
## Summary
- Convert gRPC chat responses to `GigaResponse.Chat`
- Retry gRPC calls with a refreshed token when authentication fails
- Add unit tests covering token refresh retry and failure propagation

## Testing
- `./gradlew test -Pkotlin.jvm.target.validation.mode=warning` *(fails: Could not resolve org.jetbrains.kotlin:kotlin-test:2.1.21; status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_689bab1fad1c8329a73b1deac3e49300