### PR TITLE
Allow NewFile tool to create folders

### DIFF
--- a/composeApp/src/jvmMain/kotlin/ru/gigadesk/tool/files/ToolNewFile.kt
+++ b/composeApp/src/jvmMain/kotlin/ru/gigadesk/tool/files/ToolNewFile.kt
@@ -5,17 +5,21 @@ import java.io.File
 
 class ToolNewFile(private val filesToolUtil: FilesToolUtil) : ToolSetup<ToolNewFile.Input> {
     data class Input(
-        @InputParamDescription("The path where the file will be created, including filename")
+        @InputParamDescription("The path where the file or folder will be created; add a trailing slash to create a folder")
         val path: String,
         @InputParamDescription("The content to be written to the new file")
         val text: String
     )
     override val name = "NewFile"
-    override val description = "Creates a new TEXT file at the given path with the provided content. forbidden: .xlsx, .xls, .png, .jpg, .pdf."
+    override val description = "Creates a new TEXT file at the given path with the provided content. If the path ends with a slash, creates a folder instead. forbidden: .xlsx, .xls, .png, .jpg, .pdf."
     override val fewShotExamples = listOf(
         FewShotExample(
             request = "Create notes.txt with greeting",
             params = mapOf("path" to "notes.txt", "text" to "Hello!\n")
+        ),
+        FewShotExample(
+            request = "Create a folder named drafts",
+            params = mapOf("path" to "drafts/", "text" to "")
         )
     )
     override val returnParameters = ReturnParameters(
@@ -25,13 +29,21 @@ class ToolNewFile(private val filesToolUtil: FilesToolUtil) : ToolSetup<ToolNewF
     )
 
     override fun invoke(input: Input): String {
+        val isDirectoryRequest = input.path.endsWith("/") || input.path.endsWith(File.separator)
         val fixedPath = filesToolUtil.applyDefaultEnvs(input.path)
         val file = File(fixedPath)
         if (!filesToolUtil.isPathSafe(file)) {
             throw ForbiddenFolder(fixedPath)
         }
         if (file.exists()) {
-            throw BadInputException("File already exists: ${input.path}")
+            val typeLabel = if (isDirectoryRequest) "Folder" else "File"
+            throw BadInputException("$typeLabel already exists: ${input.path}")
+        }
+        if (isDirectoryRequest) {
+            if (!file.mkdirs()) {
+                throw BadInputException("Failed to create folder: ${input.path}")
+            }
+            return "Folder created at ${input.path}"
         }
         file.parentFile?.mkdirs()
         file.writeText(input.text)


### PR DESCRIPTION
### Motivation
- Let the existing NewFile tool also create directories when callers request folder creation.
- Make the parameter and description text explicit so clients know to append a trailing slash to create a folder.
- Provide an example for creating a folder to improve usability and reduce confusion.

### Description
- Updated the `Input` parameter description in `ToolNewFile.kt` to indicate the path can be a file or folder and that a trailing slash requests folder creation.
- Clarified the `description` string and added a folder creation `FewShotExample` demonstrating `"drafts/"`.
- Added detection of directory requests via `isDirectoryRequest = input.path.endsWith("/") || input.path.endsWith(File.separator)` and branch logic that calls `mkdirs()` to create folders, with clearer error messages and distinct return messages for files vs folders.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987be3fd89083299fea2e49601ec861)