### PR TITLE
Increase stream chunk threshold progressively and flush remaining pending data

### DIFF
--- a/composeApp/src/jvmMain/kotlin/ru/gigadesk/agent/nodes/NodesLLM.kt
+++ b/composeApp/src/jvmMain/kotlin/ru/gigadesk/agent/nodes/NodesLLM.kt
@@ -58,6 +58,7 @@ class NodesLLM(
         val streamResponse = AtomicReference<GigaResponse.Chat?>(null)
         val choicesByIndex = ConcurrentHashMap<Int, ChoiceAccumulator>()
         val pending = StringBuilder()
+        var increasingChunkSize = 20
 
         withContext(Dispatchers.IO) {
             llmApi.messageStream(request).takeWhile { response ->
@@ -75,11 +76,12 @@ class NodesLLM(
                 val content = response.choices.firstOrNull()?.message?.content
                 if (content?.isNotEmpty() == true) {
                     pending.append(content)
-                    if (pending.length >= 20) {
+                    if (pending.length >= increasingChunkSize) {
                         val toEmit = pending.toString()
                         l.info("About to emit into sideEffects flow: {}", toEmit)
                         (sideEffects as MutableSharedFlow<String>).emit(toEmit)
                         pending.clear()
+                        increasingChunkSize *= 3
                     }
                 }
 
@@ -97,6 +99,12 @@ class NodesLLM(
                     model = response.model,
                     usage = response.usage,
                 ).also(streamResponse::store)
+            }
+
+            if (pending.isNotEmpty()) {
+                val toEmit = pending.toString()
+                l.info("About to emit final chunk into sideEffects flow: {}", toEmit)
+                (sideEffects as MutableSharedFlow<String>).emit(toEmit)
             }
         }
 


### PR DESCRIPTION
### Motivation
- The streaming chunk emission used a fixed threshold (`pending.length >= 20`), and the intent is to grow that threshold (e.g. 3x) after each emitted chunk to produce progressively larger chunks.  
- Growing the threshold can cause the final partial chunk to never meet the condition and be dropped, so a mechanism to always emit trailing data at the end of the stream is required.

### Description
- Added a mutable threshold `increasingChunkSize` initialized to `20` and replaced the fixed `20` check with `pending.length >= increasingChunkSize`.  
- After emitting a chunk, the threshold is multiplied by 3 (`increasingChunkSize *= 3`).  
- Added a final flush after stream collection that emits any remaining `pending` text if it is non-empty to avoid losing the last partial chunk.  
- Stream merging and `ChoiceAccumulator` logic were left unchanged.

### Testing
- Ran `./gradlew :composeApp:compileKotlinJvm`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fbc87f9108329a139165afde322ab)