### PR TITLE
Introduce GigaChatAPI interface with REST and gRPC implementations

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -10,6 +10,7 @@ import com.dumch.audio.rawToOpusOgg
 import com.dumch.giga.GigaAgent
 import com.dumch.giga.GigaAuth
 import com.dumch.giga.GigaChatAPI
+import com.dumch.giga.GigaRestChatAPI
 import com.dumch.giga.GigaVoiceAPI
 import com.dumch.keys.HotkeyListener
 import com.github.kwhat.jnativehook.GlobalScreen
@@ -49,7 +50,7 @@ suspend fun main() = coroutineScope {
     )
     launch { audioRecorder.logState() }
     val gigaVoiceAPI = GigaVoiceAPI(GigaAuth)
-    val gigaChatAPI  = GigaChatAPI.INSTANCE
+    val gigaChatAPI: GigaChatAPI = GigaRestChatAPI.INSTANCE
     withNativeHook(hotkeyListener) {
         val userInputFlow = audioRecorder.audioFlow
             .onEach { l.info("[Received audio data: ${it.size} bytes]") }

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -10,7 +10,7 @@ import com.dumch.audio.rawToOpusOgg
 import com.dumch.giga.GigaAgent
 import com.dumch.giga.GigaAuth
 import com.dumch.giga.GigaChatAPI
-import com.dumch.giga.GigaRestChatAPI
+import com.dumch.giga.GigaGRPCChatApi
 import com.dumch.giga.GigaVoiceAPI
 import com.dumch.keys.HotkeyListener
 import com.github.kwhat.jnativehook.GlobalScreen
@@ -50,7 +50,7 @@ suspend fun main() = coroutineScope {
     )
     launch { audioRecorder.logState() }
     val gigaVoiceAPI = GigaVoiceAPI(GigaAuth)
-    val gigaChatAPI: GigaChatAPI = GigaRestChatAPI.INSTANCE
+    val gigaChatAPI: GigaChatAPI = GigaGRPCChatApi.INSTANCE
     withNativeHook(hotkeyListener) {
         val userInputFlow = audioRecorder.audioFlow
             .onEach { l.info("[Received audio data: ${it.size} bytes]") }

--- a/src/main/kotlin/TextMain.kt
+++ b/src/main/kotlin/TextMain.kt
@@ -3,6 +3,7 @@ package com.dumch
 import com.dumch.giga.GigaAgent
 import com.dumch.giga.GigaAuth
 import com.dumch.giga.GigaChatAPI
+import com.dumch.giga.GigaRestChatAPI
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import org.slf4j.LoggerFactory
@@ -10,7 +11,7 @@ import org.slf4j.LoggerFactory
 private val logAgent = LoggerFactory.getLogger("Agent")
 
 suspend fun main() {
-    val agent = GigaAgent.instance(userInputFlow(), GigaChatAPI.INSTANCE)
+    val agent = GigaAgent.instance(userInputFlow(), GigaRestChatAPI.INSTANCE)
     agent.run().collect { text -> logAgent.info(text) }
 }
 

--- a/src/main/kotlin/giga/GigaAuth.kt
+++ b/src/main/kotlin/giga/GigaAuth.kt
@@ -8,6 +8,7 @@ import io.ktor.client.request.forms.*
 import io.ktor.http.*
 
 object GigaAuth {
+    private val l = org.slf4j.LoggerFactory.getLogger(GigaAuth::class.java)
     suspend fun requestToken(apiKey: String, scope: String): String {
         val client = HttpClient(CIO) {
             gigaDefaults()
@@ -20,10 +21,20 @@ object GigaAuth {
         ) {
             header("Content-Type", "application/x-www-form-urlencoded")
             header("Authorization", "Basic $apiKey")
-        }.body<GigaResponse.Token>()
+        }
 
+        if (!response.status.isSuccess()) {
+            l.error("Error in requestToken: ${response.status}")
+            throw IllegalStateException("Error in requestToken: ${response.status}")
+        }
+        val token = try {
+            response.body<GigaResponse.Token>()
+        } catch (e: Exception) {
+            l.error("Error in requestToken: ${e.message}")
+            throw e
+        }
         client.close()
-        return response.accessToken
+        return token.accessToken
     }
 }
 /*

--- a/src/main/kotlin/giga/GigaChatAPI.kt
+++ b/src/main/kotlin/giga/GigaChatAPI.kt
@@ -1,93 +1,9 @@
 package com.dumch.giga
 
-import com.dumch.tool.ToolRunBashCommand
-import com.fasterxml.jackson.module.kotlin.readValue
-import io.ktor.client.*
-import io.ktor.client.call.*
-import io.ktor.client.engine.cio.*
-import io.ktor.client.plugins.auth.*
-import io.ktor.client.plugins.auth.providers.*
-import io.ktor.client.plugins.logging.*
-import io.ktor.client.request.*
-import io.ktor.http.*
-import org.slf4j.LoggerFactory
 import java.io.File
 
-class GigaChatAPI(private val auth: GigaAuth) {
-    private val l = LoggerFactory.getLogger(GigaChatAPI::class.java)
-
-    private val client = HttpClient(CIO) {
-        gigaDefaults()
-        install(Logging) {
-            val envLevel = System.getenv("GIGA_LOG_LEVEL")
-                ?.let { LogLevel.valueOf(it) } ?: LogLevel.INFO
-            l.info("GIGA_LOG_LEVEL: $envLevel")
-            level = envLevel
-            sanitizeHeader { it.equals(HttpHeaders.Authorization, true) }
-        }
-        install(Auth) {
-            bearer {
-                loadTokens {
-                    BearerTokens(loadAccessToken(), "")
-                }
-                refreshTokens {
-                    BearerTokens(refreshAccessToken(), "")
-                }
-            }
-        }
-    }
-
-    suspend fun message(body: GigaRequest.Chat): GigaResponse.Chat {
-        val response = client.post("https://gigachat.devices.sberbank.ru/api/v1/chat/completions") {
-            setBody(body)
-        }
-        return when {
-            response.status.isSuccess() -> response.body<GigaResponse.Chat.Ok>()
-            else -> response.body<GigaResponse.Chat.Error>()
-        }
-    }
-
-    suspend fun uploadImage(file: File): GigaResponse.UploadFile {
-        return try {
-            uploadImageWithToken(file, loadAccessToken())
-        } catch (e: Exception) {
-            uploadImageWithToken(file, refreshAccessToken())
-        }
-    }
-
-    private suspend fun uploadImageWithToken(file: File, accessToken: String): GigaResponse.UploadFile {
-        val result = ToolRunBashCommand.invoke(
-            ToolRunBashCommand.Input(
-                """
-                curl -X POST 'https://gigachat.devices.sberbank.ru/api/v1/files' \
-                     -H "Authorization: Bearer $accessToken" \
-                     -F "file=@${file.path};type=image/jpeg" \
-                     -F "purpose=general"
-                """.trimIndent(),
-            )
-        )
-        val body = result.lines().last()
-        return objectMapper.readValue(body)
-    }
-
-    private suspend fun loadAccessToken(): String {
-        return System.getProperty("GIGA_ACCESS_TOKEN") ?: refreshAccessToken()
-    }
-
-    private suspend fun refreshAccessToken(): String {
-        val apiKey = System.getenv("GIGA_KEY")
-        val newToken = auth.requestToken(apiKey, "GIGACHAT_API_PERS")
-        System.setProperty("GIGA_ACCESS_TOKEN", newToken)
-        return newToken
-    }
-
-    companion object {
-        val INSTANCE = GigaChatAPI(GigaAuth)
-    }
+interface GigaChatAPI {
+    suspend fun message(body: GigaRequest.Chat): GigaResponse.Chat
+    suspend fun uploadImage(file: File): GigaResponse.UploadFile
 }
 
-//suspend fun main() {
-//    val f = File("/Users/m1/Pictures/portrait.jpeg")
-//    val resp = GigaChatAPI(GigaAuth).uploadImage(f)
-//    LoggerFactory.getLogger("GigaChatAPI").info("$resp")
-//}

--- a/src/main/kotlin/giga/GigaGRPCChatApi.kt
+++ b/src/main/kotlin/giga/GigaGRPCChatApi.kt
@@ -5,18 +5,23 @@ import gigachat.v1.Gigachatv1
 import io.grpc.ManagedChannel
 import io.grpc.Metadata
 import io.grpc.Status
-import io.grpc.StatusRuntimeException
 import org.slf4j.LoggerFactory
 import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext
 import java.io.File
 import com.fasterxml.jackson.module.kotlin.readValue
+import io.grpc.StatusException
+import io.grpc.StatusRuntimeException
 
 /**
  * Simple gRPC client for GigaChat ChatService.
+ * @param gigaChatAPI GigaRestChatAPI to support other methods like image upload
  */
-class GigaGRPCChatApi(private val auth: GigaAuth) : GigaChatAPI {
+class GigaGRPCChatApi(
+    private val auth: GigaAuth,
+    private val gigaChatAPI: GigaRestChatAPI = GigaRestChatAPI.INSTANCE,
+) : GigaChatAPI by gigaChatAPI {
     private val l = LoggerFactory.getLogger(GigaGRPCChatApi::class.java)
 
     private val channel: ManagedChannel =
@@ -52,12 +57,14 @@ class GigaGRPCChatApi(private val auth: GigaAuth) : GigaChatAPI {
         val token = loadAccessToken()
         return try {
             stub.chat(request, authHeaders(token)).toGigaResponse()
-        } catch (e: StatusRuntimeException) {
-            if (e.status.code == Status.Code.UNAUTHENTICATED) {
-                val newToken = refreshAccessToken()
-                stub.chat(request, authHeaders(newToken)).toGigaResponse()
-            } else {
-                throw e
+        } catch (e: Exception) {
+            l.error("Error in gRPC chat", e)
+            suspend fun retryWithRefresh() =
+                stub.chat(request, authHeaders(refreshAccessToken())).toGigaResponse()
+            when {
+                e is StatusException && e.status.code == Status.Code.UNAUTHENTICATED -> retryWithRefresh()
+                e is StatusRuntimeException && e.status.code == Status.Code.UNAUTHENTICATED -> retryWithRefresh()
+                else -> throw e
             }
         }
     }

--- a/src/main/kotlin/giga/GigaGRPCChatApi.kt
+++ b/src/main/kotlin/giga/GigaGRPCChatApi.kt
@@ -16,8 +16,8 @@ import com.fasterxml.jackson.module.kotlin.readValue
 /**
  * Simple gRPC client for GigaChat ChatService.
  */
-class GRPCGigaChatAPI(private val auth: GigaAuth) {
-    private val l = LoggerFactory.getLogger(GRPCGigaChatAPI::class.java)
+class GigaGRPCChatApi(private val auth: GigaAuth) : GigaChatAPI {
+    private val l = LoggerFactory.getLogger(GigaGRPCChatApi::class.java)
 
     private val channel: ManagedChannel =
         NettyChannelBuilder.forAddress("gigachat.devices.sberbank.ru", 443)
@@ -27,7 +27,7 @@ class GRPCGigaChatAPI(private val auth: GigaAuth) {
     private val stub: ChatServiceGrpcKt.ChatServiceCoroutineStub =
         ChatServiceGrpcKt.ChatServiceCoroutineStub(channel)
 
-    suspend fun message(body: GigaRequest.Chat): GigaResponse.Chat {
+    override suspend fun message(body: GigaRequest.Chat): GigaResponse.Chat {
         val request = Gigachatv1.ChatRequest.newBuilder()
             .setModel(body.model)
             .setOptions(
@@ -145,8 +145,12 @@ class GRPCGigaChatAPI(private val auth: GigaAuth) {
         )
     }
 
+    override suspend fun uploadImage(file: File): GigaResponse.UploadFile {
+        throw UnsupportedOperationException("Image upload is not supported for gRPC API")
+    }
+
     companion object {
-        val INSTANCE = GRPCGigaChatAPI(GigaAuth)
+        val INSTANCE = GigaGRPCChatApi(GigaAuth)
     }
 
     private fun loadSslContext(): SslContext {
@@ -160,7 +164,7 @@ class GRPCGigaChatAPI(private val auth: GigaAuth) {
 }
 
 suspend fun main() {
-    val api = GRPCGigaChatAPI.INSTANCE
+    val api = GigaGRPCChatApi.INSTANCE
     val result: GigaResponse.Chat = api.message(GigaRequest.Chat(
         model = "GigaChat-Pro",
         messages = listOf(

--- a/src/main/kotlin/giga/GigaRestChatAPI.kt
+++ b/src/main/kotlin/giga/GigaRestChatAPI.kt
@@ -55,6 +55,7 @@ class GigaRestChatAPI(private val auth: GigaAuth) : GigaChatAPI {
         return try {
             uploadImageWithToken(file, loadAccessToken())
         } catch (e: Exception) {
+            l.error("Error in REST chat", e)
             uploadImageWithToken(file, refreshAccessToken())
         }
     }

--- a/src/main/kotlin/giga/GigaRestChatAPI.kt
+++ b/src/main/kotlin/giga/GigaRestChatAPI.kt
@@ -59,7 +59,7 @@ class GigaRestChatAPI(private val auth: GigaAuth) : GigaChatAPI {
         }
     }
 
-    private suspend fun uploadImageWithToken(file: File, accessToken: String): GigaResponse.UploadFile {
+    private fun uploadImageWithToken(file: File, accessToken: String): GigaResponse.UploadFile {
         val result = ToolRunBashCommand.invoke(
             ToolRunBashCommand.Input(
                 """

--- a/src/main/kotlin/giga/GigaRestChatAPI.kt
+++ b/src/main/kotlin/giga/GigaRestChatAPI.kt
@@ -1,0 +1,97 @@
+package com.dumch.giga
+
+import com.dumch.tool.ToolRunBashCommand
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.auth.Auth
+import io.ktor.client.plugins.auth.providers.BearerTokens
+import io.ktor.client.plugins.auth.providers.bearer
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logging
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.HttpHeaders
+import io.ktor.http.isSuccess
+import org.slf4j.LoggerFactory
+import java.io.File
+
+class GigaRestChatAPI(private val auth: GigaAuth) : GigaChatAPI {
+    private val l = LoggerFactory.getLogger(GigaRestChatAPI::class.java)
+
+    private val client = HttpClient(CIO) {
+        gigaDefaults()
+        install(Logging) {
+            val envLevel = System.getenv("GIGA_LOG_LEVEL")
+                ?.let { LogLevel.valueOf(it) } ?: LogLevel.INFO
+            l.info("GIGA_LOG_LEVEL: $envLevel")
+            level = envLevel
+            sanitizeHeader { it.equals(HttpHeaders.Authorization, true) }
+        }
+        install(Auth) {
+            bearer {
+                loadTokens {
+                    BearerTokens(loadAccessToken(), "")
+                }
+                refreshTokens {
+                    BearerTokens(refreshAccessToken(), "")
+                }
+            }
+        }
+    }
+
+    override suspend fun message(body: GigaRequest.Chat): GigaResponse.Chat {
+        val response = client.post("https://gigachat.devices.sberbank.ru/api/v1/chat/completions") {
+            setBody(body)
+        }
+        return when {
+            response.status.isSuccess() -> response.body<GigaResponse.Chat.Ok>()
+            else -> response.body<GigaResponse.Chat.Error>()
+        }
+    }
+
+    override suspend fun uploadImage(file: File): GigaResponse.UploadFile {
+        return try {
+            uploadImageWithToken(file, loadAccessToken())
+        } catch (e: Exception) {
+            uploadImageWithToken(file, refreshAccessToken())
+        }
+    }
+
+    private suspend fun uploadImageWithToken(file: File, accessToken: String): GigaResponse.UploadFile {
+        val result = ToolRunBashCommand.invoke(
+            ToolRunBashCommand.Input(
+                """
+                curl -X POST 'https://gigachat.devices.sberbank.ru/api/v1/files' \
+                     -H "Authorization: Bearer $accessToken" \
+                     -F "file=@${file.path};type=image/jpeg" \
+                     -F "purpose=general"
+                """.trimIndent(),
+            )
+        )
+        val body = result.lines().last()
+        return objectMapper.readValue(body)
+    }
+
+    private suspend fun loadAccessToken(): String {
+        return System.getProperty("GIGA_ACCESS_TOKEN") ?: refreshAccessToken()
+    }
+
+    private suspend fun refreshAccessToken(): String {
+        val apiKey = System.getenv("GIGA_KEY")
+        val newToken = auth.requestToken(apiKey, "GIGACHAT_API_PERS")
+        System.setProperty("GIGA_ACCESS_TOKEN", newToken)
+        return newToken
+    }
+
+    companion object {
+        val INSTANCE = GigaRestChatAPI(GigaAuth)
+    }
+}
+
+//suspend fun main() {
+//    val f = File("/Users/m1/Pictures/portrait.jpeg")
+//    val resp = GigaRestChatAPI(GigaAuth).uploadImage(f)
+//    LoggerFactory.getLogger("GigaRestChatAPI").info("$resp")
+//}

--- a/src/main/kotlin/tool/desktop/ToolDesktopScreenShot.kt
+++ b/src/main/kotlin/tool/desktop/ToolDesktopScreenShot.kt
@@ -1,6 +1,7 @@
 package com.dumch.tool.desktop
 
 import com.dumch.giga.GigaChatAPI
+import com.dumch.giga.GigaRestChatAPI
 import com.dumch.image.ImageUtils
 import com.dumch.tool.*
 import kotlinx.coroutines.runBlocking
@@ -8,7 +9,7 @@ import org.slf4j.LoggerFactory
 import java.io.File
 
 class ToolDesktopScreenShot(
-    private val api: GigaChatAPI = GigaChatAPI.INSTANCE,
+    private val api: GigaChatAPI = GigaRestChatAPI.INSTANCE,
 ) : ToolSetupWithAttachments<ToolDesktopScreenShot.Input> {
     private val l = LoggerFactory.getLogger(ToolDesktopScreenShot::class.java)
 

--- a/src/test/kotlin/giga/GigaGRPCChatApiTest.kt
+++ b/src/test/kotlin/giga/GigaGRPCChatApiTest.kt
@@ -1,6 +1,6 @@
 package giga
 
-import com.dumch.giga.GRPCGigaChatAPI
+import com.dumch.giga.GigaGRPCChatApi
 import com.dumch.giga.GigaAuth
 import com.dumch.giga.GigaMessageRole
 import com.dumch.giga.GigaRequest
@@ -17,7 +17,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
-class GRPCGigaChatAPITest {
+class GigaGRPCChatApiTest {
     private val authKey = Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER)
 
     private fun sampleResponse(): Gigachatv1.ChatResponse {
@@ -64,8 +64,8 @@ class GRPCGigaChatAPITest {
             response
         }
 
-        val api = GRPCGigaChatAPI(GigaAuth)
-        val field = GRPCGigaChatAPI::class.java.getDeclaredField("stub").apply { isAccessible = true }
+        val api = GigaGRPCChatApi(GigaAuth)
+        val field = GigaGRPCChatApi::class.java.getDeclaredField("stub").apply { isAccessible = true }
         field.set(api, stub)
 
         System.setProperty("GIGA_ACCESS_TOKEN", "token1")
@@ -94,8 +94,8 @@ class GRPCGigaChatAPITest {
             throw StatusRuntimeException(Status.UNAUTHENTICATED)
         }
 
-        val api = GRPCGigaChatAPI(GigaAuth)
-        val field = GRPCGigaChatAPI::class.java.getDeclaredField("stub").apply { isAccessible = true }
+        val api = GigaGRPCChatApi(GigaAuth)
+        val field = GigaGRPCChatApi::class.java.getDeclaredField("stub").apply { isAccessible = true }
         field.set(api, stub)
 
         System.setProperty("GIGA_ACCESS_TOKEN", "token1")
@@ -116,8 +116,8 @@ class GRPCGigaChatAPITest {
         val response = sampleResponse()
         coEvery { stub.chat(any(), capture(headers)) } returns response
 
-        val api = GRPCGigaChatAPI(GigaAuth)
-        val field = GRPCGigaChatAPI::class.java.getDeclaredField("stub").apply { isAccessible = true }
+        val api = GigaGRPCChatApi(GigaAuth)
+        val field = GigaGRPCChatApi::class.java.getDeclaredField("stub").apply { isAccessible = true }
         field.set(api, stub)
 
         System.setProperty("GIGA_ACCESS_TOKEN", "token1")


### PR DESCRIPTION
## Summary
- Extract GigaChatAPI interface for chat and image upload
- Rename previous REST client to GigaRestChatAPI and adapt for new interface
- Rename gRPC client to GigaGRPCChatApi with interface conformance
- Update agent, apps and tools to depend on the interface

## Testing
- `./gradlew test` *(fails: Inconsistent JVM Target Compatibility Between Java and Kotlin Tasks)*

------
https://chatgpt.com/codex/tasks/task_e_689bbaf5e4e88329b9063defd1d04506