### PR TITLE
Restart agent session on flow termination

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -61,9 +61,16 @@ suspend fun main() = coroutineScope {
                 resp.result.joinToString("\n")
             }
 
-        GigaAgent.instance(userInputFlow, GigaGRPCChatApi.INSTANCE).run().collect { text ->
-            l.info(text)
-            playText(text)
+        while (isActive) {
+            val agent = GigaAgent.instance(userInputFlow, GigaGRPCChatApi.INSTANCE)
+            runCatching {
+                agent.run().collect { text ->
+                    l.info(text)
+                    playText(text)
+                }
+            }.onFailure { e ->
+                l.error("Agent flow terminated: ${e.message}", e)
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- restart the voice agent when its flow completes or fails to keep session alive
- drop redundant coroutine scope and file sorting per review feedback

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_689f4960911083298e38190f94ac0e0d