### PR TITLE
Integrate native media controls

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ repositories {
 
 sourceSets {
     main {
-        resources.srcDir(setOf("src/main/resources"))
+        resources.srcDirs("src/main/resources", "src/main/libs")
     }
 }
 
@@ -46,6 +46,7 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform()
+    systemProperty("java.library.path", "src/main/libs")
 }
 
 tasks.withType<JavaExec> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,11 +46,6 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform()
-    systemProperty("java.library.path", "src/main/libs")
-}
-
-tasks.withType<JavaExec> {
-    systemProperty("java.library.path", "src/main/libs")
 }
 
 tasks.processResources {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,8 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform()
+    // Ensure native library is discoverable during tests
+    systemProperty("java.library.path", "${projectDir}/src/main/libs")
 }
 
 tasks.processResources {

--- a/src/main/kotlin/libs/MediaKeysNative.kt
+++ b/src/main/kotlin/libs/MediaKeysNative.kt
@@ -3,7 +3,7 @@ package com.dumch.libs
 class MediaKeysNative {
     companion object {
         init {
-            System.loadLibrary("src/main/libs/libMediaKeys.dylib")
+            System.loadLibrary("MediaKeys")
         }
     }
 

--- a/src/main/kotlin/libs/MediaKeysNative.kt
+++ b/src/main/kotlin/libs/MediaKeysNative.kt
@@ -29,18 +29,13 @@ class MediaKeysNative {
         }
     }
 
-    private external fun sendMediaKey(keyCode: Int)
+    private external fun playPauseNative()
+    private external fun nextTrackNative()
+    private external fun previousTrackNative()
 
-    // Константы для медиа-клавиш
-    object KeyCodes {
-        const val PLAY: Int = 16
-        const val NEXT: Int = 17
-        const val PREV: Int = 18
-    }
-
-    // Публичные методы
-    fun playPause() = sendMediaKey(KeyCodes.PLAY)
-    fun nextTrack() = sendMediaKey(KeyCodes.NEXT)
-    fun previousTrack() = sendMediaKey(KeyCodes.PREV)
+    // Публичные методы вызывают нативные функции
+    fun playPause() = playPauseNative()
+    fun nextTrack() = nextTrackNative()
+    fun previousTrack() = previousTrackNative()
 
 }

--- a/src/main/kotlin/libs/MediaKeysNative.kt
+++ b/src/main/kotlin/libs/MediaKeysNative.kt
@@ -3,7 +3,29 @@ package com.dumch.libs
 class MediaKeysNative {
     companion object {
         init {
-            System.loadLibrary("MediaKeys")
+            loadFromResources()
+        }
+
+        private fun loadFromResources() {
+            val libName = "libMediaKeys.dylib"
+            val url = MediaKeysNative::class.java.classLoader.getResource(libName)
+                ?: throw UnsatisfiedLinkError("Native library $libName not found")
+
+            if (url.protocol == "file") {
+                System.load(url.toURI().path)
+            } else {
+                val suffix = if (libName.contains('.')) libName.substring(libName.lastIndexOf('.')) else null
+                val temp = kotlin.io.path.createTempFile("MediaKeys", suffix ?: "")
+                url.openStream().use { input ->
+                    java.nio.file.Files.copy(
+                        input,
+                        temp,
+                        java.nio.file.StandardCopyOption.REPLACE_EXISTING
+                    )
+                }
+                temp.toFile().deleteOnExit()
+                System.load(temp.toAbsolutePath().toString())
+            }
         }
     }
 

--- a/src/main/kotlin/tool/desktop/ToolMediaControl.kt
+++ b/src/main/kotlin/tool/desktop/ToolMediaControl.kt
@@ -32,16 +32,15 @@ class ToolMediaControl(private val bash: ToolRunBashCommand) : ToolSetup<ToolMed
     val mediaKeys = MediaKeysNative()
 
     override fun invoke(input: Input): String {
-        val script = when (input.action) {
+        when (input.action) {
             Action.next -> mediaKeys.nextTrack()
-            Action.previous ->  mediaKeys.previousTrack()
-            Action.playpause ->  mediaKeys.playPause()
-            Action.volume_up -> "set volume output volume ((output volume of (get volume settings)) + 10)"
-            Action.volume_down -> "set volume output volume ((output volume of (get volume settings)) - 10)"
-            Action.brightness_down -> "tell application \"System Events\" to key code 145"
-            Action.brightness_up -> "tell application \"System Events\" to key code 144"
+            Action.previous -> mediaKeys.previousTrack()
+            Action.playpause -> mediaKeys.playPause()
+            Action.volume_up -> bash.apple("set volume output volume ((output volume of (get volume settings)) + 10)")
+            Action.volume_down -> bash.apple("set volume output volume ((output volume of (get volume settings)) - 10)")
+            Action.brightness_down -> bash.apple("tell application \"System Events\" to key code 145")
+            Action.brightness_up -> bash.apple("tell application \"System Events\" to key code 144")
         }
-        bash.apple(script)
         return "Done"
     }
 }

--- a/src/main/libs/MediaKeysJNI.c
+++ b/src/main/libs/MediaKeysJNI.c
@@ -1,14 +1,19 @@
 #include <jni.h>
-#include "MediaKeysNative.h"
-#include <stdint.h>
 
-// Объявление Swift-функции
-extern void sendMediaKey(uint32_t keyCode);
+// Declarations of Swift functions compiled into the library
+extern void playPause(void);
+extern void nextTrack(void);
+extern void previousTrack(void);
 
-JNIEXPORT void JNICALL Java_MediaKeysNative_sendMediaKey(
-    JNIEnv *env,
-    jobject obj,
-    jint keyCode) {
-
-    sendMediaKey((uint32_t)keyCode);
+JNIEXPORT void JNICALL Java_com_dumch_libs_MediaKeysNative_playPauseNative(JNIEnv *env, jobject obj) {
+    playPause();
 }
+
+JNIEXPORT void JNICALL Java_com_dumch_libs_MediaKeysNative_nextTrackNative(JNIEnv *env, jobject obj) {
+    nextTrack();
+}
+
+JNIEXPORT void JNICALL Java_com_dumch_libs_MediaKeysNative_previousTrackNative(JNIEnv *env, jobject obj) {
+    previousTrack();
+}
+


### PR DESCRIPTION
## Summary
- Move media key JNI wrapper into Kotlin sources and load `MediaKeys` native library
- Invoke media key functions from `ToolMediaControl`
- Include native library folder in resources and make tests aware of library path

## Testing
- `./gradlew test` *(fails: Could not resolve org.jetbrains.kotlin:kotlin-test:2.1.21. Received status code 403 from server)*

------
https://chatgpt.com/codex/tasks/task_e_689c7694b77c8329a13cc7d071ee5aec