### PR TITLE
Update localized resource branding to Souz AI / Союз ИИ

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings.xml
@@ -1,9 +1,9 @@
 <resources>
-    <string name="app_name">Союз с ИИ</string>
+    <string name="app_name">Союз ИИ</string>
     <string name="app_title_short">Союз</string>
 
     <!-- Tray -->
-    <string name="tray_tooltip">Gigadesk AI</string>
+    <string name="tray_tooltip">Союз ИИ</string>
     <string name="tray_show_hide">Показать/Скрыть</string>
     <string name="tray_mute">Выключить звук</string>
     <string name="tray_exit">Выход</string>
@@ -139,7 +139,7 @@
     <string name="setup_hint_keys_found">Найдено ключей: %d. Можно продолжать.</string>
     <string name="setup_hint_voice_required">Голосовые команды используют SaluteSpeech API. Если хотите общаться голосом, обязательно добавьте этот ключ.</string>
     <string name="setup_hint_voice_unavailable">Голосовые команды в этой сборке пока недоступны.</string>
-    <string name="button_open_gigadesk">Открыть GigaDesk</string>
+    <string name="button_open_gigadesk">Открыть Союз ИИ</string>
     <string name="button_add_key_to_proceed">Добавьте хотя бы один ключ</string>
 
     <!-- Common -->
@@ -197,8 +197,8 @@
     <string name="label_context">Контекст</string>
 
     <!-- Onboarding -->
-    <string name="onboarding_speech_text">Привет! Я ГигаДэ́ск! умный помощник на твоем компьютере... Сейчас я попрошу доступы к приложениям, системе и файлам, чтобы работать корректно... Я умею пользоваться браузером, работать с почтой и календарем, работать с файлами на вашем ПК, объяснить и переписать выделенный текст, открывать приложения, создавать заметки, отвечать на вопросы, строить графики, диаграммы на основе данных.</string>
-    <string name="onboarding_display_text">Привет! Я GigaDesk, умный помощник на твоем компьютере.\nСейчас я попрошу доступы к приложениям, системе и файлам, чтобы работать корректно.\nЯ умею:\n- Пользоваться браузером\n- Работать с почтой и календарем\n- Работать с файлами на вашем ПК\n- Объяснить и переписать выделенный текст\n- Открывать приложения, создавать заметки, отвечать на вопросы\n- Строить графики, диаграммы на основе данных\n\n\nДля запуска голосового ввода - зажми правый opt(alt)\nДля очистки контекста беседы - нажми X\nДля скрытия окна - нажми Х два раза</string>
+    <string name="onboarding_speech_text">Привет! Я Союз ИИ! умный помощник на твоем компьютере... Сейчас я попрошу доступы к приложениям, системе и файлам, чтобы работать корректно... Я умею пользоваться браузером, работать с почтой и календарем, работать с файлами на вашем ПК, объяснить и переписать выделенный текст, открывать приложения, создавать заметки, отвечать на вопросы, строить графики, диаграммы на основе данных.</string>
+    <string name="onboarding_display_text">Привет! Я Союз ИИ, умный помощник на твоем компьютере.\nСейчас я попрошу доступы к приложениям, системе и файлам, чтобы работать корректно.\nЯ умею:\n- Пользоваться браузером\n- Работать с почтой и календарем\n- Работать с файлами на вашем ПК\n- Объяснить и переписать выделенный текст\n- Открывать приложения, создавать заметки, отвечать на вопросы\n- Строить графики, диаграммы на основе данных\n\n\nДля запуска голосового ввода - зажми правый opt(alt)\nДля очистки контекста беседы - нажми X\nДля скрытия окна - нажми Х два раза</string>
     <string name="onboarding_input_permission_request">Разрешите доступ к мониторингу ввода в настройках macOS — после подтверждения приложение перезапустится автоматически</string>
 
     <!-- Voice Input -->
@@ -262,7 +262,7 @@
     <string name="error_balance_unavailable_anthropic">Баланс для Anthropic недоступен</string>
     <string name="error_balance_unavailable_openai">Баланс для OpenAI недоступен</string>
     <string name="error_failed_send_logs">Не удалось отправить логи</string>
-    <string name="support_email_subject">Логи gigadesk</string>
+    <string name="support_email_subject">Логи Союз ИИ</string>
     <string name="support_email_body">Добрый день! Во вложении файлы логов приложения.</string>
     <string name="support_email_success_format">Письмо создано. Если вложение не появилось автоматически, приложите файл %s вручную.</string>
 

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -1,9 +1,9 @@
 <resources>
-    <string name="app_name">Gigadesk AI</string>
+    <string name="app_name">Souz AI</string>
     <string name="app_title_short">Union</string>
 
     <!-- Tray -->
