### PR TITLE
Add MCP risk warning above MCP servers JSON field

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings.xml
@@ -70,6 +70,7 @@
     <string name="label_voice_selection">Выбор голоса</string>
     <string name="button_select_voice">Выбрать голос</string>
     <string name="label_mcp_servers">MCP servers JSON</string>
+    <string name="warning_mcp_risk">Предупреждение: используйте MCP на свой риск. MCP может быть небезопасным и дорогим в использовании.</string>
     <string name="hint_restart_required">Изменения применятся после перезапуска приложения</string>
 
     <!-- Keys Settings -->

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -74,6 +74,7 @@
     <string name="label_voice_selection">Voice selection</string>
     <string name="button_select_voice">Select voice</string>
     <string name="label_mcp_servers">MCP servers JSON</string>
+    <string name="warning_mcp_risk">Warning: use MCP at your own risk. MCP can be insecure and expensive to use.</string>
     <string name="hint_restart_required">Changes will apply after application restart</string>
 
     <!-- Keys Settings -->

--- a/composeApp/src/jvmMain/kotlin/ru/souz/ui/settings/SettingsContent.kt
+++ b/composeApp/src/jvmMain/kotlin/ru/souz/ui/settings/SettingsContent.kt
@@ -476,6 +476,11 @@ fun GeneralSettingsContent(
             
             Column(verticalArrangement = Arrangement.spacedBy(SettingsSpacing.labelToFieldSpacing)) {
                 Text(
+                    text = stringResource(Res.string.warning_mcp_risk),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error
+                )
+                Text(
                     text = stringResource(Res.string.label_mcp_servers),
                      style = MaterialTheme.typography.labelMedium.copy(
                          fontSize = 14.sp,


### PR DESCRIPTION
### Motivation
- Warn users that MCP should be used at their own risk and that it can be insecure and expensive, by surfacing a clear note above the MCP servers configuration in Settings.

### Description
- Inserted an error-styled `Text` composable above the MCP servers JSON input in `SettingsContent.kt` and added `warning_mcp_risk` string resources to `composeResources/values/strings.xml` and `values-ru/strings.xml` (English and Russian localizations).

### Testing
- Ran `./gradlew :composeApp:compileKotlinJvm`, which started but did not produce a final completion line in the captured environment output, so full build confirmation is inconclusive; attempted an automated Playwright screenshot, which failed with `ERR_EMPTY_RESPONSE` because the desktop Compose UI is not served over HTTP in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abf60a88c8832983244d973607ef32)