### PR TITLE
Filter unsafe paths in FindInFiles results

### DIFF
--- a/composeApp/src/jvmMain/kotlin/ru/gigadesk/tool/files/ToolFindInFiles.kt
+++ b/composeApp/src/jvmMain/kotlin/ru/gigadesk/tool/files/ToolFindInFiles.kt
@@ -63,7 +63,14 @@ class ToolFindInFiles(private val filesToolUtil: FilesToolUtil) : ToolSetup<Tool
         val result = ToolRunBashCommand.sh(script, path, input.query)
             .lineSequence()
             .windowed(size = 2, step = 2, partialWindows = false)
-            .map { (filePath, matchingContent) -> listOf(filePath, matchingContent) }
+            .mapNotNull { (filePath, matchingContent) ->
+                val file = File(filePath)
+                if (filesToolUtil.isPathSafe(file)) {
+                    listOf(filePath, matchingContent)
+                } else {
+                    null
+                }
+            }
             .toList()
         return objectMapper.writeValueAsString(result)
     }


### PR DESCRIPTION
### Motivation
- Prevent leaking matches from user-forbidden subdirectories when searching a parent directory by filtering per-file results with `filesToolUtil.isPathSafe(File(filePath))` because only the base path was previously checked.

### Description
- Replace the previous mapping over the script output with `.mapNotNull` to construct `listOf(filePath, matchingContent)` only when `filesToolUtil.isPathSafe(File(filePath))`, otherwise drop the result.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69796a899cac83299fb77efc59799438)