### PR TITLE
Add hotkey for agent reset via right alt+right arrow

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -58,6 +58,9 @@ suspend fun main() = coroutineScope {
         onDoubleClick = {
             stopPlayText()
             agentRef.get()?.stop()
+        },
+        onAltRightArrow = {
+            agentRef.get()?.stop()
         }
     )
     launch { audioRecorder.logState() }

--- a/src/main/kotlin/keys/KeyListener.kt
+++ b/src/main/kotlin/keys/KeyListener.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.*
 class HotkeyListener(
     private val onPressed: (Boolean) -> Unit,
     private val onDoubleClick: () -> Unit,
+    private val onAltRightArrow: () -> Unit = {},
 ) : NativeKeyListener {
     private var isAltPressed = false
     private var isHotkeyActive = false
@@ -34,6 +35,12 @@ class HotkeyListener(
                     onPressed(true)
                 }
             }
+        }
+
+        if (isAltPressed && e.keyCode == VK.RIGHT) {
+            isAltPressed = false
+            isHotkeyActive = false
+            onAltRightArrow()
         }
     }
 
@@ -66,7 +73,8 @@ fun main() {
             val msg = if (pressed) "onStart" else "onStop"
             l.info(msg)
         },
-        onDoubleClick = { l.info("double click") }
+        onDoubleClick = { l.info("double click") },
+        onAltRightArrow = { l.info("alt+right arrow") }
     )
 
     try {


### PR DESCRIPTION
## Summary
- add optional right-alt + right-arrow callback in `HotkeyListener`
- stop current agent when right-alt + right-arrow is pressed

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a4c3b5f81c8329904c90944c53c12c