### PR TITLE
Allow reading files by absolute path

### DIFF
--- a/src/main/kotlin/tool/files/ToolReadFile.kt
+++ b/src/main/kotlin/tool/files/ToolReadFile.kt
@@ -2,15 +2,16 @@ package com.dumch.tool.files
 
 import com.dumch.tool.*
 import java.io.File
+import java.nio.file.Paths
 
 object ToolReadFile : ToolSetup<ToolReadFile.Input> {
     data class Input(
-        @InputParamDescription("A relative path pointing to a file in the project directory")
+        @InputParamDescription("Path to a file. Absolute paths are allowed; relative paths are resolved from the project directory")
         val path: String
     )
     override val name = "ReadFile"
-    override val description = "Retrieve the contents of a specified file using a relative path. " +
-            "Use this to read a file's contents. Avoid using it with directory paths"
+    override val description = "Retrieve the contents of a specified file using a path. " +
+            "Relative paths are resolved from the project directory. Avoid using it with directory paths"
     override val fewShotExamples = listOf(
         FewShotExample(
             request = "Прочти README",
@@ -24,10 +25,10 @@ object ToolReadFile : ToolSetup<ToolReadFile.Input> {
     )
 
     override fun invoke(input: Input): String {
-        val path = input.path
-        val file = File(path)
-        if (!file.exists() || file.isDirectory) {
-            throw BadInputException("Invalid file path: $path")
+        val base = Paths.get("").toAbsolutePath()
+        val file = base.resolve(input.path).normalize().toFile()
+        if (!file.exists() || !file.isFile) {
+            throw BadInputException("Invalid file path: ${input.path}")
         }
         return file.readText()
     }
@@ -35,5 +36,9 @@ object ToolReadFile : ToolSetup<ToolReadFile.Input> {
 
 fun main() {
     val tool = ToolReadFile
-    println(tool.invoke(ToolReadFile.Input("Users/duxx/Отчеты/sales_report.csv")))
+    // Using a relative path (resolved from the project directory)
+    println(tool.invoke(ToolReadFile.Input("src/test/resources/test.txt")))
+    // Using an absolute path
+    val absolute = java.io.File("src/test/resources/test.txt").absolutePath
+    println(tool.invoke(ToolReadFile.Input(absolute)))
 }

--- a/src/test/kotlin/tool/files/ToolTest.kt
+++ b/src/test/kotlin/tool/files/ToolTest.kt
@@ -25,6 +25,13 @@ class ToolTest {
     }
 
     @Test
+    fun `test ToolReadFile absolute path`() {
+        val absolute = File("src/test/resources/test.txt").absolutePath
+        val result = ToolReadFile(ToolReadFile.Input(absolute))
+        assertEquals("Test content\n", result)
+    }
+
+    @Test
     fun `test ToolListFiles`() {
         val result = ToolListFiles(ToolListFiles.Input("gradle/wrapper"))
         val files = result.removePrefix("[").removeSuffix("]").split(",").toSet()


### PR DESCRIPTION
## Summary
- normalize input path in ToolReadFile so relative paths resolve to project root and absolute paths are supported
- mention absolute path support in docs and example
- test reading file by absolute path

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a0b10988cc8329835464c26856ace6