### PR TITLE
Avoid blocking UI on audio playback

### DIFF
--- a/composeApp/src/jvmMain/kotlin/ru/gigadesk/ui/main/MainViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/ru/gigadesk/ui/main/MainViewModel.kt
@@ -156,7 +156,7 @@ class MainViewModel(
         if (currentState.isListening) return
         killTaskSideEffectJobs()
         agentRef.get()?.cancelActiveJob()
-        say.playMacPing()
+        ioLaunch { say.playMacPing() }
         setState { copy(isListening = true, statusMessage = "Запись запущена") }
         audioRecorder.start()
     }
@@ -166,7 +166,7 @@ class MainViewModel(
         audioRecorder.stop()
         setState { copy(isListening = false, statusMessage = "Обработка входа") }
         delay(300)
-        say.playTextRand(speed = 120, "ok", "okey", "окей", "ок")
+        ioLaunch { say.playTextRand(speed = 120, "ok", "okey", "окей", "ок") }
     }
 
     private suspend fun setPreviousText() {


### PR DESCRIPTION
### Motivation
- Prevent UI/main coroutine blocking caused by synchronous audio playback when starting or stopping recording.

### Description
- Run blocking `Say` calls on the IO dispatcher by wrapping `say.playMacPing()` and `say.playTextRand(...)` in `ioLaunch { ... }` in `composeApp/src/jvmMain/kotlin/ru/gigadesk/ui/main/MainViewModel.kt`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69713cb113c883299e7f26946c6823fb)