### PR TITLE
Add Selenium tool for Safari interaction

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,6 +66,9 @@ dependencies {
     implementation("ws.schild:jave-core:3.5.0")
     implementation("ws.schild:jave-nativebin-osxm1:3.5.0")
 
+    // selenium
+    implementation("org.seleniumhq.selenium:selenium-java:${Versions.Selenium}")
+
     testImplementation(kotlin("test"))
     testImplementation("io.mockk:mockk:1.13.11")
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -6,4 +6,5 @@ object Versions {
     const val Grpc = "1.65.0"
     const val GrpcKotlin = "1.4.1"
     const val Protobuf = "3.25.3"
+    const val Selenium = "4.35.0"
 }

--- a/src/main/kotlin/tool/desktop/ToolSafariBrowserInterfaction.kt
+++ b/src/main/kotlin/tool/desktop/ToolSafariBrowserInterfaction.kt
@@ -1,0 +1,49 @@
+package com.dumch.tool.desktop
+
+import com.dumch.tool.*
+import org.openqa.selenium.WebDriver
+import org.openqa.selenium.safari.SafariDriver
+import org.openqa.selenium.safari.SafariOptions
+import org.slf4j.LoggerFactory
+
+/**
+ * Opens a given URL in Safari using Selenium WebDriver.
+ */
+class ToolSafariBrowserInterfaction : ToolSetup<ToolSafariBrowserInterfaction.Input> {
+    private val l = LoggerFactory.getLogger(ToolSafariBrowserInterfaction::class.java)
+
+    data class Input(
+        @InputParamDescription("The url to open, e.g., 'https://www.google.com'")
+        val url: String = "https://www.google.com"
+    )
+
+    override val name: String = "SafariBrowserInterfaction"
+    override val description: String = "Opens a web page in Safari via Selenium WebDriver"
+
+    override val fewShotExamples = listOf(
+        FewShotExample(
+            request = "Открой google.com в Safari",
+            params = mapOf("url" to "https://www.google.com")
+        )
+    )
+
+    override val returnParameters = ReturnParameters(
+        properties = mapOf(
+            "result" to ReturnProperty("string", "Operation status")
+        )
+    )
+
+    override fun invoke(input: Input): String {
+        return try {
+            val options = SafariOptions()
+            val driver: WebDriver = SafariDriver(options)
+            driver.get(input.url)
+            "Done"
+        } catch (e: Exception) {
+            "Error in ToolSafariBrowserInterfaction: ${e.message}".also {
+                l.error(it, e)
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Selenium version constant and dependency
- implement ToolSafariBrowserInterfaction to open URLs in Safari via WebDriver

## Testing
- `./gradlew test` *(fails: Inconsistent JVM target compatibility for compileJava 23 vs compileKotlin 21)*

------
https://chatgpt.com/codex/tasks/task_e_689dc371bc5c8329bed7c3c068374e93