### PR TITLE
Implement assistant message squeezing and add tests

### DIFF
--- a/src/main/kotlin/giga/GigaAgent.kt
+++ b/src/main/kotlin/giga/GigaAgent.kt
@@ -120,8 +120,7 @@ class GigaAgent(
             }
             totalTokens += response.usage.totalTokens
         }
-
-        // squeezeTexts() // TODO: uncomment when implemented
+        conversation.squeezeTexts()
         if (stopRequested.get() || results.isEmpty()) {
             return
         } else {
@@ -133,7 +132,27 @@ class GigaAgent(
 
     // Consolidates agent messages with text into one message
     private fun ArrayDeque<GigaRequest.Message>.squeezeTexts() {
-        TODO("Need to make sure that near messages with texts with role=agents are consolidated into one message")
+        if (isEmpty()) return
+        val squeezed = ArrayDeque<GigaRequest.Message>(size)
+        for (msg in this) {
+            val last = squeezed.lastOrNull()
+            if (
+                last != null &&
+                last.role == GigaMessageRole.assistant &&
+                msg.role == GigaMessageRole.assistant &&
+                last.content.isNotBlank() &&
+                msg.content.isNotBlank() &&
+                (last.functionsStateId == msg.functionsStateId || msg.functionsStateId == null)
+            ) {
+                squeezed.removeLast()
+                val joined = if (last.content.isEmpty()) msg.content else last.content + "\n" + msg.content
+                squeezed.add(last.copy(content = joined))
+            } else {
+                squeezed.add(msg)
+            }
+        }
+        clear()
+        addAll(squeezed)
     }
 
     fun stop() {
@@ -194,7 +213,7 @@ class GigaAgent(
         val bodyJson = gigaJsonMapper.writeValueAsString(body)
         l.debug("Classifying user message: $userText, \nbody: \n${logObjectMapper.writeValueAsString(body)}")
         return try {
-            apiClassifier.classify(bodyJson)
+            apiClassifier.classify(bodyJson) ?: localClassifier.classify(bodyJson)
         } catch (e: Exception) {
             l.error("Error in apiClassifier: ${e.message}")
             localClassifier.classify(bodyJson)

--- a/src/test/kotlin/giga/GigaAgentTest.kt
+++ b/src/test/kotlin/giga/GigaAgentTest.kt
@@ -261,6 +261,64 @@ class GigaAgentTest {
         assertEquals(0.33f, bodies.last().temperature)
     }
 
+    @Test
+    fun `squeezeTexts merges function call and text`() {
+        val agent = GigaAgent(
+            userMessages = flowOf<String>(),
+            api = mockk(),
+            ragRepo = mockRagRepo(),
+            settings = GigaAgent.Settings(toolsByCategory = emptyMap(), model = GigaModel.Pro, stream = true),
+        )
+        val conversation = ArrayDeque<GigaRequest.Message>().apply {
+            add(GigaRequest.Message(GigaMessageRole.user, "u1"))
+            add(
+                GigaRequest.Message(
+                    GigaMessageRole.assistant,
+                    "fn",
+                    functionsStateId = "id1"
+                )
+            )
+            add(
+                GigaRequest.Message(
+                    GigaMessageRole.assistant,
+                    "text",
+                    functionsStateId = null
+                )
+            )
+            add(GigaRequest.Message(GigaMessageRole.user, "u2"))
+        }
+        val m = GigaAgent::class.java.getDeclaredMethod("squeezeTexts", ArrayDeque::class.java)
+        m.isAccessible = true
+        m.invoke(agent, conversation)
+
+        assertEquals(3, conversation.size)
+        val assistant = conversation.elementAt(1)
+        assertEquals("fn\ntext", assistant.content)
+        assertEquals("id1", assistant.functionsStateId)
+    }
+
+    @Test
+    fun `squeezeTexts merges consecutive assistant texts`() {
+        val agent = GigaAgent(
+            userMessages = flowOf<String>(),
+            api = mockk(),
+            ragRepo = mockRagRepo(),
+            settings = GigaAgent.Settings(toolsByCategory = emptyMap(), model = GigaModel.Pro, stream = true),
+        )
+        val conversation = ArrayDeque<GigaRequest.Message>().apply {
+            add(GigaRequest.Message(GigaMessageRole.user, "u"))
+            add(GigaRequest.Message(GigaMessageRole.assistant, "a1"))
+            add(GigaRequest.Message(GigaMessageRole.assistant, "a2"))
+            add(GigaRequest.Message(GigaMessageRole.assistant, "a3"))
+        }
+        val m = GigaAgent::class.java.getDeclaredMethod("squeezeTexts", ArrayDeque::class.java)
+        m.isAccessible = true
+        m.invoke(agent, conversation)
+
+        assertEquals(2, conversation.size)
+        assertEquals("a1\na2\na3", conversation.last().content)
+    }
+
     private fun mockRagRepo(): DesktopInfoRepository = mockk<DesktopInfoRepository> {
         coEvery { search(any(), any()) } returns emptyList()
     }


### PR DESCRIPTION
## Summary
- Merge consecutive assistant messages into a single message via `squeezeTexts` and use it during streaming
- Fall back to local classifier when API classifier fails to categorize
- Add tests covering message squeezing cases

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a39cc8e2688329be58ae3d6309d1f0