### PR TITLE
Add balance REST method to GigaChat API

### DIFF
--- a/src/main/kotlin/giga/DTO.kt
+++ b/src/main/kotlin/giga/DTO.kt
@@ -88,6 +88,16 @@ object GigaResponse {
         @JsonProperty("object") val objectType: String? = null,
     )
 
+    data class BalanceItem(
+        val usage: String,
+        val value: Int,
+    )
+
+    sealed interface Balance {
+        data class Ok(val balance: List<BalanceItem>) : Balance
+        data class Error(val status: Int, val message: String) : Balance
+    }
+
     enum class FinishReason { stop, length, function_call, blacklist, error }
 }
 

--- a/src/main/kotlin/giga/GigaChatAPI.kt
+++ b/src/main/kotlin/giga/GigaChatAPI.kt
@@ -9,5 +9,6 @@ interface GigaChatAPI {
     suspend fun embeddings(body: GigaRequest.Embeddings): GigaResponse.Embeddings
     suspend fun uploadFile(file: File): GigaResponse.UploadFile
     suspend fun downloadFile(fileId: String): String?
+    suspend fun balance(): GigaResponse.Balance
 }
 

--- a/src/main/kotlin/giga/GigaRestChatAPI.kt
+++ b/src/main/kotlin/giga/GigaRestChatAPI.kt
@@ -148,6 +148,26 @@ class GigaRestChatAPI(private val auth: GigaAuth) : GigaChatAPI {
         }
     }
 
+    override suspend fun balance(): GigaResponse.Balance = try {
+        val response = client.get(BALANCE_URL)
+        when {
+            response.status.isSuccess() -> response.body<GigaResponse.Balance.Ok>()
+            response.status == HttpStatusCode.Unauthorized || response.status == HttpStatusCode.Forbidden ->
+                GigaResponse.Balance.Error(
+                    response.status.value,
+                    "Authentication error: ${response.status.description}"
+                )
+
+            else -> runCatching { response.body<GigaResponse.Balance.Error>() }
+                .getOrElse {
+                    GigaResponse.Balance.Error(response.status.value, response.status.description)
+                }
+        }
+    } catch (t: Throwable) {
+        l.error("Error in REST balance", t)
+        GigaResponse.Balance.Error(-1, "Connection error: ${t.message}")
+    }
+
     private fun parseStreamChunk(data: String): GigaResponse.Chat {
         val node = objectMapper.readTree(data)
         val choicesNode = node["choices"] ?: emptyList()
@@ -257,6 +277,7 @@ class GigaRestChatAPI(private val auth: GigaAuth) : GigaChatAPI {
     companion object {
         private val URL = "https://gigachat.devices.sberbank.ru/api/v1/chat/completions"
         private val EMBEDDINGS_URL = "https://gigachat.devices.sberbank.ru/api/v1/embeddings"
+        private val BALANCE_URL = "https://gigachat.devices.sberbank.ru/api/v1/balance"
 
         val INSTANCE = GigaRestChatAPI(GigaAuth)
     }

--- a/src/test/kotlin/giga/BalanceParseTest.kt
+++ b/src/test/kotlin/giga/BalanceParseTest.kt
@@ -1,0 +1,16 @@
+package giga
+
+import com.dumch.giga.GigaResponse
+import com.dumch.giga.objectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class BalanceParseTest {
+    @Test
+    fun parseBalance() {
+        val json = """{"balance":[{"usage":"GigaChat","value":42}]}"""
+        val resp: GigaResponse.Balance.Ok = objectMapper.readValue(json)
+        assertEquals(42, resp.balance[0].value)
+    }
+}


### PR DESCRIPTION
## Summary
- expose balance retrieval in `GigaChatAPI`
- implement REST call to `/balance` in `GigaRestChatAPI`
- add data classes for balance response and test parser

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a3bac327048329a46fd17dd4a85e08