### PR TITLE
Add additional default forbidden folders in SettingsProvider

### DIFF
--- a/composeApp/src/jvmMain/kotlin/ru/souz/db/SettingsProvider.kt
+++ b/composeApp/src/jvmMain/kotlin/ru/souz/db/SettingsProvider.kt
@@ -331,7 +331,15 @@ class SettingsProviderImpl(private val configStore: ConfigStore) : SettingsProvi
         private const val MCP_SERVERS_FILE = "MCP_SERVERS_FILE"
         const val REGION_RU = "ru"
         const val REGION_EN = "en"
-        private val DEFAULT_FORBIDDEN_FOLDERS = listOf("~/Library/")
+        private val DEFAULT_FORBIDDEN_FOLDERS = listOf(
+            "~/Library/",
+            "~/.bash_history",
+            "~/.zsh_history",
+            "~/.zprofile",
+            "~/.zshenv",
+            "~/.bashprofile",
+            "~/.ssh",
+        )
     }
 }
 


### PR DESCRIPTION
### Motivation
- Prevent indexing or accidental access to common sensitive user files and shell history by expanding the default forbidden folders list in settings.

### Description
- Update `DEFAULT_FORBIDDEN_FOLDERS` in `composeApp/src/jvmMain/kotlin/ru/souz/db/SettingsProvider.kt` to include `~/.bash_history`, `~/.zsh_history`, `~/.zprofile`, `~/.zshenv`, `~/.bashprofile`, and `~/.ssh` in addition to the existing `~/Library/` entry.

### Testing
- Ran a project build and unit tests with `./gradlew build`, and the build and tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aca43dc4148329952be63c0943b32f)