### PR TITLE
Add exponential backoff for onboarding input-permission retries

### DIFF
--- a/composeApp/src/jvmMain/kotlin/ru/gigadesk/ui/main/usecases/OnboardingUseCase.kt
+++ b/composeApp/src/jvmMain/kotlin/ru/gigadesk/ui/main/usecases/OnboardingUseCase.kt
@@ -17,6 +17,7 @@ import ru.gigadesk.ui.main.ChatMessage
 import ru.gigadesk.ui.main.MainState
 import ru.gigadesk.ui.main.ToolPermissionDialogData
 import kotlin.math.max
+import kotlin.math.min
 import gigadesk.composeapp.generated.resources.Res
 import gigadesk.composeapp.generated.resources.*
 import org.jetbrains.compose.resources.getString
@@ -106,12 +107,16 @@ class OnboardingUseCase(
                 )
             }
 
+            var retryDelayMs = ONBOARDING_PERMISSION_RETRY_INITIAL_DELAY_MS
             while (isActive) {
-                delay(4_000)
                 if (canRegisterNativeHookNow()) {
                     l.info("Input monitoring permission granted, relaunching application")
                     relaunchApp()
+                    return@launch
                 }
+
+                delay(retryDelayMs)
+                retryDelayMs = min(retryDelayMs * 2, ONBOARDING_PERMISSION_RETRY_MAX_DELAY_MS)
             }
         }
     }
@@ -136,5 +141,7 @@ class OnboardingUseCase(
 
     companion object {
         private const val ONBOARDING_PERMISSION_DELAY_MS = 100000
+        private const val ONBOARDING_PERMISSION_RETRY_INITIAL_DELAY_MS = 4_000L
+        private const val ONBOARDING_PERMISSION_RETRY_MAX_DELAY_MS = 64_000L
     }
 }


### PR DESCRIPTION
### Motivation
- Improve the onboarding flow that polls for native input-monitoring permission by replacing a fixed retry interval with exponential backoff to reduce resource usage and be less aggressive. 
- Preserve the existing initial onboarding delay before the first permission prompt so the UX doesn't change. 
- Ensure the watcher coroutine exits immediately once permission is detected to avoid unnecessary work.

### Description
- Reworked `handleMissingInputMonitoringPermission` in `OnboardingUseCase` to use an exponentially increasing retry delay starting at `4_000ms` and doubling up to a `64_000ms` cap. 
- Added `ONBOARDING_PERMISSION_RETRY_INITIAL_DELAY_MS` and `ONBOARDING_PERMISSION_RETRY_MAX_DELAY_MS` constants and imported `kotlin.math.min`. 
- Check for permission immediately in the loop and `return` from the watcher coroutine (and trigger `relaunchApp`) as soon as permission is detected. 
- Kept the existing initial `ONBOARDING_PERMISSION_DELAY_MS` behavior before the first prompt.

### Testing
- Attempted `./gradlew :composeApp:test` which failed due to the task not being available in this project layout. 
- Ran the JVM tests with `./gradlew :composeApp:jvmTest --tests "ru.gigadesk.ui.main.MainViewModelTest.missing input monitoring permission updates status message"`, which compiled and executed but the test run failed with an `UnsatisfiedLinkError` originating from the native hook dependency, preventing completion of the unit test in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995e7056dfc8329ab246718df064b14)