### PR TITLE
Add Log4j-to-SLF4J bridge to route Log4j2 API to Logback

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -140,6 +140,7 @@ kotlin {
             implementation(libs.jackson)
             implementation(libs.logback)
             implementation(libs.slfj)
+            implementation(libs.log4j.to.slf4j)
 
             // ktor client (core + cio + logging + auth + content-negotiation + serialization)
             implementation(libs.bundles.ktorClient)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ ktor = "3.2.2"
 letsPlot-core = "4.0.0"
 letsPlot-kotlin = "4.6.0"
 logback = "1.5.18"
+log4j = "2.24.3"
 lucene = "9.9.2"
 markdown = "0.27.0"
 mockk = "1.13.11"
@@ -71,6 +72,7 @@ letsPlot-common = { module = "org.jetbrains.lets-plot:lets-plot-common", version
 letsPlot-kotlin = { module = "org.jetbrains.lets-plot:lets-plot-kotlin-jvm", version.ref = "letsPlot-kotlin" }
 letsPlot-imageExport = { module = "org.jetbrains.lets-plot:lets-plot-image-export", version.ref = "letsPlot-core" }
 logback = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
+log4j-to-slf4j = { module = "org.apache.logging.log4j:log4j-to-slf4j", version.ref = "log4j" }
 lucene-core = { module = "org.apache.lucene:lucene-core", version.ref = "lucene" }
 markdown = { module = "com.mikepenz:multiplatform-markdown-renderer", version.ref = "markdown" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }


### PR DESCRIPTION
### Motivation
- Stop the `Log4j2 could not find a logging implementation` warning by routing Log4j2 API calls from transitive dependencies into the existing SLF4J/Logback backend.

### Description
- Add a `log4j` version and `log4j-to-slf4j` library entry in `gradle/libs.versions.toml` and wire `implementation(libs.log4j.to.slf4j)` into `composeApp` JVM main dependencies in `composeApp/build.gradle.kts`.

### Testing
- Ran `./gradlew :composeApp:compileKotlinJvm -q`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994b4542a18832984212bb018b2ad1e)