### PR TITLE
Fix file download command interpolation

### DIFF
--- a/src/main/kotlin/giga/GigaRestChatAPI.kt
+++ b/src/main/kotlin/giga/GigaRestChatAPI.kt
@@ -201,10 +201,10 @@ class GigaRestChatAPI(private val auth: GigaAuth) : GigaChatAPI {
     ): String? {
         val documentsDir = File(System.getProperty("user.home"), "SluxxDocuments").apply { mkdirs() }
         val command = """
-            cd ${'$'}{documentsDir.absolutePath} && \
-            curl -s -L -g 'https://gigachat.devices.sberbank.ru/api/v1/files/${'$'}{fileId}/content' \
+            cd "${documentsDir.absolutePath}" && \
+            curl -s -L -g 'https://gigachat.devices.sberbank.ru/api/v1/files/${fileId}/content' \
             -H 'Accept: application/octet-stream' \
-            -H 'Authorization: Bearer ${'$'}accessToken' \
+            -H 'Authorization: Bearer $accessToken' \
             -OJ -w '%{filename_effective}' -o /dev/null
         """.trimIndent()
         val fileName = ToolRunBashCommand.invoke(


### PR DESCRIPTION
## Summary
- Correct shell command string in downloadFileWithToken
- Ensure file path, fileId, and token are interpolated properly

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_689f8237380c83299b15ea83b633d507