### PR TITLE
Configure default log directory for DMG builds

### DIFF
--- a/composeApp/src/jvmMain/resources/logback.xml
+++ b/composeApp/src/jvmMain/resources/logback.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <property name="LOG_DIR" value="out/logs"/>
+    <property name="STATE_LOG_DIR" value="${HOME:-${user.home}}/.local/state/abledo/logs"/>
+    <property name="LOG_DIR" value="${LOG_DIR:-${STATE_LOG_DIR}}"/>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>


### PR DESCRIPTION
## Summary
- default log output to ~/.local/state/abledo/logs for packaged builds
- allow overriding the log directory via LOG_DIR environment variable

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925e28d7a5883299ed97e7ae69a3d83)