### PR TITLE
Improve app bundle detection for Input Monitoring enrollment

### DIFF
--- a/composeApp/src/jvmMain/kotlin/ru/gigadesk/db/SettingsProvider.kt
+++ b/composeApp/src/jvmMain/kotlin/ru/gigadesk/db/SettingsProvider.kt
@@ -10,6 +10,9 @@ class SettingsProvider(private val configStore: ConfigStore) {
 
     var gigaChatKey: String? by keyDelegate(configKey = GIGA_CHAT_KEY, envKey = "GIGA_KEY")
     var saluteSpeechKey: String? by keyDelegate(configKey = SALUTE_SPEECH_KEY, envKey = "VOICE_KEY")
+    var isSetupCompleted: Boolean
+        get() = _isSetupCompletedDelegate?.lowercase() == "true"
+        set(value) { _isSetupCompletedDelegate = value.toString() }
     var supportEmail: String? by keyDelegate(configKey = SUPPORT_EMAIL, envKey = SUPPORT_EMAIL)
     var systemPrompt: String? by keyDelegate(configKey = SYSTEM_PROMPT, envKey = SYSTEM_PROMPT)
     var defaultCalendar: String? by keyDelegate(configKey = DEFAULT_CALENDAR, envKey = DEFAULT_CALENDAR)
@@ -44,10 +47,16 @@ class SettingsProvider(private val configStore: ConfigStore) {
     companion object {
         private const val GIGA_CHAT_KEY = "GIGA_CHAT_KEY"
         private const val SALUTE_SPEECH_KEY = "SALUTE_SPEECH_KEY"
+        private const val SETUP_COMPLETED = "SETUP_COMPLETED"
         private const val USE_FEW_SHOTS = "USE_FEW_SHOTS"
         private const val SUPPORT_EMAIL = "SUPPORT_EMAIL"
         private const val SYSTEM_PROMPT = "SYSTEM_PROMPT"
         private const val DEFAULT_CALENDAR = "DEFAULT_CALENDAR"
         private const val GIGA_MODEL = "GIGA_MODEL"
     }
+
+    private var _isSetupCompletedDelegate: String? by keyDelegate(
+        configKey = SETUP_COMPLETED,
+        envKey = SETUP_COMPLETED
+    )
 }

--- a/composeApp/src/jvmMain/kotlin/ru/gigadesk/ui/setup/SetupViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/ru/gigadesk/ui/setup/SetupViewModel.kt
@@ -13,6 +13,9 @@ import ru.gigadesk.audio.Say
 import ru.gigadesk.db.SettingsProvider
 import ru.gigadesk.permissions.AppRelauncher
 import ru.gigadesk.ui.BaseViewModel
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
 
 class SetupViewModel(
     override val di: DI,
@@ -36,6 +39,9 @@ class SetupViewModel(
                 accessibilityGranted = accessibilityGranted,
                 isCheckingPermissions = false
             )
+            if (shouldOpenMain(gigaChatKey, saluteSpeechKey, inputMonitoringGranted, accessibilityGranted)) {
+                send(SetupEffect.OpenMain)
+            }
         }
     }
 
