### PR TITLE
feat: support temperature parameter in chat APIs

### DIFF
--- a/src/main/kotlin/giga/DTO.kt
+++ b/src/main/kotlin/giga/DTO.kt
@@ -97,6 +97,7 @@ object GigaRequest {
         @JsonProperty("function_call")
         val functionCall: String = "auto",
         val functions: List<Function> = emptyList(),
+        val temperature: Float? = null,
         val stream: Boolean = false,
     )
 

--- a/src/main/kotlin/giga/GigaAgent.kt
+++ b/src/main/kotlin/giga/GigaAgent.kt
@@ -270,6 +270,7 @@ class GigaAgent(
             model = settings.model.alias,
             messages = conversation,
             functions = fns,
+            temperature = settings.temperature,
         )
         return api.message(body)
     }
@@ -282,6 +283,7 @@ class GigaAgent(
             model = settings.model.alias,
             messages = conversation,
             functions = fns,
+            temperature = settings.temperature,
         )
         l.debug("Chat request:\n{}", logObjectMapper.writeValueAsString(body))
         return api.messageStream(body)
@@ -291,6 +293,7 @@ class GigaAgent(
         val toolsByCategory: Map<ToolCategory, Map<String, GigaToolSetup>>,
         val model: GigaModel = GigaModel.Max,
         val stream: Boolean = false,
+        val temperature: Float? = null,
     )
 
     companion object {

--- a/src/main/kotlin/giga/GigaGRPCChatApi.kt
+++ b/src/main/kotlin/giga/GigaGRPCChatApi.kt
@@ -62,9 +62,12 @@ class GigaGRPCChatApi(
             .setModel(body.model)
             .setOptions(
                 Gigachatv1.ChatOptions.newBuilder()
-                    .addAllFunctions(
-                        body.functions.map { it.toGRPC() }
-                    )
+                    .apply {
+                        addAllFunctions(
+                            body.functions.map { it.toGRPC() }
+                        )
+                        body.temperature?.let { temperature = it }
+                    }
                     .build()
             )
             .addAllMessages(body.messages.map { msg ->
@@ -99,9 +102,12 @@ class GigaGRPCChatApi(
             .setModel(body.model)
             .setOptions(
                 Gigachatv1.ChatOptions.newBuilder()
-                    .addAllFunctions(
-                        body.functions.map { it.toGRPC() }
-                    )
+                    .apply {
+                        addAllFunctions(
+                            body.functions.map { it.toGRPC() }
+                        )
+                        body.temperature?.let { temperature = it }
+                    }
                     .build()
             )
             .addAllMessages(body.messages.map { msg ->

--- a/src/test/kotlin/giga/GigaAgentTest.kt
+++ b/src/test/kotlin/giga/GigaAgentTest.kt
@@ -162,6 +162,53 @@ class GigaAgentTest {
         coVerify(exactly = 1) { api.message(any()) }
     }
 
+    @Test
+    fun `passes temperature from settings`() = runBlocking {
+        val api = mockk<GigaChatAPI>()
+        val usage = GigaResponse.Usage(1, 1, 2, 0)
+        val classifyMsg = GigaResponse.Message(
+            content = "io",
+            role = GigaMessageRole.assistant,
+            functionCall = null,
+            functionsStateId = null,
+        )
+        val classifyResponse = GigaResponse.Chat.Ok(
+            choices = listOf(GigaResponse.Choice(classifyMsg, 0, GigaResponse.FinishReason.stop)),
+            created = 0L,
+            model = "m",
+            usage = usage,
+        )
+        val msg = GigaResponse.Message(
+            content = "hello",
+            role = GigaMessageRole.assistant,
+            functionCall = null,
+            functionsStateId = null,
+        )
+        val response = GigaResponse.Chat.Ok(
+            choices = listOf(GigaResponse.Choice(msg, 0, GigaResponse.FinishReason.stop)),
+            created = 0L,
+            model = "m",
+            usage = usage,
+        )
+        val bodies = mutableListOf<GigaRequest.Chat>()
+        coEvery { api.message(capture(bodies)) } returnsMany listOf(classifyResponse, response)
+
+        val agent = GigaAgent(
+            userMessages = flowOf("hi"),
+            api = api,
+            settings = GigaAgent.Settings(
+                toolsByCategory = emptyMap(),
+                model = GigaModel.Pro,
+                stream = false,
+                temperature = 0.33f,
+            ),
+        )
+
+        agent.run().toList()
+
+        assertEquals(0.33f, bodies.last().temperature)
+    }
+
     private fun dummyTool(name: String): GigaToolSetup = object : GigaToolSetup {
         override val fn: GigaRequest.Function = GigaRequest.Function(
             name = name,

--- a/src/test/kotlin/giga/GigaGRPCChatApiTest.kt
+++ b/src/test/kotlin/giga/GigaGRPCChatApiTest.kt
@@ -235,4 +235,53 @@ class GigaGRPCChatApiTest {
         val ok = results.single() as GigaResponse.Chat.Ok
         assertTrue(ok.choices.isEmpty())
     }
+
+    @Test
+    fun `passes temperature in message request`() = runBlocking {
+        mockkObject(GigaAuth)
+        val stub = mockk<ChatServiceGrpcKt.ChatServiceCoroutineStub>()
+        val requestSlot = slot<Gigachatv1.ChatRequest>()
+        val response = sampleResponse()
+        coEvery { stub.chat(capture(requestSlot), any()) } returns response
+
+        System.setProperty("GIGA_ACCESS_TOKEN", "token1")
+        val api = GigaGRPCChatApi(GigaAuth)
+        val field = GigaGRPCChatApi::class.java.getDeclaredField("stub").apply { isAccessible = true }
+        field.set(api, stub)
+
+        val body = GigaRequest.Chat(
+            model = "GigaChat-Pro",
+            messages = listOf(GigaRequest.Message(GigaMessageRole.user, "hi")),
+            temperature = 0.42f
+        )
+
+        api.message(body)
+
+        assertEquals(0.42f, requestSlot.captured.options.temperature)
+    }
+
+    @Test
+    fun `passes temperature in messageStream request`() = runBlocking {
+        mockkObject(GigaAuth)
+        val stub = mockk<ChatServiceGrpcKt.ChatServiceCoroutineStub>()
+        val requestSlot = slot<Gigachatv1.ChatRequest>()
+        val response = sampleResponse(finishReason = "length")
+        every { stub.chatStream(capture(requestSlot), any()) } returns flow { emit(response) }
+
+        System.setProperty("GIGA_ACCESS_TOKEN", "token1")
+        val api = GigaGRPCChatApi(GigaAuth)
+        val field = GigaGRPCChatApi::class.java.getDeclaredField("stub").apply { isAccessible = true }
+        field.set(api, stub)
+
+        val body = GigaRequest.Chat(
+            model = "GigaChat-Pro",
+            messages = listOf(GigaRequest.Message(GigaMessageRole.user, "hi")),
+            temperature = 0.5f,
+            stream = true,
+        )
+
+        api.messageStream(body).toList()
+
+        assertEquals(0.5f, requestSlot.captured.options.temperature)
+    }
 }


### PR DESCRIPTION
## Summary
- add temperature option to chat request DTO and agent settings
- forward temperature to gRPC ChatOptions and REST requests
- test temperature propagation in chat and streaming paths

## Testing
- `./gradlew test --rerun-tasks`


------
https://chatgpt.com/codex/tasks/task_e_68a084de47608329b2e54a0e32d921f3