### PR TITLE
Refactor sound settings to generic ConfigStore

### DIFF
--- a/src/main/kotlin/audio/AudioPlay.kt
+++ b/src/main/kotlin/audio/AudioPlay.kt
@@ -3,10 +3,14 @@ package com.dumch.audio
 import java.io.File
 import javax.sound.sampled.AudioSystem
 import javax.sound.sampled.LineEvent
+import com.dumch.tool.config.ConfigStore
+
+private const val SPEED_KEY = "sound_speed"
+private const val DEFAULT_SPEED = 230
 
 private var sayProcess: Process? = null
 
-fun playText(text: String, speed: Int = 230) {
+fun playText(text: String, speed: Int = ConfigStore.get(SPEED_KEY, DEFAULT_SPEED)) {
     stopPlayText()
     val saveEnding = "$text "
     sayProcess = ProcessBuilder("say", "-r", "$speed", saveEnding).start()
@@ -20,7 +24,7 @@ fun stopPlayText() {
 
 private val random = java.util.Random()
 
-fun playTextRand(speed: Int = 230, vararg texts: String) {
+fun playTextRand(speed: Int = ConfigStore.get(SPEED_KEY, DEFAULT_SPEED), vararg texts: String) {
     val text = texts[random.nextInt(texts.size)]
     playText(text, speed)
 }

--- a/src/main/kotlin/tool/config/ConfigStore.kt
+++ b/src/main/kotlin/tool/config/ConfigStore.kt
@@ -1,20 +1,18 @@
 package com.dumch.tool.config
 
+import com.dumch.giga.objectMapper
 import java.util.prefs.Preferences
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 
 object ConfigStore {
-    @PublishedApi
+    @PublishedApi // to use prefs inside the reified (inlined) `get`
     internal val prefs: Preferences = Preferences.userNodeForPackage(ConfigStore::class.java)
-    @PublishedApi
-    internal val mapper = jacksonObjectMapper()
 
     fun put(key: String, value: Any) {
         val str = when (value) {
             is String -> value
             is Int, is Long, is Float, is Double, is Boolean -> value.toString()
-            else -> mapper.writeValueAsString(value)
+            else -> objectMapper.writeValueAsString(value)
         }
         prefs.put(key, str)
     }
@@ -32,7 +30,7 @@ object ConfigStore {
                 Double::class -> str.toDouble()
                 Boolean::class -> str.toBooleanStrict()
                 String::class -> str
-                else -> mapper.readValue<T>(str)
+                else -> objectMapper.readValue<T>(str)
             } as T
         }.getOrNull()
     }

--- a/src/main/kotlin/tool/config/ConfigStore.kt
+++ b/src/main/kotlin/tool/config/ConfigStore.kt
@@ -1,0 +1,39 @@
+package com.dumch.tool.config
+
+import java.util.prefs.Preferences
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+
+object ConfigStore {
+    @PublishedApi
+    internal val prefs: Preferences = Preferences.userNodeForPackage(ConfigStore::class.java)
+    @PublishedApi
+    internal val mapper = jacksonObjectMapper()
+
+    fun put(key: String, value: Any) {
+        val str = when (value) {
+            is String -> value
+            is Int, is Long, is Float, is Double, is Boolean -> value.toString()
+            else -> mapper.writeValueAsString(value)
+        }
+        prefs.put(key, str)
+    }
+
+    inline fun <reified T : Any> get(key: String, default: T): T =
+        get<T>(key) ?: default
+
+    inline fun <reified T : Any> get(key: String): T? {
+        val str = prefs.get(key, null) ?: return null
+        return runCatching {
+            when (T::class) {
+                Int::class -> str.toInt()
+                Long::class -> str.toLong()
+                Float::class -> str.toFloat()
+                Double::class -> str.toDouble()
+                Boolean::class -> str.toBooleanStrict()
+                String::class -> str
+                else -> mapper.readValue<T>(str)
+            } as T
+        }.getOrNull()
+    }
+}

--- a/src/main/kotlin/tool/config/ToolSoundConfig.kt
+++ b/src/main/kotlin/tool/config/ToolSoundConfig.kt
@@ -1,0 +1,33 @@
+package com.dumch.tool.config
+
+import com.dumch.tool.*
+
+private const val SPEED_KEY = "sound_speed"
+
+object ToolSoundConfig : ToolSetup<ToolSoundConfig.Input> {
+    override val name: String = "SoundConfig"
+    override val description: String = "Updates sound configuration such as speed"
+
+    override val fewShotExamples = listOf(
+        FewShotExample(
+            request = "Set sound speed to 180",
+            params = mapOf("speed" to 180)
+        )
+    )
+
+    override val returnParameters = ReturnParameters(
+        properties = mapOf(
+            "result" to ReturnProperty("string", "Confirmation message")
+        )
+    )
+
+    override fun invoke(input: Input): String {
+        ConfigStore.put(SPEED_KEY, input.speed)
+        return "Sound speed updated to ${input.speed}"
+    }
+
+    data class Input(
+        @InputParamDescription("Desired speed for speech synthesis")
+        val speed: Int
+    )
+}

--- a/src/main/kotlin/tool/config/ToolSoundConfig.kt
+++ b/src/main/kotlin/tool/config/ToolSoundConfig.kt
@@ -10,14 +10,14 @@ object ToolSoundConfig : ToolSetup<ToolSoundConfig.Input> {
 
     override val fewShotExamples = listOf(
         FewShotExample(
-            request = "Set sound speed to 180",
+            request = "Установи скорость речи на 180 символов в секунду",
             params = mapOf("speed" to 180)
-        )
+        ),
     )
 
     override val returnParameters = ReturnParameters(
         properties = mapOf(
-            "result" to ReturnProperty("string", "Confirmation message")
+            "result" to ReturnProperty("string", "Confirmation message or error")
         )
     )
 

--- a/src/main/kotlin/tool/configs/ToolsFromConfig.kt
+++ b/src/main/kotlin/tool/configs/ToolsFromConfig.kt
@@ -1,0 +1,38 @@
+package com.dumch.tool.configs
+
+import com.dumch.tool.*
+
+class ToolsFromConfig {
+    fun getTools(): List<ToolSetup<SimpleTextInput>> {
+        val t = object : ToolSetup<SimpleTextInput> {
+            override val name: String = "CreateNote"
+            override val description: String = "Opens Notes and create new note with text"
+            override val fewShotExamples = listOf(
+                FewShotExample(
+                    request = "Создай заметку, чтобы купить молоко в субботу",
+                    params = mapOf("noteText" to "Купить молоко в субботу")
+                )
+            )
+            override val returnParameters = ReturnParameters(
+                properties = mapOf(
+                    "result" to ReturnProperty("string", "Operation status")
+                )
+            )
+
+            override fun invoke(input: SimpleTextInput): String {
+                TODO()
+            }
+        }
+        return listOf(t)
+    }
+
+    data class SimpleTextInput(
+        @InputParamDescription("Text of note")
+        val text: String
+    )
+
+    data class ToolConfigSetup(
+        val name: String,
+        val description: String,
+    )
+}


### PR DESCRIPTION
## Summary
- rename `tool/configs` to `tool/config`
- replace `SoundConfig` with `ConfigStore` backed by Preferences and jackson for typed values
- update audio playback and sound config tool to use the generic store

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_689f40ae914883298432eda2e2f908f6