### PR TITLE
Allow stopping streaming responses when recording is interrupted

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import org.slf4j.LoggerFactory
+import java.util.concurrent.atomic.AtomicReference
 
 private val l = LoggerFactory.getLogger("AI")
 
@@ -29,12 +30,14 @@ suspend fun main() = coroutineScope {
         recorder = ActiveSoundActiveSoundRecorder(),
         coroutineScope = appScope,
     )
+    val agentRef = AtomicReference<GigaAgent?>(null)
     val hotkeyListener = HotkeyListener(
         onPressed = { pressed ->
             l.info(if (pressed) "onStart" else "onStop")
             when {
                 pressed -> {
                     stopPlayText()
+                    agentRef.get()?.stop()
                     playMacPing()
                     audioRecorder.start()
                 }
@@ -47,7 +50,10 @@ suspend fun main() = coroutineScope {
                 }
             }
         },
-        onDoubleClick = ::stopPlayText
+        onDoubleClick = {
+            stopPlayText()
+            agentRef.get()?.stop()
+        }
     )
     launch { audioRecorder.logState() }
     val gigaVoiceAPI = GigaVoiceAPI(GigaAuth)
@@ -70,6 +76,7 @@ suspend fun main() = coroutineScope {
 
         while (isActive) {
             val agent = GigaAgent.instance(userInputFlow, GigaGRPCChatApi.INSTANCE, model = model)
+            agentRef.set(agent)
             runCatching {
                 agent.run().collect { text ->
                     l.info(text)

--- a/src/main/kotlin/giga/GigaAgent.kt
+++ b/src/main/kotlin/giga/GigaAgent.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
 import kotlin.collections.map
+import java.util.concurrent.atomic.AtomicBoolean
 
 class GigaAgent(
     private val userMessages: Flow<String>,
@@ -27,6 +28,7 @@ class GigaAgent(
     private val installedApps = runCatching {
         ToolShowApps.invoke(ToolShowApps.Input(ToolShowApps.AppState.installed))
     }.getOrElse { "[]" }
+    private val stopRequested = AtomicBoolean(false)
 
     fun run(): Flow<String> = channelFlow {
         val conversation = ArrayDeque<GigaRequest.Message>().apply {
@@ -70,12 +72,13 @@ class GigaAgent(
     }
 
     private suspend fun ProducerScope<String>.streamPipeline(conversation: ArrayDeque<GigaRequest.Message>) {
+        stopRequested.set(false)
         val responses = chatStream(conversation)
         val results = ArrayList<GigaRequest.Message>()
         var totalTokens = 0
         responses.takeWhile { response ->
             l.info("response: $response")
-            when (response) {
+            !stopRequested.get() && when (response) {
                 is GigaResponse.Chat.Error -> {
                     l.error("Error in chunk: response: $response")
                     send("Ошибочка вышла, извините")
@@ -84,7 +87,9 @@ class GigaAgent(
                 is GigaResponse.Chat.Ok -> true
             }
         }.collect { response ->
+            if (stopRequested.get()) return@collect
             (response as GigaResponse.Chat.Ok).choices.forEach { choice ->
+                if (stopRequested.get()) return@forEach
                 choice.toMessage()?.let { msg ->
                     conversation.add(msg)
                     handleGigaChoice(choice)?.let { results.add(it) }
@@ -93,13 +98,17 @@ class GigaAgent(
             totalTokens += response.usage.totalTokens
         }
 
-        if (results.isEmpty()) {
+        if (stopRequested.get() || results.isEmpty()) {
             return
         } else {
             conversation.addAll(results)
             trySummarize(totalTokens, conversation)
             streamPipeline(conversation)
         }
+    }
+
+    fun stop() {
+        stopRequested.set(true)
     }
 
     private suspend fun ProducerScope<String>.singleResponsePipeline(conversation: ArrayDeque<GigaRequest.Message>) {


### PR DESCRIPTION
## Summary
- add cancel flag and `stop()` to `GigaAgent` to exit `streamPipeline`
- stop active agent when user presses or double-clicks Alt

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_689f5ccbe5588329ac3362693a745592