### PR TITLE
Extend DesktopDataExtractor with Notes support

### DIFF
--- a/src/main/kotlin/db/DesktopDataExtractor.kt
+++ b/src/main/kotlin/db/DesktopDataExtractor.kt
@@ -18,7 +18,7 @@ import kotlin.collections.map
  * ready for embedding.
  */
 object DesktopDataExtractor {
-    fun extract(): List<String> {
+    fun all(): List<String> {
         val installed = runCatching {
             val json = ToolShowApps.invoke(ToolShowApps.Input(ToolShowApps.AppState.installed))
             val arr: List<Map<String, String>> = objectMapper.readValue(json)
@@ -33,7 +33,10 @@ object DesktopDataExtractor {
         }.getOrElse { emptyList() }
 
         val instructions = runCatching {
-            val list = ConfigStore.get<ArrayList<ToolInstructionStore.Input>>(ToolInstructionStore.INSTUCTIONS_KEY, ArrayList())
+            val list = ConfigStore.get<ArrayList<ToolInstructionStore.Input>>(
+                ToolInstructionStore.INSTUCTIONS_KEY,
+                ArrayList()
+            )
             list.map { inp ->
                 "Помни о такой инструкции: Когда я говорю: `${inp.name}`, выполняй инструкцию: ${inp.action}"
             }
@@ -58,28 +61,22 @@ object DesktopDataExtractor {
         }.getOrElse { emptyList() }
     }
 
-    fun notes(): List<String> {
-        return runCatching {
-            val script = """
-                tell application "Notes"
-                    set allNotes to name of every note
-                    return allNotes
-                end tell
+    fun notes(): List<String> = runCatching {
+        val script = """
+set AppleScript's text item delimiters to linefeed
+tell application "Notes" to set xs to name of notes
+return xs as text
             """.trimIndent()
-
-            ToolRunBashCommand.apple(script)
-                .split(",")
-                .mapNotNull { it.trim().takeIf { s -> s.isNotEmpty() } }
-                .map { "У меня есть заметка: $it" }
-        }.getOrElse { emptyList() }
-    }
+        val raw = ToolRunBashCommand.apple(script)
+        raw.lines().map { "У меня есть заметка: $it" }
+    }.getOrElse { emptyList() }
 }
 
 fun main() {
     val logObjectMapper = jacksonObjectMapper().enable(SerializationFeature.INDENT_OUTPUT)
     println(
         logObjectMapper.writeValueAsString(
-            DesktopDataExtractor.extract()
+            DesktopDataExtractor.all()
         )
     )
 }

--- a/src/main/kotlin/db/DesktopDataExtractor.kt
+++ b/src/main/kotlin/db/DesktopDataExtractor.kt
@@ -39,7 +39,7 @@ object DesktopDataExtractor {
             }
         }.getOrElse { emptyList() }
 
-        return installed + dirs + instructions + browserHistory(500)
+        return installed + dirs + instructions + notes() + browserHistory(500)
     }
 
     fun browserHistory(count: Int = 10): List<String> {
@@ -55,6 +55,22 @@ object DesktopDataExtractor {
                 val (date, url, title) = historyLine.split("|")
                 "В истории браузера есть запись: $title, url: $url, дата: $date"
             }
+        }.getOrElse { emptyList() }
+    }
+
+    fun notes(): List<String> {
+        return runCatching {
+            val script = """
+                tell application "Notes"
+                    set allNotes to name of every note
+                    return allNotes
+                end tell
+            """.trimIndent()
+
+            ToolRunBashCommand.apple(script)
+                .split(",")
+                .mapNotNull { it.trim().takeIf { s -> s.isNotEmpty() } }
+                .map { "У меня есть заметка: $it" }
         }.getOrElse { emptyList() }
     }
 }

--- a/src/main/kotlin/db/DesktopInfoRepository.kt
+++ b/src/main/kotlin/db/DesktopInfoRepository.kt
@@ -28,7 +28,7 @@ class DesktopInfoRepository(
         val today = LocalDate.now().toString() // returns data like 2023-03-31
         if (ConfigStore.get(LAST_RUN_KEY, "") == today) return
         db.clearAllTexts()
-        val data = DesktopDataExtractor.extract()
+        val data = DesktopDataExtractor.all()
         storeDesktopInfo(data)
         ConfigStore.put(LAST_RUN_KEY, today)
     }
@@ -62,5 +62,5 @@ suspend fun main() {
     val api = GigaRestChatAPI(GigaAuth)
     val repo = DesktopInfoRepository(api, VectorDB)
     repo.storeDesktopDataDaily()
-    println(repo.search("Найди историю в браузере про четырехногих животных похожих на волка"))
+    println(repo.search("Есть ли что-то в заметках про Жену?"))
 }

--- a/src/main/kotlin/tool/ToolRunBashCommand.kt
+++ b/src/main/kotlin/tool/ToolRunBashCommand.kt
@@ -31,15 +31,17 @@ object ToolRunBashCommand : ToolSetup<ToolRunBashCommand.Input> {
 
     fun apple(script: String): String {
         val scriptInvocation = """
-            osascript <<EOF
-            $script
-            EOF
+osascript <<EOF
+$script
+EOF
         """.trimIndent()
-        val p = ProcessBuilder("bash","-lc", scriptInvocation).redirectErrorStream(false).start()
-        val output = p.inputStream.bufferedReader().readText()
+        val p = ProcessBuilder("bash","-lc", scriptInvocation)
+            .redirectErrorStream(true)
+            .start()
+        val output = p.inputStream.bufferedReader().use(BufferedReader::readText)
         val exitCode = p.waitFor()
         if (exitCode != 0) throw ShellException(output, exitCode)
-        return p.inputStream.bufferedReader().readText().trim()
+        return output.trim()
     }
 
     data class Input(

--- a/src/test/kotlin/giga/GigaToolTest.kt
+++ b/src/test/kotlin/giga/GigaToolTest.kt
@@ -1,16 +1,12 @@
 package giga
 
-import com.dumch.giga.GigaRequest
-import com.dumch.giga.GigaResponse
-import com.dumch.giga.GigaToolSetup
-import com.dumch.giga.GigaMessageRole
-import com.dumch.giga.gigaJsonMapper
-import com.dumch.giga.toGiga
+import com.dumch.giga.*
 import com.dumch.tool.files.ToolListFiles
+import com.fasterxml.jackson.module.kotlin.contains
 import kotlinx.coroutines.runBlocking
+import org.slf4j.LoggerFactory
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import org.slf4j.LoggerFactory
 
 class GigaToolTest {
     @Test
@@ -39,7 +35,13 @@ class GigaToolTest {
         val result = toolsMap[functionCall.name]!!.invoke(functionCall)
         l.info("$result")
         assertEquals(GigaMessageRole.function, result.role)
-        val actual = gigaJsonMapper.readTree(result.content).get("result").asText()
+        val actual = gigaJsonMapper.readTree(result.content).let { nodes ->
+            if (nodes.contains("result")) {
+                nodes.get("result").asText()
+            } else {
+                nodes.asText()
+            }
+        }
         val actualSet = actual.removePrefix("[").removeSuffix("]").split(",").toSet()
         val expected = setOf(
             "src/test/resources/directory/",


### PR DESCRIPTION
## Summary
- include Apple Notes titles in DesktopDataExtractor output
- add notes() helper to run AppleScript and format entries

## Testing
- `./gradlew test` *(fails: GigaToolTest > test function invocation() FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_68a20e9931b48329907fa0826659db21