### PR TITLE
Add permission approvals for note creation and Telegram actions

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings.xml
@@ -271,6 +271,10 @@
     <string name="permission_move_file">Перемещаем файл?</string>
     <string name="permission_delete_file">Удаляем файл?</string>
     <string name="permission_delete_note">Удаляем заметку?</string>
+    <string name="permission_create_note">Создаем заметку?</string>
+    <string name="permission_telegram_send">Отправляем сообщение в Telegram?</string>
+    <string name="permission_telegram_forward">Пересылаем сообщение в Telegram?</string>
+    <string name="permission_telegram_set_state">Применяем действие к чату Telegram?</string>
 
     <!-- Telegram Login -->
     <string name="telegram_step_phone">Шаг 1: укажите номер телефона</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -271,6 +271,10 @@
     <string name="permission_move_file">Move file?</string>
     <string name="permission_delete_file">Delete file?</string>
     <string name="permission_delete_note">Delete note?</string>
+    <string name="permission_create_note">Create note?</string>
+    <string name="permission_telegram_send">Send Telegram message?</string>
+    <string name="permission_telegram_forward">Forward Telegram message?</string>
+    <string name="permission_telegram_set_state">Apply Telegram chat action?</string>
 
     <!-- Telegram Login -->
     <string name="telegram_step_phone">Step 1: enter phone number</string>

