### PR TITLE
Add apple events permission for Chrome access

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -103,6 +103,8 @@ compose.desktop {
                         <string>Needed for voice capture.</string>
                         <key>NSSystemAdministrationUsageDescription</key>
                         <string>Needed to observe input for shortcuts.</string>
+                        <key>NSAppleEventsUsageDescription</key>
+                        <string>Needed to control Chrome for browser automation.</string>
                     """.trimIndent()
                 }
             }


### PR DESCRIPTION
## Summary
- add NSAppleEventsUsageDescription to request permission for controlling Chrome

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e35d0ab68832994ab98c5f748cfd3)