### PR TITLE
Add CSV plotting tool

### DIFF
--- a/scripts/plot_csv.py
+++ b/scripts/plot_csv.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+import csv
+import sys
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+
+
+def main():
+    if len(sys.argv) < 4:
+        print("Usage: plot_csv.py <csv_file> <x_column> <y_column> [output_file]", file=sys.stderr)
+        sys.exit(1)
+    csv_path = sys.argv[1]
+    x_col = sys.argv[2]
+    y_col = sys.argv[3]
+    output_path = sys.argv[4] if len(sys.argv) > 4 else "plot.png"
+
+    x_vals = []
+    y_vals = []
+    try:
+        with open(csv_path, newline='') as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                x_vals.append(float(row[x_col]))
+                y_vals.append(float(row[y_col]))
+    except FileNotFoundError:
+        print(f"File not found: {csv_path}", file=sys.stderr)
+        sys.exit(1)
+    except KeyError as e:
+        print(f"Missing column: {e}", file=sys.stderr)
+        sys.exit(1)
+    except ValueError as e:
+        print(f"Invalid numeric value: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    plt.figure()
+    plt.plot(x_vals, y_vals)
+    plt.xlabel(x_col)
+    plt.ylabel(y_col)
+    plt.tight_layout()
+    plt.savefig(output_path)
+    print(output_path)
+
+if __name__ == "__main__":
+    main()

--- a/src/main/kotlin/tool/ToolsFactory.kt
+++ b/src/main/kotlin/tool/ToolsFactory.kt
@@ -20,6 +20,7 @@ import com.dumch.tool.desktop.ToolMinimizeWindows
 import com.dumch.tool.desktop.ToolMouseClickMac
 import com.dumch.tool.desktop.ToolOpen
 import com.dumch.tool.desktop.ToolOpenFolder
+import com.dumch.tool.desktop.ToolPlotCsv
 import com.dumch.tool.desktop.ToolUploadFile
 import com.dumch.tool.desktop.ToolWindowsManager
 import com.dumch.tool.files.ToolDeleteFile
@@ -66,6 +67,7 @@ object ToolsFactory {
                 ToolCreateNote(ToolRunBashCommand).toGiga(),
                 ToolMinimizeWindows(ToolRunBashCommand).toGiga(),
                 ToolOpenFolder(ToolRunBashCommand).toGiga(),
+                ToolPlotCsv(ToolRunBashCommand).toGiga(),
                 // ToolShowApps.toGiga(), // we get it by default anyway
             ).associateBy { it.fn.name },
         )

--- a/src/main/kotlin/tool/desktop/ToolPlotCsv.kt
+++ b/src/main/kotlin/tool/desktop/ToolPlotCsv.kt
@@ -1,0 +1,50 @@
+package com.dumch.tool.desktop
+
+import com.dumch.tool.FewShotExample
+import com.dumch.tool.InputParamDescription
+import com.dumch.tool.ReturnParameters
+import com.dumch.tool.ReturnProperty
+import com.dumch.tool.ToolRunBashCommand
+import com.dumch.tool.ToolSetup
+import java.io.File
+
+class ToolPlotCsv(private val bash: ToolRunBashCommand) : ToolSetup<ToolPlotCsv.Input> {
+    data class Input(
+        @InputParamDescription("Path to a CSV file with table data")
+        val path: String,
+        @InputParamDescription("Column name to use for the x-axis")
+        val xColumn: String,
+        @InputParamDescription("Column name to use for the y-axis")
+        val yColumn: String,
+        @InputParamDescription("Path for the output image. Defaults to 'plot.png'")
+        val output: String? = null,
+    )
+
+    override val name: String = "PlotCsv"
+    override val description: String = "Generate a line plot image from a CSV file using matplotlib"
+
+    override val fewShotExamples = listOf(
+        FewShotExample(
+            request = "Построй график зависимости sales от month из файла data.csv",
+            params = mapOf(
+                "path" to "data.csv",
+                "xColumn" to "month",
+                "yColumn" to "sales"
+            )
+        )
+    )
+
+    override val returnParameters = ReturnParameters(
+        properties = mapOf(
+            "result" to ReturnProperty("string", "Stdout from plot command")
+        )
+    )
+
+    override fun invoke(input: Input): String {
+        val scriptPath = File("scripts/plot_csv.py").absolutePath
+        val csvPath = File(input.path).absolutePath
+        val outputPath = File(input.output ?: "plot.png").absolutePath
+        val command = "python \"$scriptPath\" \"$csvPath\" \"${input.xColumn}\" \"${input.yColumn}\" \"$outputPath\""
+        return bash.sh(command)
+    }
+}


### PR DESCRIPTION
## Summary
- add Python script to plot CSV data with matplotlib
- introduce `ToolPlotCsv` to run the plotting script via bash
- register `ToolPlotCsv` under the desktop tool category
- ensure `ToolPlotCsv` resolves absolute paths so files are found reliably

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a0874cf5848329a6a857e885c14432