### PR TITLE
Handle Escape navigation for non-main screens

### DIFF
--- a/composeApp/src/jvmMain/kotlin/ru/souz/App.kt
+++ b/composeApp/src/jvmMain/kotlin/ru/souz/App.kt
@@ -13,6 +13,11 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -44,6 +49,27 @@ fun App(
     val snackbarScope = rememberCoroutineScope()
     val isOnline = remember { mutableStateOf(true) }
 
+    fun goBackFromCurrentScreen(): Boolean {
+        return when (val screen = currentScreen) {
+            Setup, Main -> false
+            Settings -> {
+                currentScreen = Main
+                true
+            }
+            is Tools -> {
+                currentScreen = Settings
+                true
+            }
+            is ToolDetails -> {
+                if (toolsScreen == null) {
+                    toolsScreen = Tools()
+                }
+                currentScreen = toolsScreen ?: Tools()
+                true
+            }
+        }
+    }
+
     LaunchedEffect(Unit) {
         while (true) {
             val online = withContext(Dispatchers.IO) { isInternetAvailable() }
@@ -60,7 +86,17 @@ fun App(
             color = Color.Transparent
         ) {
             SharedTransitionLayout {
-                Box(modifier = Modifier.fillMaxSize()) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .onPreviewKeyEvent { event ->
+                            if (event.type == KeyEventType.KeyDown && event.key == Key.Escape) {
+                                goBackFromCurrentScreen()
+                            } else {
+                                false
+                            }
+                        }
+                ) {
                     AnimatedContent(
                         targetState = currentScreen,
                         transitionSpec = {


### PR DESCRIPTION
### Motivation
- Make the Escape key behave consistently across the app by closing non-primary screens and returning to the previous screen while keeping `Setup` (onboarding) and `Main` unaffected.

### Description
- Added key input imports and attached a root-level `onPreviewKeyEvent` to the app `Box` to intercept `Key.Escape` presses.
- Implemented `goBackFromCurrentScreen()` which maps `Settings -> Main`, `Tools -> Settings`, and `ToolDetails -> Tools` (reusing the existing tools screen id when available), and returns `false` for `Setup` and `Main`.
- Kept existing animated content and navigation behavior unchanged and centralized Escape handling at the app root (`App` composable).

### Testing
- Ran `./gradlew :composeApp:compileKotlinJvm --console=plain` which completed successfully (build warnings only); compile step passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a46c7dfcd48329a3acf0a936cb4795)