### PR TITLE
Improve local classifier and add broad classification tests

### DIFF
--- a/src/main/kotlin/tool/UserMessageClassifier.kt
+++ b/src/main/kotlin/tool/UserMessageClassifier.kt
@@ -33,7 +33,7 @@ object LocalRegexClassifier : UserMessageClassifier {
 
         val scores = CATEGORY_PATTERNS.mapValues { (_, patterns) ->
             patterns.sumOf { (regex, weight) ->
-                if (regex.containsMatchIn(text)) weight else 0.0
+                regex.findAll(text).count() * weight
             }
         }
 
@@ -53,7 +53,7 @@ object LocalRegexClassifier : UserMessageClassifier {
                 Regex("readme|ридми|разработ|рефактор|отрефактор|баг|композиц|наслед|абстракт|ооп|полиморф|лисков|чистый код"),
                 2.0
             ),
-            WeightedRegex(Regex("реализ|ошибк|open closed|абстракц"), 1.0),
+            WeightedRegex(Regex("реализ|ошибк|open closed|абстракц|код"), 1.0),
             WeightedRegex(Regex("вынес|напис|поправ|измен|додел|чищ|удобн|созда"), 0.5),
         ),
         ToolCategory.BROWSER to listOf(
@@ -67,6 +67,7 @@ object LocalRegexClassifier : UserMessageClassifier {
         ToolCategory.DESKTOP to listOf(
             WeightedRegex(Regex("перенеси окно|перейди на экран|перетащи окно|размести приложения по"), 2.0),
             WeightedRegex(Regex("окн|window|desktop"), 1.5),
+            WeightedRegex(Regex("папк|folder|заметк|note|телеграм|telegram|покаж|фокус|увелич|располож|сверн"), 1.5),
             WeightedRegex(Regex("прилож|app|mouse|мыш|screen|скрин|экран"), 1.0),
         ),
         ToolCategory.IO to listOf(
@@ -75,7 +76,7 @@ object LocalRegexClassifier : UserMessageClassifier {
         ),
         ToolCategory.DATAANALYTICS to listOf(
             WeightedRegex(Regex("построй|созда|сделай|проанализ|график|chart|graph|plot|что на графике"), 2.0),
-            WeightedRegex(Regex("найд|find|скольк|корреляци|correlation|причин|корреляции"), 1.0),
+            WeightedRegex(Regex("find|скольк|корреляц|correlation|причин"), 1.0),
         ),
     )
 }

--- a/src/test/kotlin/tool/LocalRegexClassifierTest.kt
+++ b/src/test/kotlin/tool/LocalRegexClassifierTest.kt
@@ -102,4 +102,32 @@ class LocalRegexClassifierTest {
         val category = classifier.classify(body("прочитай readme и открой http://example.com"))
         assertEquals(null, category)
     }
+
+    @Test
+    fun `classifies provided phrases`() = runBlocking {
+        val classifier = LocalRegexClassifier
+        val cases = listOf(
+            "Напиши в телеграм Артуру что я на демо" to ToolCategory.DESKTOP,
+            "Открой приложение Интеллиджи Айдеа" to ToolCategory.DESKTOP,
+            "Что делает выбранный участок кода?" to ToolCategory.CODER,
+            "Открой сайт сбера" to ToolCategory.BROWSER,
+            "Найди в закладках и открой страницу с обзором фондового рынка" to ToolCategory.BROWSER,
+            "Расскажи кратко о чем рассказано на текущей странице" to ToolCategory.BROWSER,
+            "Открой папку семья" to ToolCategory.DESKTOP,
+            "Покажи тетю фросю" to ToolCategory.DESKTOP,
+            "Открой папку отчеты" to ToolCategory.DESKTOP,
+            "Построй график дохода по клиенту из файла сейлз репорт" to ToolCategory.DATAANALYTICS,
+            "Добавь заметку - купить пивка" to ToolCategory.DESKTOP,
+            "Открой заметку демо" to ToolCategory.DESKTOP,
+            "сфокусируйся на окне справа" to ToolCategory.DESKTOP,
+            "увеличь окно" to ToolCategory.DESKTOP,
+            "расположи окна вертикально" to ToolCategory.DESKTOP,
+            "сверни все окна" to ToolCategory.DESKTOP,
+        )
+
+        for ((text, expected) in cases) {
+            val category = classifier.classify(body(text))
+            assertEquals(expected, category, text)
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Count all regex hits to score each tool category
- Expand desktop, coder and analytics regex patterns
- Add comprehensive tests for common user phrases

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a4f64534c48329841daf75823a387c