### PR TITLE
Rename PermissionsUseCase to OnboardingUseCase

### DIFF
--- a/composeApp/src/jvmMain/kotlin/ru/gigadesk/ui/main/MainViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/ru/gigadesk/ui/main/MainViewModel.kt
@@ -29,7 +29,7 @@ import ru.gigadesk.ui.main.usecases.ChatUseCase
 import ru.gigadesk.ui.main.usecases.MainUseCaseOutput
 import ru.gigadesk.ui.main.usecases.MainUseCases
 import ru.gigadesk.ui.main.usecases.MainUseCasesFactory
-import ru.gigadesk.ui.main.usecases.PermissionsUseCase
+import ru.gigadesk.ui.main.usecases.OnboardingUseCase
 import ru.gigadesk.ui.main.usecases.SpeechUseCase
 import ru.gigadesk.ui.main.usecases.VoiceInputUseCase
 import java.util.concurrent.atomic.AtomicReference
@@ -52,7 +52,7 @@ class MainViewModel(
     private val chatUseCase: ChatUseCase = useCases.chat
     private val voiceInputUseCase: VoiceInputUseCase = useCases.voiceInput
     private val speechUseCase: SpeechUseCase = useCases.speech
-    private val permissionsUseCase: PermissionsUseCase = useCases.permissions
+    private val permissionsUseCase: OnboardingUseCase = useCases.permissions
 
     init {
         agentRef.set(graphAgent)

--- a/composeApp/src/jvmMain/kotlin/ru/gigadesk/ui/main/usecases/MainUseCasesFactory.kt
+++ b/composeApp/src/jvmMain/kotlin/ru/gigadesk/ui/main/usecases/MainUseCasesFactory.kt
@@ -12,7 +12,7 @@ data class MainUseCases(
     val chat: ChatUseCase,
     val voiceInput: VoiceInputUseCase,
     val speech: SpeechUseCase,
-    val permissions: PermissionsUseCase,
+    val permissions: OnboardingUseCase,
 )
 
 class MainUseCasesFactory(
@@ -32,7 +32,7 @@ class MainUseCasesFactory(
             speechUseCase = speechUseCase,
             ioDispatcher = ioDispatcher,
         )
-        val permissionsUseCase = PermissionsUseCase(
+        val permissionsUseCase = OnboardingUseCase(
             settingsProvider = settingsProvider,
             toolPermissionBroker = toolPermissionBroker,
             speechUseCase = speechUseCase,

--- a/composeApp/src/jvmMain/kotlin/ru/gigadesk/ui/main/usecases/OnboardingUseCase.kt
+++ b/composeApp/src/jvmMain/kotlin/ru/gigadesk/ui/main/usecases/OnboardingUseCase.kt
@@ -17,13 +17,13 @@ import ru.gigadesk.ui.main.MainState
 import ru.gigadesk.ui.main.ToolPermissionDialogData
 import kotlin.math.max
 
-class PermissionsUseCase(
+class OnboardingUseCase(
     private val settingsProvider: SettingsProvider,
     private val toolPermissionBroker: ToolPermissionBroker,
     private val speechUseCase: SpeechUseCase,
     private val relaunchApp: () -> Unit = { AppRelauncher.relaunch() },
 ) {
-    private val l = LoggerFactory.getLogger(PermissionsUseCase::class.java)
+    private val l = LoggerFactory.getLogger(OnboardingUseCase::class.java)
     private var onboardingSpeechStartedAt: Long? = null
     private var permissionWatcherJob: Job? = null
 

--- a/composeApp/src/jvmMain/kotlin/ru/gigadesk/ui/main/usecases/VoiceInputUseCase.kt
+++ b/composeApp/src/jvmMain/kotlin/ru/gigadesk/ui/main/usecases/VoiceInputUseCase.kt
@@ -28,7 +28,7 @@ class VoiceInputUseCase(
     private val gigaVoiceAPI: GigaVoiceAPI,
     private val chatUseCase: ChatUseCase,
     private val speechUseCase: SpeechUseCase,
-    private val permissionsUseCase: PermissionsUseCase,
+    private val permissionsUseCase: OnboardingUseCase,
 ) {
     private val l = LoggerFactory.getLogger(VoiceInputUseCase::class.java)
     private var lastRecognizedText: String? = null


### PR DESCRIPTION
### Motivation
- The use-case implements onboarding flows (onboarding speech, permission dialogs and relaunch), so the name `OnboardingUseCase` better reflects its responsibilities than `PermissionsUseCase`.
- This change clarifies intent in wiring and type names across the JVM UI code.
- No external skills were used for this change.

### Description
- Renamed class and source file from `PermissionsUseCase.kt`/`PermissionsUseCase` to `OnboardingUseCase.kt`/`OnboardingUseCase` and updated the logger reference accordingly.
- Updated the `MainUseCases` data type and `MainUseCasesFactory` to produce and expose `OnboardingUseCase` as the `permissions` entry.
- Updated all JVM-main references and imports to the new type in `MainViewModel` and `VoiceInputUseCase` so usages like `registerNativeHook()` and `runOnboardingIfNeeded()` continue to work.
- Affected files: `OnboardingUseCase.kt` (formerly `PermissionsUseCase.kt`), `MainUseCasesFactory.kt`, `MainViewModel.kt`, and `VoiceInputUseCase.kt`.

### Testing
- Ran `./gradlew :composeApp:compileKotlinJvm` and the build task completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990f94005cc83298784e2a802c9b76f)