### PR TITLE
Refactor JNI interface to single media key function

### DIFF
--- a/src/main/libs/BUILD.md
+++ b/src/main/libs/BUILD.md
@@ -1,0 +1,12 @@
+# Building libMediaKeys.dylib
+
+Rebuild the JNI library on macOS with the Xcode toolchain:
+
+```bash
+swiftc -emit-library -target x86_64-apple-macosx13.0 \
+  ../swift/MediaKeys.swift MediaKeysJNI.c \
+  -o libMediaKeys.dylib
+```
+
+This compiles the Swift media key handler and the JNI bridge into
+`libMediaKeys.dylib`.

--- a/src/main/libs/MediaKeysJNI.c
+++ b/src/main/libs/MediaKeysJNI.c
@@ -1,19 +1,11 @@
 #include <jni.h>
+#include <stdint.h>
 
-// Declarations of Swift functions compiled into the library
-extern void playPause(void);
-extern void nextTrack(void);
-extern void previousTrack(void);
+extern void sendMediaKeyEvent(uint32_t keyCode);
 
-JNIEXPORT void JNICALL Java_com_dumch_libs_MediaKeysNative_playPauseNative(JNIEnv *env, jobject obj) {
-    playPause();
-}
-
-JNIEXPORT void JNICALL Java_com_dumch_libs_MediaKeysNative_nextTrackNative(JNIEnv *env, jobject obj) {
-    nextTrack();
-}
-
-JNIEXPORT void JNICALL Java_com_dumch_libs_MediaKeysNative_previousTrackNative(JNIEnv *env, jobject obj) {
-    previousTrack();
+JNIEXPORT void JNICALL
+Java_com_dumch_libs_MediaKeysNative_sendMediaKeyEvent
+  (JNIEnv* env, jobject obj, jint keyCode) {
+    sendMediaKeyEvent((uint32_t)keyCode);
 }
 

--- a/src/main/swift/MediaKeys.swift
+++ b/src/main/swift/MediaKeys.swift
@@ -1,7 +1,10 @@
-import Cocoa
 import Foundation
 
-func sendMediaKeyEvent(keyCode: UInt32) {
+#if canImport(Cocoa)
+import Cocoa
+
+@_cdecl("sendMediaKeyEvent")
+public func sendMediaKeyEvent(_ keyCode: UInt32) {
     // Создаем системное событие
     let event = NSEvent.otherEvent(
         with: .systemDefined,
@@ -14,10 +17,10 @@ func sendMediaKeyEvent(keyCode: UInt32) {
         data1: Int((keyCode << 16) | (0xA << 8)),
         data2: -1
     )
-    
+
     // Отправляем событие
     event?.cgEvent?.post(tap: .cghidEventTap)
-    
+
     // Создаем событие отпускания клавиши
     let releaseEvent = NSEvent.otherEvent(
         with: .systemDefined,
@@ -32,13 +35,19 @@ func sendMediaKeyEvent(keyCode: UInt32) {
     )
     releaseEvent?.cgEvent?.post(tap: .cghidEventTap)
 }
+#else
+@_cdecl("sendMediaKeyEvent")
+public func sendMediaKeyEvent(_ keyCode: UInt32) {
+    // Stub for non-macOS platforms
+}
+#endif
 
 // Системные коды медиа-клавиш
 let NX_KEY_PLAY: UInt32 = 16
 let NX_KEY_NEXT: UInt32 = 17
 let NX_KEY_PREV: UInt32 = 18
 
-
 // Пример использования
-//sendMediaKeyEvent(keyCode: NX_KEY_PLAY) // Play/Pause
-//sendMediaKeyEvent(keyCode: NX_KEY_NEXT) // Next Track
+// sendMediaKeyEvent(NX_KEY_PLAY) // Play/Pause
+// sendMediaKeyEvent(NX_KEY_NEXT) // Next Track
+


### PR DESCRIPTION
## Summary
- consolidate JNI wrappers into `sendMediaKeyEvent`
- export `sendMediaKeyEvent` from Swift with a C symbol and stub for non-macOS
- document how to rebuild `libMediaKeys.dylib` instead of shipping a new binary

## Testing
- `./gradlew test` *(fails: Could not resolve org.jetbrains.kotlin:kotlin-test:2.1.21)*

------
https://chatgpt.com/codex/tasks/task_e_689cc748eb548329978bf5fa9c5a6860