### PR TITLE
feat: handle downloaded files

### DIFF
--- a/src/main/kotlin/giga/GigaRestChatAPI.kt
+++ b/src/main/kotlin/giga/GigaRestChatAPI.kt
@@ -198,22 +198,20 @@ class GigaRestChatAPI(private val auth: GigaAuth) : GigaChatAPI {
     private fun downloadFileWithToken(
         fileId: String,
         accessToken: String,
-        outputFileName: String = "downloaded_file"
     ): String? {
-        val downloadsDir = File(System.getProperty("user.home"), "Downloads").apply { mkdirs() }
-        val outputFile = File(downloadsDir, outputFileName)
-        val result = ToolRunBashCommand.invoke(
-            ToolRunBashCommand.Input(
-                """
-                curl -L -g 'https://gigachat.devices.sberbank.ru/api/v1/files/${fileId}/content' \
-                -H 'Accept: application/octet-stream' \
-                -H 'Authorization: Bearer $accessToken' \
-                -o $outputFileName
-                """.trimIndent(),
-            )
+        val documentsDir = File(System.getProperty("user.home"), "SluxxDocuments").apply { mkdirs() }
+        val command = """
+            cd ${'$'}{documentsDir.absolutePath} && \
+            curl -s -L -g 'https://gigachat.devices.sberbank.ru/api/v1/files/${'$'}{fileId}/content' \
+            -H 'Accept: application/octet-stream' \
+            -H 'Authorization: Bearer ${'$'}accessToken' \
+            -OJ -w '%{filename_effective}' -o /dev/null
+        """.trimIndent()
+        val fileName = ToolRunBashCommand.invoke(
+            ToolRunBashCommand.Input(command)
         )
 
-        return outputFile.absolutePath
+        return File(documentsDir, fileName).absolutePath
     }
 
     private suspend fun loadAccessToken(): String {

--- a/src/main/kotlin/tool/desktop/ToolFileSharing.kt
+++ b/src/main/kotlin/tool/desktop/ToolFileSharing.kt
@@ -11,6 +11,7 @@ import com.dumch.tool.ToolSetupWithAttachments
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
 import java.io.File
+import java.awt.Desktop
 
 class ToolFileSharing(
     private val api: GigaChatAPI = GigaRestChatAPI.INSTANCE,
@@ -57,11 +58,26 @@ class ToolFileSharing(
     override fun invoke(input: Input): String = runBlocking { suspendInvoke(input) }
 
     override suspend fun suspendInvoke(input: Input): String {
-        val file = File(input.filePath)
-
         return when (input.action) {
-            Action.upload -> api.uploadFile(file).id
-            Action.download -> api.downloadFile(input.fileId) ?: "File not found"
+            Action.upload -> {
+                val file = File(input.filePath)
+                api.uploadFile(file).id
+            }
+            Action.download -> {
+                val path = api.downloadFile(input.fileId)
+                if (path != null) {
+                    try {
+                        if (Desktop.isDesktopSupported()) {
+                            Desktop.getDesktop().open(File(path))
+                        }
+                    } catch (e: Exception) {
+                        l.error("Failed to open file", e)
+                    }
+                    path
+                } else {
+                    "File not found"
+                }
+            }
         }
     }
 

--- a/src/test/kotlin/giga/GigaToolTest.kt
+++ b/src/test/kotlin/giga/GigaToolTest.kt
@@ -38,12 +38,18 @@ class GigaToolTest {
         val l = LoggerFactory.getLogger(GigaToolTest::class.java)
         val result = toolsMap[functionCall.name]!!.invoke(functionCall)
         l.info("$result")
-        assertEquals(
-            GigaRequest.Message(
-                role = GigaMessageRole.function,
-                content = """{"result":"[src/test/resources/directory/,src/test/resources/directory/file.txt,src/test/resources/test.txt]"}""",
-            ),
-            result
-        )
+
+        // ensure function role
+        assertEquals(GigaMessageRole.function, result.role)
+
+        // compare returned paths ignoring order
+        val resultPaths = gigaJsonMapper.readTree(result.content)["result"].asText()
+            .removePrefix("[").removeSuffix("]").split(",").map { it.trim() }.sorted()
+        val expectedPaths = listOf(
+            "src/test/resources/directory/",
+            "src/test/resources/directory/file.txt",
+            "src/test/resources/test.txt",
+        ).sorted()
+        assertEquals(expectedPaths, resultPaths)
     }
 }


### PR DESCRIPTION
## Summary
- save GigaChat downloads to `$HOME/SluxxDocuments` using server filename
- automatically open files after downloading
- stabilize file listing test by ignoring order

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_689f5142843c83298d3084262c2e6757