### PR TITLE
Persist all Giga API logs to files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+# Logs
+*.log
+
 ### IntelliJ IDEA ###
 .idea/
 *.iws

--- a/src/main/kotlin/giga/GigaGRPCChatApi.kt
+++ b/src/main/kotlin/giga/GigaGRPCChatApi.kt
@@ -10,7 +10,6 @@ import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext
 import ch.qos.logback.classic.Level
-import ch.qos.logback.classic.Logger
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
@@ -29,18 +28,15 @@ class GigaGRPCChatApi(
     private val l = LoggerFactory.getLogger(GigaGRPCChatApi::class.java)
 
     init {
-        val envLevel = System.getenv("GIGA_GRPC_LOG_LEVEL")
-            ?: System.getenv("GIGA_LOG_LEVEL")
-        val nettyLevel = envLevel
-            ?.let {
-                val normalized = if (it.equals("NONE", ignoreCase = true)) "OFF" else it
-                runCatching { Level.valueOf(normalized) }.getOrNull()
-            }
-            ?: Level.WARN
-        l.info("GIGA_GRPC_LOG_LEVEL: $nettyLevel")
-        (LoggerFactory.getLogger("io.grpc") as? Logger)?.level = nettyLevel
-        (LoggerFactory.getLogger("io.grpc.netty.shaded") as? Logger)?.level = nettyLevel
-        (LoggerFactory.getLogger("io.netty") as? Logger)?.level = nettyLevel
+        runCatching {
+            val level = LogFileConfigurer.configure(
+                logFile = "gigagrpc.log",
+                envVars = listOf("GIGA_GRPC_LOG_LEVEL", "GIGA_LOG_LEVEL"),
+                defaultLevel = Level.WARN,
+                treatNoneAsOff = true,
+            )
+            l.info("GIGA_GRPC_LOG_LEVEL: $level")
+        }.onFailure { e -> l.warn("Failed to configure logging", e) }
     }
 
     private val channel: ManagedChannel =

--- a/src/main/kotlin/giga/GigaRestChatAPI.kt
+++ b/src/main/kotlin/giga/GigaRestChatAPI.kt
@@ -18,17 +18,26 @@ import kotlinx.coroutines.flow.flow
 import org.slf4j.LoggerFactory
 import java.io.File
 import kotlin.time.Duration.Companion.seconds
+import ch.qos.logback.classic.Level
 
 class GigaRestChatAPI(private val auth: GigaAuth) : GigaChatAPI {
     private val l = LoggerFactory.getLogger(GigaRestChatAPI::class.java)
 
+    init {
+        runCatching {
+            val level = LogFileConfigurer.configure(
+                logFile = "gigarest.log",
+                envVars = listOf("GIGA_LOG_LEVEL"),
+                defaultLevel = Level.INFO,
+            )
+            l.info("GIGA_LOG_LEVEL: $level")
+        }.onFailure { e -> l.warn("Failed to configure logging", e) }
+    }
+
     private val client = HttpClient(CIO) {
         gigaDefaults()
         install(Logging) {
-            val envLevel = System.getenv("GIGA_LOG_LEVEL")
-                ?.let { LogLevel.valueOf(it) } ?: LogLevel.INFO
-            l.info("GIGA_LOG_LEVEL: $envLevel")
-            level = envLevel
+            level = LogLevel.ALL
             sanitizeHeader { it.equals(HttpHeaders.Authorization, true) }
         }
         install(Auth) {

--- a/src/main/kotlin/giga/LogFileConfigurer.kt
+++ b/src/main/kotlin/giga/LogFileConfigurer.kt
@@ -1,0 +1,64 @@
+package com.dumch.giga
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.FileAppender
+import ch.qos.logback.core.ConsoleAppender
+import ch.qos.logback.classic.filter.ThresholdFilter
+import org.slf4j.LoggerFactory
+
+object LogFileConfigurer {
+    fun configure(
+        logFile: String,
+        envVars: List<String>,
+        defaultLevel: Level = Level.INFO,
+        treatNoneAsOff: Boolean = false,
+    ): Level {
+        val rawLevel = envVars.asSequence()
+            .mapNotNull { System.getenv(it) }
+            .firstOrNull()
+        val consoleLevel = rawLevel
+            ?.let {
+                val normalized = if (treatNoneAsOff && it.equals("NONE", true)) "OFF" else it
+                runCatching { Level.valueOf(normalized) }.getOrNull()
+            }
+            ?: defaultLevel
+
+        val root = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME) as? Logger ?: return consoleLevel
+        root.level = Level.ALL
+
+        root.iteratorForAppenders().asSequence()
+            .filterIsInstance<ConsoleAppender<ILoggingEvent>>()
+            .forEach { appender ->
+                appender.clearAllFilters()
+                val filter = ThresholdFilter().apply {
+                    setLevel(consoleLevel.levelStr)
+                    start()
+                }
+                appender.addFilter(filter)
+            }
+
+        if (root.getAppender("FILE_$logFile") == null) {
+            val context = root.loggerContext
+            val encoder = PatternLayoutEncoder().apply {
+                this.context = context
+                pattern = "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"
+                start()
+            }
+            val appender = FileAppender<ILoggingEvent>().apply {
+                this.context = context
+                name = "FILE_$logFile"
+                file = logFile
+                isAppend = true
+                this.encoder = encoder
+                start()
+            }
+            root.addAppender(appender)
+        }
+
+        return consoleLevel
+    }
+}
+


### PR DESCRIPTION
## Summary
- Centralize log file setup in `LogFileConfigurer` so file logs capture all levels while console output obeys environment variables
- Apply shared logging helper to gRPC and REST clients for `gigagrpc.log` and `gigarest.log`

## Testing
- `./gradlew test` *(fails: NullPointerException in GigaGRPCChatApiTest; assertion failures in GigaToolTest and ToolTest)*

------
https://chatgpt.com/codex/tasks/task_e_689f0da4a4d48329ad14e4c95511f2f8