--- a/composeApp/src/jvmMain/kotlin/ru/gigadesk/di/Dependencies.kt
+++ b/composeApp/src/jvmMain/kotlin/ru/gigadesk/di/Dependencies.kt
@@ -127,7 +127,7 @@ val mainDiModule = DI.Module(DiTags.MODULE_MAIN) {
     bindSingleton { ToolSoundConfigDiff(ConfigStore) }
     bindSingleton { ToolInstructionStore(ConfigStore, instance()) }
     bindSingleton { ToolOpenNote(ToolRunBashCommand) }
-    bindSingleton { ToolCreateNote(ToolRunBashCommand) }
+    bindSingleton { ToolCreateNote(ToolRunBashCommand, instance()) }
     bindSingleton { ToolDeleteNote(ToolRunBashCommand, instance()) }
     bindSingleton { ToolListNotes(ToolRunBashCommand) }
     bindSingleton { ToolSearchNotes(ToolRunBashCommand) }
@@ -157,9 +157,9 @@ val mainDiModule = DI.Module(DiTags.MODULE_MAIN) {
     bindSingleton { ToolPresentationRead() }
     bindSingleton { ToolTelegramReadInbox(instance()) }
     bindSingleton { ToolTelegramGetHistory(instance()) }
-    bindSingleton { ToolTelegramSetState(instance()) }
-    bindSingleton { ToolTelegramSend(instance()) }
-    bindSingleton { ToolTelegramForward(instance()) }
+    bindSingleton { ToolTelegramSetState(instance(), instance()) }
+    bindSingleton { ToolTelegramSend(instance(), instance()) }
+    bindSingleton { ToolTelegramForward(instance(), instance()) }
     bindSingleton { ToolTelegramSearch(instance()) }
     bindSingleton { ToolTelegramSavedMessages(instance()) }
 

--- a/composeApp/src/jvmMain/kotlin/ru/gigadesk/tool/notes/ToolCreateNote.kt
+++ b/composeApp/src/jvmMain/kotlin/ru/gigadesk/tool/notes/ToolCreateNote.kt
@@ -5,10 +5,18 @@ import ru.gigadesk.tool.FewShotExample
 import ru.gigadesk.tool.InputParamDescription
 import ru.gigadesk.tool.ReturnParameters
 import ru.gigadesk.tool.ReturnProperty
+import ru.gigadesk.tool.ToolPermissionBroker
+import ru.gigadesk.tool.ToolPermissionResult
 import ru.gigadesk.tool.ToolRunBashCommand
 import ru.gigadesk.tool.ToolSetup
+import gigadesk.composeapp.generated.resources.Res
+import gigadesk.composeapp.generated.resources.*
+import org.jetbrains.compose.resources.getString
 
-class ToolCreateNote(private val bash: ToolRunBashCommand) : ToolSetup<ToolCreateNote.Input> {
+class ToolCreateNote(
+    private val bash: ToolRunBashCommand,
+    private val permissionBroker: ToolPermissionBroker? = null,
+) : ToolSetup<ToolCreateNote.Input> {
     data class Input(
         @InputParamDescription("Text of note")
         val noteText: String
@@ -26,6 +34,16 @@ class ToolCreateNote(private val bash: ToolRunBashCommand) : ToolSetup<ToolCreat
             "result" to ReturnProperty("string", "Operation status")
         )
     )
+
+    override suspend fun suspendInvoke(input: Input): String {
+        val result = permissionBroker?.requestPermission(
+            getString(Res.string.permission_create_note),
+            linkedMapOf("noteText" to input.noteText)
+        )
+        if (result is ToolPermissionResult.No) return result.msg
+        return invoke(input)
+    }
+
     override fun invoke(input: Input): String {
         if (input.noteText.isBlank()) throw BadInputException("Note text cannot be empty")
         bash.invoke(

--- a/composeApp/src/jvmMain/kotlin/ru/gigadesk/tool/telegram/ToolTelegramForward.kt
+++ b/composeApp/src/jvmMain/kotlin/ru/gigadesk/tool/telegram/ToolTelegramForward.kt
@@ -11,10 +11,16 @@ import ru.gigadesk.tool.FewShotExample
 import ru.gigadesk.tool.InputParamDescription
 import ru.gigadesk.tool.ReturnParameters
 import ru.gigadesk.tool.ReturnProperty
+import ru.gigadesk.tool.ToolPermissionBroker
+import ru.gigadesk.tool.ToolPermissionResult
 import ru.gigadesk.tool.ToolSetup
+import gigadesk.composeapp.generated.resources.Res
+import gigadesk.composeapp.generated.resources.*
+import org.jetbrains.compose.resources.getString
 
 class ToolTelegramForward(
     private val telegramService: TelegramService,
+    private val permissionBroker: ToolPermissionBroker? = null,
 ) : ToolSetup<ToolTelegramForward.Input> {
     private val settingsProvider: SettingsProvider by lazy { SettingsProviderImpl(ConfigStore) }
 
@@ -62,6 +68,16 @@ class ToolTelegramForward(
                 "SafeMode enabled: ask user confirmation and repeat call with confirmed=true"
             )
         }
+
+        val result = permissionBroker?.requestPermission(
+            getString(Res.string.permission_telegram_forward),
+            linkedMapOf(
+                "fromChat" to input.fromChat,
+                "toChat" to input.toChat,
+                "messageId" to input.messageId,
+            )
+        )
+        if (result is ToolPermissionResult.No) return result.msg
 
         val forwarded = runCatching {
             telegramService.forwardMessage(input.fromChat, input.toChat, input.messageId)

--- a/composeApp/src/jvmMain/kotlin/ru/gigadesk/tool/telegram/ToolTelegramSend.kt
+++ b/composeApp/src/jvmMain/kotlin/ru/gigadesk/tool/telegram/ToolTelegramSend.kt
@@ -8,10 +8,16 @@ import ru.gigadesk.tool.FewShotExample
 import ru.gigadesk.tool.InputParamDescription
 import ru.gigadesk.tool.ReturnParameters
 import ru.gigadesk.tool.ReturnProperty
+import ru.gigadesk.tool.ToolPermissionBroker
+import ru.gigadesk.tool.ToolPermissionResult
 import ru.gigadesk.tool.ToolSetup
+import gigadesk.composeapp.generated.resources.Res
+import gigadesk.composeapp.generated.resources.*
+import org.jetbrains.compose.resources.getString
 
 class ToolTelegramSend(
     private val telegramService: TelegramService,
+    private val permissionBroker: ToolPermissionBroker? = null,
 ) : ToolSetup<ToolTelegramSend.Input> {
 
     data class Input(
@@ -47,6 +53,15 @@ class ToolTelegramSend(
         if (input.text.isBlank()) {
             throw BadInputException("text is required")
         }
+
+        val result = permissionBroker?.requestPermission(
+            getString(Res.string.permission_telegram_send),
+            linkedMapOf(
+                "targetName" to input.targetName,
+                "text" to input.text,
+            )
+        )
+        if (result is ToolPermissionResult.No) return result.msg
 
         val sent = runCatching {
             telegramService.sendMessageToTarget(input.targetName, input.text)

--- a/composeApp/src/jvmMain/kotlin/ru/gigadesk/tool/telegram/ToolTelegramSetState.kt
+++ b/composeApp/src/jvmMain/kotlin/ru/gigadesk/tool/telegram/ToolTelegramSetState.kt
@@ -12,10 +12,16 @@ import ru.gigadesk.tool.FewShotExample
 import ru.gigadesk.tool.InputParamDescription
 import ru.gigadesk.tool.ReturnParameters
 import ru.gigadesk.tool.ReturnProperty
+import ru.gigadesk.tool.ToolPermissionBroker
+import ru.gigadesk.tool.ToolPermissionResult
 import ru.gigadesk.tool.ToolSetup
+import gigadesk.composeapp.generated.resources.Res
+import gigadesk.composeapp.generated.resources.*
+import org.jetbrains.compose.resources.getString
 
 class ToolTelegramSetState(
     private val telegramService: TelegramService,
+    private val permissionBroker: ToolPermissionBroker? = null,
 ) : ToolSetup<ToolTelegramSetState.Input> {
     private val settingsProvider: SettingsProvider by lazy { SettingsProviderImpl(ConfigStore) }
 
@@ -65,6 +71,15 @@ class ToolTelegramSetState(
                 "SafeMode enabled: ask user confirmation and repeat call with confirmed=true"
             )
         }
+
+        val result = permissionBroker?.requestPermission(
+            getString(Res.string.permission_telegram_set_state),
+            linkedMapOf(
+                "chatName" to input.chatName,
+                "action" to input.action.name,
+            )
+        )
+        if (result is ToolPermissionResult.No) return result.msg
 
         val action = when (input.action) {
             Action.Mute -> TelegramChatAction.Mute


### PR DESCRIPTION
### Motivation

- Bring note creation and Telegram mutating tools in line with the existing dangerous-action approval flow used by file tools (e.g. `ToolDeleteFile`), so UI/agent can prompt/record explicit user permission before performing potentially destructive or privacy-sensitive actions.

### Description

- Added permission broker checks to `ToolCreateNote`, `ToolTelegramSend`, `ToolTelegramForward`, and `ToolTelegramSetState` by injecting `ToolPermissionBroker?` and calling `requestPermission` in `suspendInvoke` before executing the action.
- Followed existing approval pattern: return `result.msg` when `requestPermission` yields `ToolPermissionResult.No` and proceed to `invoke` otherwise.
- Registered the `ToolPermissionBroker` instance in DI bindings for the updated tools by wiring the broker into `Dependencies.kt` (so tools receive `instance()` where applicable).
- Added localized permission prompt strings in EN and RU resource files: `permission_create_note`, `permission_telegram_send`, `permission_telegram_forward`, and `permission_telegram_set_state`.

### Testing

- Compiled the JVM module to validate changes with `./gradlew :composeApp:compileKotlinJvm`, which completed successfully (`BUILD SUCCESSFUL`).
- No new automated unit tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994b5ab1a6883299f0d5803603c86b6)