### PR TITLE
Add structured logging for chat APIs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,8 @@ dependencies {
     implementation(kotlin("reflect"))
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.Coroutines}")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.17.0")
-    implementation("ch.qos.logback:logback-classic:${Versions.Logback}")
+      implementation("ch.qos.logback:logback-classic:${Versions.Logback}")
+      implementation("org.slf4j:jul-to-slf4j:2.0.17")
 
     // ktor
     implementation("io.ktor:ktor-client-core:${Versions.Ktor}")

--- a/src/main/kotlin/giga/GigaGRPCChatApi.kt
+++ b/src/main/kotlin/giga/GigaGRPCChatApi.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import org.slf4j.LoggerFactory
+import org.slf4j.bridge.SLF4JBridgeHandler
 import java.io.File
 
 /**
@@ -29,6 +30,12 @@ class GigaGRPCChatApi(
     private val l = LoggerFactory.getLogger(GigaGRPCChatApi::class.java)
 
     init {
+        // Bridge JUL (used by gRPC) to SLF4J so logback handles all logs
+        if (!SLF4JBridgeHandler.isInstalled()) {
+            SLF4JBridgeHandler.removeHandlersForRootLogger()
+            SLF4JBridgeHandler.install()
+        }
+
         val envLevel = System.getenv("GIGA_GRPC_LOG_LEVEL")
             ?: System.getenv("GIGA_LOG_LEVEL")
         val nettyLevel = envLevel

--- a/src/main/kotlin/giga/GigaRestChatAPI.kt
+++ b/src/main/kotlin/giga/GigaRestChatAPI.kt
@@ -27,7 +27,12 @@ class GigaRestChatAPI(private val auth: GigaAuth) : GigaChatAPI {
         install(Logging) {
             val envLevel = System.getenv("GIGA_LOG_LEVEL")
                 ?.let { LogLevel.valueOf(it) } ?: LogLevel.INFO
-            l.info("GIGA_LOG_LEVEL: $envLevel")
+            this@GigaRestChatAPI.l.info("GIGA_LOG_LEVEL: $envLevel")
+            logger = object : Logger {
+                override fun log(message: String) {
+                    this@GigaRestChatAPI.l.debug(message)
+                }
+            }
             level = envLevel
             sanitizeHeader { it.equals(HttpHeaders.Authorization, true) }
         }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -4,10 +4,10 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n</pattern>
         </encoder>
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>WARN</level>
+            <level>INFO</level>
         </filter>
     </appender>
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,15 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+    <property name="LOG_DIR" value="out/logs"/>
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%logger{0}: %msg%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
         </encoder>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>WARN</level>
+        </filter>
+    </appender>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_DIR}/giga.log</file>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_DIR}/giga.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
     </appender>
 
     <!-- Mute verbose ffmpeg output parsed by JAVE -->
     <logger name="ws.schild.jave" level="OFF" additivity="false"/>
 
-    <root level="debug">
+    <root level="ALL">
         <appender-ref ref="STDOUT"/>
+        <appender-ref ref="FILE"/>
     </root>
 </configuration>


### PR DESCRIPTION
## Summary
- log warn/error to console and send all logs to rolling file in `out/logs`
- bridge gRPC JUL logs to logback and use SLF4J loggers in APIs
- route Ktor client logs through SLF4J
- rename logger variables to `l` for consistency

## Testing
- `./gradlew test` *(fails: IndexOutOfBoundsException, assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_689f1bdb118c8329afb6598100118619