-    <string name="tray_tooltip">Gigadesk AI</string>
+    <string name="tray_tooltip">Souz AI</string>
     <string name="tray_show_hide">Show/Hide</string>
     <string name="tray_mute">Mute</string>
     <string name="tray_exit">Exit</string>
@@ -139,7 +139,7 @@
     <string name="setup_hint_keys_found">Keys found: %d. You can continue.</string>
     <string name="setup_hint_voice_required">Voice commands use SaluteSpeech API. If you want to use voice, be sure to add this key.</string>
     <string name="setup_hint_voice_unavailable">Voice commands are not available in this build yet.</string>
-    <string name="button_open_gigadesk">Open GigaDesk</string>
+    <string name="button_open_gigadesk">Open Souz AI</string>
     <string name="button_add_key_to_proceed">Add at least one key</string>
 
     <!-- Common -->
@@ -197,8 +197,8 @@
     <string name="label_context">Context</string>
 
     <!-- Onboarding -->
-    <string name="onboarding_speech_text">Hello! I am GigaDesk, your smart assistant on your computer... I will now ask for permissions to access applications, the system, and files to work correctly... I can use the browser, work with mail and calendar, work with files on your PC, explain and rewrite selected text, open applications, create notes, answer questions, and build charts and diagrams based on data.</string>
-    <string name="onboarding_display_text">Hello! I am GigaDesk, a smart assistant on your computer.\nNow I will ask for permissions to access applications, the system, and files to work correctly.\nI can:\n- Use the browser\n- Work with mail and calendar\n- Work with files on your PC\n- Explain and rewrite selected text\n- Open applications, create notes, answer questions\n- Build charts and diagrams based on data\n\n\nTo start voice input - hold right opt(alt)\nTo clear conversation context - press X\nTo hide the window - press X twice</string>
+    <string name="onboarding_speech_text">Hello! I am Souz AI, your smart assistant on your computer... I will now ask for permissions to access applications, the system, and files to work correctly... I can use the browser, work with mail and calendar, work with files on your PC, explain and rewrite selected text, open applications, create notes, answer questions, and build charts and diagrams based on data.</string>
+    <string name="onboarding_display_text">Hello! I am Souz AI, a smart assistant on your computer.\nNow I will ask for permissions to access applications, the system, and files to work correctly.\nI can:\n- Use the browser\n- Work with mail and calendar\n- Work with files on your PC\n- Explain and rewrite selected text\n- Open applications, create notes, answer questions\n- Build charts and diagrams based on data\n\n\nTo start voice input - hold right opt(alt)\nTo clear conversation context - press X\nTo hide the window - press X twice</string>
     <string name="onboarding_input_permission_request">Allow access to input monitoring in macOS settings — the application will restart automatically after confirmation</string>
 
     <!-- Voice Input -->
@@ -262,7 +262,7 @@
     <string name="error_balance_unavailable_anthropic">Balance unavailable for Anthropic</string>
     <string name="error_balance_unavailable_openai">Balance unavailable for OpenAI</string>
     <string name="error_failed_send_logs">Failed to send logs</string>
-    <string name="support_email_subject">Gigadesk logs</string>
+    <string name="support_email_subject">Souz AI logs</string>
     <string name="support_email_body">Hello! Attached are the application log files.</string>
     <string name="support_email_success_format">Email created. If the attachment did not appear automatically, please attach the file %s manually.</string>
 


### PR DESCRIPTION
### Motivation
- Replace legacy "Gigadesk" branding in the common Compose Multiplatform resources with the new product names for English and Russian editions.
- Ensure onboarding, tray tooltip, open-button labels and support email subject reflect the new brand in both locales.
- Fix a small Russian onboarding variant that still referenced the old branding form.

### Description
- Updated `composeApp/src/commonMain/composeResources/values/strings.xml` to replace English branding values with `Souz AI` for `app_name`, `tray_tooltip`, `button_open_gigadesk`, onboarding texts, and `support_email_subject`.
- Updated `composeApp/src/commonMain/composeResources/values-ru/strings.xml` to replace Russian branding values with `Союз ИИ` for `app_name`, `tray_tooltip`, `button_open_gigadesk`, onboarding texts, and `support_email_subject`.
- Adjusted the Russian onboarding intro phrase to a consistent `Союз ИИ` form and performed a targeted text replacement to remove remaining mentions of the old brand.

### Testing
- Ran `rg` searches across the two modified resource files to confirm there are no remaining occurrences of the old branding terms, which returned only the updated `Souz AI` / `Союз ИИ` entries.
- Inspected the modified files (`nl -ba` output) to verify the onboarding and UI strings were updated as intended and found no regressions in surrounding resource keys.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995ea74d9208329b96a5a58b19f09b6)