### PR TITLE
ci: remove main push trigger from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: CI-Tests
 
 on:
   pull_request:
-  push:
-    branches: [main]
 
 jobs:
   tests:


### PR DESCRIPTION
### Motivation
- Limit CI runs to `pull_request` events and prevent automatic runs on direct `push` to `main` to reduce unnecessary or duplicate workflows.

### Description
- Remove the `push` trigger (including `branches: [main]`) from `.github/workflows/ci.yml`, leaving the workflow triggered only on `pull_request`.

### Testing
- No automated tests were executed because this change only updates workflow trigger configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd2b5bed9c8329b149aa3ff8e2bb53)