### PR TITLE
Fix flaky ToolDeleteFile disapproval test by using runBlocking

### DIFF
--- a/composeApp/src/jvmTest/kotlin/tool/files/ToolTest.kt
+++ b/composeApp/src/jvmTest/kotlin/tool/files/ToolTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeoutOrNull
 import org.slf4j.LoggerFactory
@@ -470,8 +471,8 @@ class ToolTest {
     }
 
     @Test
-    fun `test ToolDeleteFile returns disapproved when user rejects action`() = runTest {
-        if (!hasOpenGlRuntime()) return@runTest
+    fun `test ToolDeleteFile returns disapproved when user rejects action`() = runBlocking {
+        if (!hasOpenGlRuntime()) return@runBlocking
         val tempDir = createTempDirectory()
         try {
             val filesToolUtil = createFilesToolUtil(listOf("~/Library/"))


### PR DESCRIPTION
### Motivation

- The `ToolDeleteFile` disapproval test was flaky due to coroutine-test scheduler state causing `UncaughtExceptionsBeforeTest` before the test started. 
- Use a plain coroutine scope to avoid interference from the test scheduler while preserving the async permission flow.

### Description

- Replaced `runTest` with `runBlocking` for the test `ToolDeleteFile returns disapproved when user rejects action` in `composeApp/src/jvmTest/kotlin/tool/files/ToolTest.kt` and added the required `runBlocking` import. 
- Kept the existing `async`/permission request and `permissionBroker.resolve(...)` flow unchanged so the test logic remains the same.

### Testing

- Attempted to run the single test with `./gradlew :composeApp:jvmTest --tests "tool.files.ToolTest.test ToolDeleteFile returns disapproved when user rejects action"`, but the build timed out during compilation in this environment and the test run could not complete. 
- No automated test failures were observed from local edits prior to the timeout, but full verification requires a complete CI/test run due to the compilation timeout here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd560369608329b43684969ff17cf3)