### PR TITLE
Add tests for GigaAgent

### DIFF
--- a/src/main/kotlin/giga/GigaAgent.kt
+++ b/src/main/kotlin/giga/GigaAgent.kt
@@ -27,6 +27,7 @@ class GigaAgent(
     private val settings: Settings,
 ) {
     private val l = LoggerFactory.getLogger(GigaAgent::class.java)
+    private val tools: Map<String, GigaToolSetup> = settings.functions
     private val functions: List<GigaRequest.Function> = tools.map { it.value.fn }
 
     fun run(): Flow<String> = channelFlow {
@@ -219,30 +220,32 @@ class GigaAgent(
             """.trimIndent()
         )
 
-        private val tools: Map<String, GigaToolSetup> = listOf(
-            ToolReadFile.toGiga(),
-            ToolListFiles.toGiga(),
-            ToolNewFile.toGiga(),
-            ToolDeleteFile.toGiga(),
-            ToolModifyFile.toGiga(),
-            ToolWindowsManager.toGiga(),
-            ToolSafariInfo(ToolRunBashCommand).toGiga(),
-            ToolMouseClickMac().toGiga(),
-            ToolHotkeyMac().toGiga(),
-            ToolMediaControl(ToolRunBashCommand).toGiga(),
-            ToolFindTextInFiles.toGiga(),
-            ToolDesktopScreenShot().toGiga(),
-            ToolCreateNote(ToolRunBashCommand).toGiga(),
-            ToolOpenFolder(ToolRunBashCommand).toGiga(),
-            ToolCollectButtons(ToolRunBashCommand).toGiga(),
-            ToolOpen(ToolRunBashCommand).toGiga(),
-            ToolCreateNewBrowserTab(ToolRunBashCommand).toGiga(),
-            ToolMinimizeWindows(ToolRunBashCommand).toGiga(),
-        ).associateBy { it.fn.name }
+        private val defaultTools: Map<String, GigaToolSetup> by lazy {
+            listOf(
+                ToolReadFile.toGiga(),
+                ToolListFiles.toGiga(),
+                ToolNewFile.toGiga(),
+                ToolDeleteFile.toGiga(),
+                ToolModifyFile.toGiga(),
+                ToolWindowsManager.toGiga(),
+                ToolSafariInfo(ToolRunBashCommand).toGiga(),
+                ToolMouseClickMac().toGiga(),
+                ToolHotkeyMac().toGiga(),
+                ToolMediaControl(ToolRunBashCommand).toGiga(),
+                ToolFindTextInFiles.toGiga(),
+                ToolDesktopScreenShot().toGiga(),
+                ToolCreateNote(ToolRunBashCommand).toGiga(),
+                ToolOpenFolder(ToolRunBashCommand).toGiga(),
+                ToolCollectButtons(ToolRunBashCommand).toGiga(),
+                ToolOpen(ToolRunBashCommand).toGiga(),
+                ToolCreateNewBrowserTab(ToolRunBashCommand).toGiga(),
+                ToolMinimizeWindows(ToolRunBashCommand).toGiga(),
+            ).associateBy { it.fn.name }
+        }
 
         fun instance(userMessages: Flow<String>, api: GigaChatAPI): GigaAgent {
             val settings = Settings(
-                tools,
+                defaultTools,
                 GigaModel.Max,
                 stream = true,
             )

--- a/src/main/kotlin/giga/GigaAgent.kt
+++ b/src/main/kotlin/giga/GigaAgent.kt
@@ -1,24 +1,15 @@
 package com.dumch.giga
 
 import com.dumch.tool.ToolRunBashCommand
-import com.dumch.tool.desktop.ToolCollectButtons
-import com.dumch.tool.desktop.ToolCreateNote
-import com.dumch.tool.desktop.ToolDesktopScreenShot
-import com.dumch.tool.desktop.ToolMouseClickMac
-import com.dumch.tool.desktop.ToolOpen
-import com.dumch.tool.desktop.ToolCreateNewBrowserTab
-import com.dumch.tool.desktop.ToolHotkeyMac
-import com.dumch.tool.desktop.ToolMediaControl
-import com.dumch.tool.desktop.ToolMinimizeWindows
-import com.dumch.tool.desktop.ToolSafariInfo
-import com.dumch.tool.desktop.ToolShowApps
-import com.dumch.tool.desktop.ToolWindowsManager
+import com.dumch.tool.desktop.*
 import com.dumch.tool.files.*
-import kotlinx.coroutines.*
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.ProducerScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.takeWhile
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
 
 class GigaAgent(
@@ -27,7 +18,8 @@ class GigaAgent(
     private val settings: Settings,
 ) {
     private val l = LoggerFactory.getLogger(GigaAgent::class.java)
-    private val functions: List<GigaRequest.Function> = tools.map { it.value.fn }
+    private val tools: Map<String, GigaToolSetup> = settings.functions
+    private val functions: List<GigaRequest.Function> = settings.functions.map { it.value.fn }
     private val installedApps = ToolShowApps.invoke(ToolShowApps.Input(ToolShowApps.AppState.installed))
 
     fun run(): Flow<String> = channelFlow {
@@ -237,27 +229,29 @@ class GigaAgent(
             """.trimIndent()
         )
 
-        private val tools: Map<String, GigaToolSetup> = listOf(
-            ToolReadFile.toGiga(),
-            ToolListFiles.toGiga(),
-            ToolNewFile.toGiga(),
-            ToolDeleteFile.toGiga(),
-            ToolModifyFile.toGiga(),
-            ToolWindowsManager.toGiga(),
-            ToolSafariInfo(ToolRunBashCommand).toGiga(),
-            ToolMouseClickMac().toGiga(),
-            ToolHotkeyMac().toGiga(),
-            ToolMediaControl(ToolRunBashCommand).toGiga(),
-            ToolFindTextInFiles.toGiga(),
-            ToolDesktopScreenShot().toGiga(),
-            ToolCreateNote(ToolRunBashCommand).toGiga(),
-//            ToolShowApps.toGiga(),
-//            ToolOpenFolder(ToolRunBashCommand).toGiga(),
-            ToolCollectButtons(ToolRunBashCommand).toGiga(),
-            ToolOpen(ToolRunBashCommand).toGiga(),
-            ToolCreateNewBrowserTab(ToolRunBashCommand).toGiga(),
-            ToolMinimizeWindows(ToolRunBashCommand).toGiga(),
-        ).associateBy { it.fn.name }
+        private val tools: Map<String, GigaToolSetup> by lazy {
+            listOf(
+                ToolReadFile.toGiga(),
+                ToolListFiles.toGiga(),
+                ToolNewFile.toGiga(),
+                ToolDeleteFile.toGiga(),
+                ToolModifyFile.toGiga(),
+                ToolWindowsManager.toGiga(),
+                ToolSafariInfo(ToolRunBashCommand).toGiga(),
+                ToolMouseClickMac().toGiga(),
+                ToolHotkeyMac().toGiga(),
+                ToolMediaControl(ToolRunBashCommand).toGiga(),
+                ToolFindTextInFiles.toGiga(),
+                ToolDesktopScreenShot().toGiga(),
+                ToolCreateNote(ToolRunBashCommand).toGiga(),
+//                ToolShowApps.toGiga(),
+//                ToolOpenFolder(ToolRunBashCommand).toGiga(),
+                ToolCollectButtons(ToolRunBashCommand).toGiga(),
+                ToolOpen(ToolRunBashCommand).toGiga(),
+                ToolCreateNewBrowserTab(ToolRunBashCommand).toGiga(),
+                ToolMinimizeWindows(ToolRunBashCommand).toGiga(),
+            ).associateBy { it.fn.name }
+        }
 
         fun instance(
             userMessages: Flow<String>,

--- a/src/main/kotlin/giga/GigaGRPCChatApi.kt
+++ b/src/main/kotlin/giga/GigaGRPCChatApi.kt
@@ -191,7 +191,8 @@ class GigaGRPCChatApi(
     }
 
     private suspend fun refreshAccessToken(): String {
-        val apiKey = System.getenv("GIGA_KEY")
+        val apiKey = System.getenv("GIGA_KEY") ?: System.getProperty("GIGA_KEY")
+            ?: throw IllegalStateException("GIGA_KEY is not set")
         val newToken = auth.requestToken(apiKey, "GIGACHAT_API_PERS")
         System.setProperty("GIGA_ACCESS_TOKEN", newToken)
         return newToken

--- a/src/main/kotlin/giga/GigaRestChatAPI.kt
+++ b/src/main/kotlin/giga/GigaRestChatAPI.kt
@@ -186,7 +186,8 @@ class GigaRestChatAPI(private val auth: GigaAuth) : GigaChatAPI {
     }
 
     private suspend fun refreshAccessToken(): String {
-        val apiKey = System.getenv("GIGA_KEY")
+        val apiKey = System.getenv("GIGA_KEY") ?: System.getProperty("GIGA_KEY")
+            ?: throw IllegalStateException("GIGA_KEY is not set")
         val newToken = auth.requestToken(apiKey, "GIGACHAT_API_PERS")
         System.setProperty("GIGA_ACCESS_TOKEN", newToken)
         return newToken

--- a/src/test/kotlin/giga/GigaAgentTest.kt
+++ b/src/test/kotlin/giga/GigaAgentTest.kt
@@ -1,0 +1,148 @@
+package giga
+
+import com.dumch.giga.*
+import io.mockk.*
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class GigaAgentTest {
+    @Test
+    fun `singleResponse emits assistant reply`() = runBlocking {
+        val api = mockk<GigaChatAPI>()
+        val usage = GigaResponse.Usage(1, 1, 2, 0)
+        val msg = GigaResponse.Message(
+            content = "hello",
+            role = GigaMessageRole.assistant,
+            functionCall = null,
+            functionsStateId = null,
+        )
+        val response = GigaResponse.Chat.Ok(
+            choices = listOf(GigaResponse.Choice(msg, 0, GigaResponse.FinishReason.stop)),
+            created = 0L,
+            model = "m",
+            usage = usage,
+        )
+        coEvery { api.message(any()) } returns response
+
+        val agent = GigaAgent(
+            userMessages = flowOf("hi"),
+            api = api,
+            settings = GigaAgent.Settings(functions = emptyMap(), model = GigaModel.Pro, stream = false),
+        )
+        val results = agent.run().toList()
+
+        assertEquals(listOf("hello"), results)
+        coVerify(exactly = 1) { api.message(any()) }
+    }
+
+    @Test
+    fun `executes tool and sends result back to api`() = runBlocking {
+        val api = mockk<GigaChatAPI>()
+        val usage = GigaResponse.Usage(1, 1, 2, 0)
+
+        val fnCallMsg = GigaResponse.Message(
+            content = "",
+            role = GigaMessageRole.assistant,
+            functionCall = GigaResponse.FunctionCall(
+                name = "ListFiles",
+                arguments = mapOf("path" to "src/test/resources"),
+            ),
+            functionsStateId = "1",
+        )
+        val fnResponse = GigaResponse.Chat.Ok(
+            choices = listOf(GigaResponse.Choice(fnCallMsg, 0, GigaResponse.FinishReason.function_call)),
+            created = 0L,
+            model = "m",
+            usage = usage,
+        )
+        val finalMsg = GigaResponse.Message(
+            content = "done",
+            role = GigaMessageRole.assistant,
+            functionCall = null,
+            functionsStateId = null,
+        )
+        val finalResponse = GigaResponse.Chat.Ok(
+            choices = listOf(GigaResponse.Choice(finalMsg, 0, GigaResponse.FinishReason.stop)),
+            created = 0L,
+            model = "m",
+            usage = usage,
+        )
+
+        val bodies = mutableListOf<GigaRequest.Chat>()
+        coEvery { api.message(capture(bodies)) } returnsMany listOf(fnResponse, finalResponse)
+
+        val agent = GigaAgent(
+            userMessages = flowOf("list"),
+            api = api,
+            settings = GigaAgent.Settings(
+                functions = mapOf("ListFiles" to dummyTool("ListFiles")),
+                model = GigaModel.Pro,
+                stream = false,
+            ),
+        )
+        val outputs = agent.run().toList().also {
+            coVerify(exactly = 2) { api.message(any()) }
+        }
+
+        assertEquals(listOf("done"), outputs)
+        val fnResult = bodies[1].messages[bodies[1].messages.size - 2]
+        assertEquals(GigaMessageRole.function, fnResult.role)
+        assertEquals("{}", fnResult.content)
+    }
+
+    @Test
+    fun `stream mode uses messageStream`() = runBlocking {
+        val api = mockk<GigaChatAPI>()
+        val usage = GigaResponse.Usage(1, 1, 2, 0)
+        val msg = GigaResponse.Message(
+            content = "streamed",
+            role = GigaMessageRole.assistant,
+            functionCall = null,
+            functionsStateId = null,
+        )
+        val response = GigaResponse.Chat.Ok(
+            choices = listOf(GigaResponse.Choice(msg, 0, GigaResponse.FinishReason.stop)),
+            created = 0L,
+            model = "m",
+            usage = usage,
+        )
+        coEvery { api.messageStream(any()) } returns flowOf(response)
+
+        val agent = GigaAgent(
+            userMessages = flowOf("hi"),
+            api = api,
+            settings = GigaAgent.Settings(functions = emptyMap(), model = GigaModel.Pro, stream = true),
+        )
+        val results = agent.run().toList()
+
+        assertEquals(listOf("streamed"), results)
+        coVerify(exactly = 1) { api.messageStream(any()) }
+        coVerify(exactly = 0) { api.message(any()) }
+    }
+
+    private fun dummyTool(name: String): GigaToolSetup = object : GigaToolSetup {
+        override val fn: GigaRequest.Function = GigaRequest.Function(
+            name = name,
+            description = "",
+            parameters = GigaRequest.Parameters(
+                type = "object",
+                properties = emptyMap(),
+            ),
+            returnParameters = GigaRequest.Parameters(
+                type = "object",
+                properties = emptyMap(),
+            )
+        )
+
+        override suspend fun invoke(functionCall: GigaResponse.FunctionCall): GigaRequest.Message {
+            return GigaRequest.Message(
+                role = GigaMessageRole.function,
+                content = "{}",
+            )
+        }
+    }
+}
+

--- a/src/test/kotlin/giga/GigaGRPCChatApiTest.kt
+++ b/src/test/kotlin/giga/GigaGRPCChatApiTest.kt
@@ -50,6 +50,7 @@ class GigaGRPCChatApiTest {
     fun tearDown() {
         unmockkAll()
         System.clearProperty("GIGA_ACCESS_TOKEN")
+        System.clearProperty("GIGA_KEY")
     }
 
     @Test
@@ -67,11 +68,11 @@ class GigaGRPCChatApiTest {
             response
         }
 
-        val api = GigaGRPCChatApi(GigaAuth)
+        System.setProperty("GIGA_ACCESS_TOKEN", "token1")
+        System.setProperty("GIGA_KEY", "key")
+        val api = GigaGRPCChatApi(GigaAuth, mockk())
         val field = GigaGRPCChatApi::class.java.getDeclaredField("stub").apply { isAccessible = true }
         field.set(api, stub)
-
-        System.setProperty("GIGA_ACCESS_TOKEN", "token1")
         val body = GigaRequest.Chat(
             model = "GigaChat-Pro",
             messages = listOf(GigaRequest.Message(GigaMessageRole.user, "hi"))
@@ -93,11 +94,11 @@ class GigaGRPCChatApiTest {
         val stub = mockk<ChatServiceGrpcKt.ChatServiceCoroutineStub>()
         coEvery { stub.chat(any(), any()) } throws StatusRuntimeException(Status.UNAUTHENTICATED)
 
-        val api = GigaGRPCChatApi(GigaAuth)
+        System.setProperty("GIGA_ACCESS_TOKEN", "token1")
+        System.setProperty("GIGA_KEY", "key")
+        val api = GigaGRPCChatApi(GigaAuth, mockk())
         val field = GigaGRPCChatApi::class.java.getDeclaredField("stub").apply { isAccessible = true }
         field.set(api, stub)
-
-        System.setProperty("GIGA_ACCESS_TOKEN", "token1")
         val body = GigaRequest.Chat(
             model = "GigaChat-Pro",
             messages = listOf(GigaRequest.Message(GigaMessageRole.user, "hi"))
@@ -115,11 +116,11 @@ class GigaGRPCChatApiTest {
         val response = sampleResponse()
         coEvery { stub.chat(any(), capture(headers)) } returns response
 
-        val api = GigaGRPCChatApi(GigaAuth)
+        System.setProperty("GIGA_ACCESS_TOKEN", "token1")
+        System.setProperty("GIGA_KEY", "key")
+        val api = GigaGRPCChatApi(GigaAuth, mockk())
         val field = GigaGRPCChatApi::class.java.getDeclaredField("stub").apply { isAccessible = true }
         field.set(api, stub)
-
-        System.setProperty("GIGA_ACCESS_TOKEN", "token1")
         val body = GigaRequest.Chat(
             model = "GigaChat-Pro",
             messages = listOf(GigaRequest.Message(GigaMessageRole.user, "hi"))
@@ -154,11 +155,11 @@ class GigaGRPCChatApiTest {
             }
         }
 
-        val api = GigaGRPCChatApi(GigaAuth)
+        System.setProperty("GIGA_ACCESS_TOKEN", "token1")
+        System.setProperty("GIGA_KEY", "key")
+        val api = GigaGRPCChatApi(GigaAuth, mockk())
         val field = GigaGRPCChatApi::class.java.getDeclaredField("stub").apply { isAccessible = true }
         field.set(api, stub)
-
-        System.setProperty("GIGA_ACCESS_TOKEN", "token1")
         val body = GigaRequest.Chat(
             model = "GigaChat-Pro",
             stream = true,
@@ -180,11 +181,10 @@ class GigaGRPCChatApiTest {
         val stub = mockk<ChatServiceGrpcKt.ChatServiceCoroutineStub>()
         every { stub.chatStream(any(), any()) } returns flow { throw StatusRuntimeException(Status.INTERNAL) }
 
+        System.setProperty("GIGA_ACCESS_TOKEN", "token1")
         val api = GigaGRPCChatApi(GigaAuth)
         val field = GigaGRPCChatApi::class.java.getDeclaredField("stub").apply { isAccessible = true }
         field.set(api, stub)
-
-        System.setProperty("GIGA_ACCESS_TOKEN", "token1")
         val body = GigaRequest.Chat(
             model = "GigaChat-Pro",
             stream = true,


### PR DESCRIPTION
## Summary
- refactor GigaAgent to accept tool map and lazily build default tools
- allow token refresh to read `GIGA_KEY` from system properties
- add focused unit tests for GigaAgent and update GRPC API tests

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_689edf496dd88329b03ab3bd666305d4