### PR TITLE
Handle Escape key back navigation outside Setup/Main

### DIFF
--- a/composeApp/src/jvmMain/kotlin/ru/souz/App.kt
+++ b/composeApp/src/jvmMain/kotlin/ru/souz/App.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.*
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -44,6 +45,32 @@ fun App(
     val snackbarScope = rememberCoroutineScope()
     val isOnline = remember { mutableStateOf(true) }
 
+    fun navigateBackFromScreen(screen: Screen): Boolean {
+        return when (screen) {
+            Setup,
+            Main,
+            -> false
+
+            Settings -> {
+                currentScreen = Main
+                true
+            }
+
+            is Tools -> {
+                currentScreen = Settings
+                true
+            }
+
+            is ToolDetails -> {
+                if (toolsScreen == null) {
+                    toolsScreen = Tools()
+                }
+                currentScreen = toolsScreen ?: Tools()
+                true
+            }
+        }
+    }
+
     LaunchedEffect(Unit) {
         while (true) {
             val online = withContext(Dispatchers.IO) { isInternetAvailable() }
@@ -60,7 +87,17 @@ fun App(
             color = Color.Transparent
         ) {
             SharedTransitionLayout {
-                Box(modifier = Modifier.fillMaxSize()) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .onPreviewKeyEvent { event ->
+                            if (event.type == KeyEventType.KeyDown && event.key == Key.Escape) {
+                                navigateBackFromScreen(currentScreen)
+                            } else {
+                                false
+                            }
+                        }
+                ) {
                     AnimatedContent(
                         targetState = currentScreen,
                         transitionSpec = {


### PR DESCRIPTION
### Motivation
- Provide a consistent Escape key behavior: pressing Esc should close the current screen and go back to the previous one for all top-level screens except Onboarding (Setup) and Main.
- Avoid scattering per-screen Escape handlers by centralizing navigation at the root `App` component.

### Description
- Added a `navigateBackFromScreen(screen: Screen): Boolean` helper in `App.kt` that maps `Settings -> Main`, `Tools -> Settings`, and `ToolDetails -> active Tools`, and returns `false` for `Setup` and `Main`.
- Wired a root `onPreviewKeyEvent` on the main `Box` to capture `Key.Escape` and invoke `navigateBackFromScreen` so Esc performs back navigation from non-excluded screens.
- Consolidated required imports (`androidx.compose.ui.input.key.*`) and kept existing screen-state logic and `toolsScreen` instance restoration behavior.

### Testing
- Ran `./gradlew :composeApp:compileKotlinJvm --no-daemon` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a46c7dfcd48329a3acf0a936cb4795)