@@ -58,6 +64,7 @@ class SetupViewModel(
                 .onFailure { logger.warn("Failed to open voice settings", it) }
             SetupEvent.Proceed -> {
                 if (currentState.canProceed) {
+                    settingsProvider.isSetupCompleted = true
                     send(SetupEffect.OpenMain)
                 }
             }
@@ -106,6 +113,21 @@ class SetupViewModel(
         return messages
     }
 
+    private fun shouldOpenMain(
+        gigaChatKey: String,
+        saluteSpeechKey: String,
+        inputMonitoringGranted: Boolean,
+        accessibilityGranted: Boolean,
+    ): Boolean {
+        if (!settingsProvider.isSetupCompleted) {
+            return false
+        }
+        return gigaChatKey.isNotBlank() &&
+            saluteSpeechKey.isNotBlank() &&
+            inputMonitoringGranted &&
+            accessibilityGranted
+    }
+
     private fun refreshPermissions(relaunchIfGranted: Boolean) {
         permissionWatcherJob?.cancel()
         permissionWatcherJob = viewModelScope.launch {
@@ -129,10 +151,42 @@ class SetupViewModel(
 
     private fun openInputMonitoringSettings() {
         runCatching {
+            val appPath = resolveAppBundlePath()
             ProcessBuilder(
                 "open",
                 "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent"
             ).start()
+            if (appPath != null) {
+                val script = """
+                    tell application "System Settings"
+                        activate
+                    end tell
+                    delay 0.5
+                    tell application "System Events"
+                        tell process "System Settings"
+                            repeat until exists window 1
+                                delay 0.2
+                            end repeat
+                            if exists (button "Add" of window 1) then
+                                click button "Add" of window 1
+                            else if exists (button "+" of window 1) then
+                                click button "+" of window 1
+                            end if
+                        end tell
+                    end tell
+                    delay 0.3
+                    tell application "System Events"
+                        keystroke "G" using {command down, shift down}
+                        delay 0.2
+                        keystroke "$appPath"
+                        delay 0.2
+                        keystroke return
+                        delay 0.2
+                        keystroke return
+                    end tell
+                """.trimIndent()
+                ProcessBuilder("osascript", "-e", script).start()
+            }
         }.onFailure { logger.warn("Failed to open input monitoring settings", it) }
     }
 
@@ -143,6 +197,32 @@ class SetupViewModel(
                 "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
             ).start()
         }.onFailure { logger.warn("Failed to open accessibility settings", it) }
+    }
+
+    private fun resolveAppBundlePath(): String? {
+        val packagedAppPath = System.getProperty("jpackage.app-path")
+        if (!packagedAppPath.isNullOrBlank() && Files.exists(Paths.get(packagedAppPath))) {
+            return packagedAppPath
+        }
+
+        val command = ProcessHandle.current().info().command().orElse(null)
+        val commandMatch = command?.let { Regex("(.+\\.app)").find(it) }
+        if (commandMatch != null) {
+            return Paths.get(commandMatch.groupValues[1]).toString()
+        }
+
+        val argsMatch = ProcessHandle.current().info().arguments().orElse(null)
+            ?.firstNotNullOfOrNull { arg -> Regex("(.+\\.app)").find(arg) }
+        if (argsMatch != null) {
+            return Paths.get(argsMatch.groupValues[1]).toString()
+        }
+
+        val appName = System.getProperty("jpackage.app-name")?.ifBlank { null } ?: "GigaDesk"
+        val candidates = listOf(
+            Path.of("/Applications", "$appName.app"),
+            Path.of(System.getProperty("user.home"), "Applications", "$appName.app")
+        )
+        return candidates.firstOrNull { Files.exists(it) }?.toString()
     }
 
     private fun canRegisterNativeHookNow(): Boolean = runCatching {


### PR DESCRIPTION
### Motivation
- Make the Input Monitoring enrollment helper more reliable by ensuring the script receives a valid application bundle path to prefill the System Settings add dialog.
- Respect the persisted "setup completed" state so the app can skip the setup screen on subsequent launches when keys and permissions are already satisfied.

### Description
- Added a persisted `isSetupCompleted` flag to `SettingsProvider` with a new config key `SETUP_COMPLETED` and a backing delegate `_isSetupCompletedDelegate`.
- Updated `SetupViewModel` to set `settingsProvider.isSetupCompleted = true` on `Proceed` and to auto-send `SetupEffect.OpenMain` during initialization when the flag and permission checks pass via `shouldOpenMain(...)`.
- Implemented `resolveAppBundlePath()` in `SetupViewModel` to detect the application `.app` path from `jpackage.app-path`, the process command, process arguments, and fallback candidate locations (`/Applications` and `~/Applications`) using `Files`/`Path` utilities.
- Enhanced `openInputMonitoringSettings()` to call the AppleScript enrollment helper only when a resolved `.app` path is available so the add dialog can be prefilled.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bb144e3948329b5640d74c3c7815b)