### PR TITLE
Introduce runtime config and unified BackendAgentTurn model for agent executions

### DIFF
--- a/backend/src/main/kotlin/ru/souz/backend/agent/model/BackendAgentModels.kt
+++ b/backend/src/main/kotlin/ru/souz/backend/agent/model/BackendAgentModels.kt
@@ -1,5 +1,8 @@
 package ru.souz.backend.agent.model
 
+import java.util.UUID
+import ru.souz.backend.execution.model.AgentExecutionRuntimeConfig
+
 /** Stable backend conversation identifier composed from user and conversation ids. */
 data class AgentConversationKey(
     val userId: String,
@@ -18,3 +21,17 @@ internal data class BackendConversationTurnRequest(
     val systemPrompt: String? = null,
     val streamingMessages: Boolean? = null,
 )
+
+internal data class BackendAgentTurn(
+    val userId: String,
+    val chatId: UUID,
+    val executionId: UUID,
+    val conversationId: String,
+    val input: BackendAgentTurnInput,
+    val config: AgentExecutionRuntimeConfig,
+)
+
+internal sealed interface BackendAgentTurnInput {
+    data class UserMessage(val content: String) : BackendAgentTurnInput
+    data class OptionAnswer(val optionId: UUID, val payload: String) : BackendAgentTurnInput
+}

--- a/backend/src/main/kotlin/ru/souz/backend/execution/model/AgentExecutionRuntimeConfig.kt
+++ b/backend/src/main/kotlin/ru/souz/backend/execution/model/AgentExecutionRuntimeConfig.kt
@@ -1,0 +1,12 @@
+package ru.souz.backend.execution.model
+
+data class AgentExecutionRuntimeConfig(
+    val modelAlias: String,
+    val contextSize: Int,
+    val temperature: Float?,
+    val locale: String,
+    val timeZone: String,
+    val systemPrompt: String?,
+    val streamingMessages: Boolean,
+    val showToolEvents: Boolean,
+)

--- a/backend/src/main/kotlin/ru/souz/backend/execution/service/AgentExecutionRequestFactory.kt
+++ b/backend/src/main/kotlin/ru/souz/backend/execution/service/AgentExecutionRequestFactory.kt
@@ -3,12 +3,14 @@ package ru.souz.backend.execution.service
 import java.time.Instant
 import java.util.UUID
 import ru.souz.backend.agent.model.AgentConversationKey
-import ru.souz.backend.agent.model.BackendConversationTurnRequest
+import ru.souz.backend.agent.model.BackendAgentTurn
+import ru.souz.backend.agent.model.BackendAgentTurnInput
 import ru.souz.backend.agent.runtime.BackendAgentRuntimeEventSink
 import ru.souz.backend.chat.repository.MessageRepository
 import ru.souz.backend.config.BackendFeatureFlags
 import ru.souz.backend.events.service.AgentEventService
 import ru.souz.backend.execution.model.AgentExecution
+import ru.souz.backend.execution.model.AgentExecutionRuntimeConfig
 import ru.souz.backend.execution.model.AgentExecutionStatus
 import ru.souz.backend.execution.repository.AgentExecutionRepository
 import ru.souz.backend.http.BackendV1Exception
@@ -21,18 +23,17 @@ import ru.souz.backend.toolcall.repository.ToolCallRepository
 import ru.souz.llms.restJsonMapper
 
 internal data class PreparedChatTurn(
-    val normalizedClientMessageId: String?,
     val effectiveSettings: EffectiveUserSettings,
     val execution: AgentExecution,
     val conversationKey: AgentConversationKey,
-    val runtimeRequest: BackendConversationTurnRequest,
+    val turn: BackendAgentTurn,
     val userMessageMetadata: Map<String, String>,
     val shouldReturnRunning: Boolean,
 )
 
 internal data class PreparedContinuationTurn(
     val conversationKey: AgentConversationKey,
-    val runtimeRequest: BackendConversationTurnRequest,
+    val turn: BackendAgentTurn,
     val streamingMessagesEnabled: Boolean,
     val toolEventsEnabled: Boolean,
 )
@@ -41,202 +42,85 @@ internal class AgentExecutionRequestFactory(
     private val effectiveSettingsResolver: EffectiveSettingsResolver,
     private val featureFlags: BackendFeatureFlags,
 ) {
-    suspend fun prepareChatTurn(
-        userId: String,
-        chatId: UUID,
-        content: String,
-        clientMessageId: String? = null,
-        requestOverrides: UserSettingsOverrides = UserSettingsOverrides(),
-    ): PreparedChatTurn {
+    suspend fun prepareChatTurn(userId: String, chatId: UUID, content: String, clientMessageId: String? = null, requestOverrides: UserSettingsOverrides = UserSettingsOverrides()): PreparedChatTurn {
         val effectiveSettings = effectiveSettingsResolver.resolve(userId, requestOverrides)
         val normalizedClientMessageId = clientMessageId?.trim()?.takeIf { it.isNotEmpty() }
-        val execution = AgentExecution(
-            id = UUID.randomUUID(),
-            userId = userId,
-            chatId = chatId,
-            userMessageId = null,
-            assistantMessageId = null,
-            status = AgentExecutionStatus.QUEUED,
-            requestId = null,
-            clientMessageId = normalizedClientMessageId,
-            model = effectiveSettings.defaultModel,
-            provider = effectiveSettings.defaultModel.provider,
-            startedAt = Instant.now(),
-            finishedAt = null,
-            cancelRequested = false,
-            errorCode = null,
-            errorMessage = null,
-            usage = null,
-            metadata = executionMetadata(
-                contextSize = effectiveSettings.contextSize,
-                temperature = effectiveSettings.temperature,
-                locale = effectiveSettings.locale.toLanguageTag(),
-                timeZone = effectiveSettings.timeZone.id,
-                systemPrompt = effectiveSettings.systemPrompt,
-                streamingMessages = effectiveSettings.streamingMessages,
-                showToolEvents = effectiveSettings.showToolEvents,
-            ),
+        val config = AgentExecutionRuntimeConfig(
+            modelAlias = effectiveSettings.defaultModel.alias,
+            contextSize = effectiveSettings.contextSize,
+            temperature = effectiveSettings.temperature,
+            locale = effectiveSettings.locale.toLanguageTag(),
+            timeZone = effectiveSettings.timeZone.id,
+            systemPrompt = effectiveSettings.systemPrompt,
+            streamingMessages = effectiveSettings.streamingMessages,
+            showToolEvents = effectiveSettings.showToolEvents,
         )
-
+        val execution = AgentExecution(
+            id = UUID.randomUUID(), userId = userId, chatId = chatId, userMessageId = null, assistantMessageId = null,
+            status = AgentExecutionStatus.QUEUED, requestId = null, clientMessageId = normalizedClientMessageId,
+            model = effectiveSettings.defaultModel, provider = effectiveSettings.defaultModel.provider,
+            startedAt = Instant.now(), finishedAt = null, cancelRequested = false, errorCode = null, errorMessage = null,
+            usage = null, metadata = executionMetadata(config),
+        )
         return PreparedChatTurn(
-            normalizedClientMessageId = normalizedClientMessageId,
             effectiveSettings = effectiveSettings,
             execution = execution,
             conversationKey = conversationKey(userId, chatId),
-            runtimeRequest = BackendConversationTurnRequest(
-                prompt = content,
-                model = effectiveSettings.defaultModel.alias,
-                contextSize = effectiveSettings.contextSize,
-                locale = effectiveSettings.locale.toLanguageTag(),
-                timeZone = effectiveSettings.timeZone.id,
-                executionId = execution.id.toString(),
-                temperature = effectiveSettings.temperature,
-                systemPrompt = effectiveSettings.systemPrompt,
-                streamingMessages = effectiveSettings.streamingMessages,
-            ),
+            turn = BackendAgentTurn(userId, chatId, execution.id, chatId.toString(), BackendAgentTurnInput.UserMessage(content), config),
             userMessageMetadata = userMessageMetadata(normalizedClientMessageId),
             shouldReturnRunning = effectiveSettings.streamingMessages && featureFlags.wsEvents,
         )
     }
 
-    fun prepareContinuationTurn(
-        execution: AgentExecution,
-        option: Option,
-    ): PreparedContinuationTurn {
-        val runtimeRequest = createContinuationTurnRequest(execution, option)
+    fun prepareContinuationTurn(execution: AgentExecution, option: Option): PreparedContinuationTurn {
+        val config = executionRuntimeConfig(execution)
         return PreparedContinuationTurn(
             conversationKey = conversationKey(execution.userId, execution.chatId),
-            runtimeRequest = runtimeRequest,
-            streamingMessagesEnabled = runtimeRequest.streamingMessages == true,
-            toolEventsEnabled = executionMetadataBoolean(execution, METADATA_SHOW_TOOL_EVENTS) ?: false,
+            turn = BackendAgentTurn(execution.userId, execution.chatId, execution.id, execution.chatId.toString(), BackendAgentTurnInput.OptionAnswer(option.id, option.continuationPayloadJson()), config),
+            streamingMessagesEnabled = config.streamingMessages,
+            toolEventsEnabled = config.showToolEvents,
         )
     }
 
-    fun createContinuationTurnRequest(
-        execution: AgentExecution,
-        option: Option,
-    ): BackendConversationTurnRequest =
-        BackendConversationTurnRequest(
-            prompt = option.toContinuationInput(),
-            model = execution.model?.alias
-                ?: throw internalError("Execution model is missing."),
-            contextSize = executionMetadataInt(execution, METADATA_CONTEXT_SIZE)
-                ?: throw internalError("Execution contextSize is missing."),
-            locale = execution.metadata[METADATA_LOCALE]
-                ?: throw internalError("Execution locale is missing."),
-            timeZone = execution.metadata[METADATA_TIME_ZONE]
-                ?: throw internalError("Execution timeZone is missing."),
-            executionId = execution.id.toString(),
-            temperature = executionMetadataFloat(execution, METADATA_TEMPERATURE),
-            systemPrompt = execution.metadata[METADATA_SYSTEM_PROMPT]?.takeIf { it.isNotEmpty() },
-            streamingMessages = executionMetadataBoolean(execution, METADATA_STREAMING_MESSAGES),
-        )
+    fun createEventSink(userId: String, chatId: UUID, execution: AgentExecution, messageRepository: MessageRepository, optionRepository: OptionRepository, executionRepository: AgentExecutionRepository, eventService: AgentEventService, toolCallRepository: ToolCallRepository, streamingMessagesEnabled: Boolean, toolEventsEnabled: Boolean): BackendAgentRuntimeEventSink =
+        BackendAgentRuntimeEventSink(userId, chatId, execution.id, messageRepository, optionRepository, executionRepository, eventService, toolCallRepository, streamingMessagesEnabled, toolEventsEnabled, featureFlags.options, execution.assistantMessageId)
 
-    fun createEventSink(
-        userId: String,
-        chatId: UUID,
-        execution: AgentExecution,
-        messageRepository: MessageRepository,
-        optionRepository: OptionRepository,
-        executionRepository: AgentExecutionRepository,
-        eventService: AgentEventService,
-        toolCallRepository: ToolCallRepository,
-        streamingMessagesEnabled: Boolean,
-        toolEventsEnabled: Boolean,
-    ): BackendAgentRuntimeEventSink =
-        BackendAgentRuntimeEventSink(
-            userId = userId,
-            chatId = chatId,
-            executionId = execution.id,
-            messageRepository = messageRepository,
-            optionRepository = optionRepository,
-            executionRepository = executionRepository,
-            eventService = eventService,
-            toolCallRepository = toolCallRepository,
-            streamingMessagesEnabled = streamingMessagesEnabled,
-            toolEventsEnabled = toolEventsEnabled,
-            optionsEnabled = featureFlags.options,
-            assistantMessageId = execution.assistantMessageId,
-        )
+    private fun conversationKey(userId: String, chatId: UUID) = AgentConversationKey(userId, chatId.toString())
+    private fun userMessageMetadata(clientMessageId: String?) = clientMessageId?.let { linkedMapOf("clientMessageId" to it) } ?: emptyMap()
 
-    private fun conversationKey(userId: String, chatId: UUID): AgentConversationKey =
-        AgentConversationKey(
-            userId = userId,
-            conversationId = chatId.toString(),
-        )
-
-    private fun userMessageMetadata(clientMessageId: String?): Map<String, String> =
-        clientMessageId?.let { linkedMapOf("clientMessageId" to it) } ?: emptyMap()
-
-    private fun executionMetadata(
-        contextSize: Int,
-        temperature: Float,
-        locale: String,
-        timeZone: String,
-        systemPrompt: String?,
-        streamingMessages: Boolean,
-        showToolEvents: Boolean,
-    ): Map<String, String> = buildMap {
-        put(METADATA_CONTEXT_SIZE, contextSize.toString())
-        put(METADATA_TEMPERATURE, temperature.toString())
-        put(METADATA_LOCALE, locale)
-        put(METADATA_TIME_ZONE, timeZone)
-        put(METADATA_STREAMING_MESSAGES, streamingMessages.toString())
-        put(METADATA_SHOW_TOOL_EVENTS, showToolEvents.toString())
-        systemPrompt?.let { put(METADATA_SYSTEM_PROMPT, it) }
+    private fun executionMetadata(config: AgentExecutionRuntimeConfig): Map<String, String> = buildMap {
+        put(METADATA_RUNTIME_CONFIG, restJsonMapper.writeValueAsString(config))
+        put("contextSize", config.contextSize.toString())
+        config.temperature?.let { put("temperature", it.toString()) }
+        put("locale", config.locale)
+        put("timeZone", config.timeZone)
+        put("streamingMessages", config.streamingMessages.toString())
+        put("showToolEvents", config.showToolEvents.toString())
+        config.systemPrompt?.let { put("systemPrompt", it) }
     }
 
-    private fun executionMetadataInt(
-        execution: AgentExecution,
-        key: String,
-    ): Int? = execution.metadata[key]?.toIntOrNull()
-
-    private fun executionMetadataFloat(
-        execution: AgentExecution,
-        key: String,
-    ): Float? = execution.metadata[key]?.toFloatOrNull()
-
-    private fun executionMetadataBoolean(
-        execution: AgentExecution,
-        key: String,
-    ): Boolean? = execution.metadata[key]?.toBooleanStrictOrNull()
+    private fun executionRuntimeConfig(execution: AgentExecution): AgentExecutionRuntimeConfig {
+        execution.metadata[METADATA_RUNTIME_CONFIG]?.let { return restJsonMapper.readValue(it, AgentExecutionRuntimeConfig::class.java) }
+        return AgentExecutionRuntimeConfig(
+            modelAlias = execution.model?.alias ?: throw internalError("Execution model is missing."),
+            contextSize = execution.metadata["contextSize"]?.toIntOrNull() ?: throw internalError("Execution contextSize is missing."),
+            temperature = execution.metadata["temperature"]?.toFloatOrNull(),
+            locale = execution.metadata["locale"] ?: throw internalError("Execution locale is missing."),
+            timeZone = execution.metadata["timeZone"] ?: throw internalError("Execution timeZone is missing."),
+            systemPrompt = execution.metadata["systemPrompt"]?.takeIf { it.isNotEmpty() },
+            streamingMessages = execution.metadata["streamingMessages"]?.toBooleanStrictOrNull() ?: false,
+            showToolEvents = execution.metadata["showToolEvents"]?.toBooleanStrictOrNull() ?: false,
+        )
+    }
 }
 
+private fun Option.continuationPayloadJson(): String = toContinuationInput().removePrefix("__option_answer__ ")
 private fun Option.toContinuationInput(): String {
     val answer = answer ?: error("Option answer is required for continuation.")
     val optionById = options.associateBy { it.id }
-    val selectedOptions = answer.selectedOptionIds.mapNotNull(optionById::get).map { option ->
-        linkedMapOf(
-            "id" to option.id,
-            "label" to option.label,
-            "content" to option.content,
-        )
-    }
-    val payload = linkedMapOf<String, Any?>(
-        "type" to "option_answer",
-        "optionId" to id.toString(),
-        "kind" to kind.value,
-        "selectionMode" to selectionMode,
-        "selectedOptionIds" to answer.selectedOptionIds.toList(),
-        "selectedOptions" to selectedOptions,
-        "freeText" to answer.freeText,
-        "metadata" to answer.metadata,
-    )
-    return "$OPTION_CONTINUATION_PREFIX ${restJsonMapper.writeValueAsString(payload)}"
+    val selectedOptions = answer.selectedOptionIds.mapNotNull(optionById::get).map { linkedMapOf("id" to it.id, "label" to it.label, "content" to it.content) }
+    val payload = linkedMapOf<String, Any?>("type" to "option_answer", "optionId" to id.toString(), "kind" to kind.value, "selectionMode" to selectionMode, "selectedOptionIds" to answer.selectedOptionIds.toList(), "selectedOptions" to selectedOptions, "freeText" to answer.freeText, "metadata" to answer.metadata)
+    return "__option_answer__ ${restJsonMapper.writeValueAsString(payload)}"
 }
-
-private fun internalError(message: String): BackendV1Exception =
-    BackendV1Exception(
-        status = io.ktor.http.HttpStatusCode.InternalServerError,
-        code = "internal_error",
-        message = message,
-    )
-
-private const val METADATA_CONTEXT_SIZE = "contextSize"
-private const val METADATA_TEMPERATURE = "temperature"
-private const val METADATA_LOCALE = "locale"
-private const val METADATA_TIME_ZONE = "timeZone"
-private const val METADATA_SYSTEM_PROMPT = "systemPrompt"
-private const val METADATA_STREAMING_MESSAGES = "streamingMessages"
-private const val METADATA_SHOW_TOOL_EVENTS = "showToolEvents"
-private const val OPTION_CONTINUATION_PREFIX = "__option_answer__"
+private fun internalError(message: String) = BackendV1Exception(io.ktor.http.HttpStatusCode.InternalServerError, "internal_error", message)
+private const val METADATA_RUNTIME_CONFIG = "runtimeConfig"

--- a/backend/src/main/kotlin/ru/souz/backend/execution/service/AgentExecutionService.kt
+++ b/backend/src/main/kotlin/ru/souz/backend/execution/service/AgentExecutionService.kt
@@ -104,7 +104,20 @@ class AgentExecutionService internal constructor(
                         chat = chat,
                         execution = runningExecution,
                         conversationKey = prepared.conversationKey,
-                        turnRequest = prepared.runtimeRequest,
+                        turnRequest = ru.souz.backend.agent.model.BackendConversationTurnRequest(
+                            prompt = when (val input = prepared.turn.input) {
+                                is ru.souz.backend.agent.model.BackendAgentTurnInput.UserMessage -> input.content
+                                is ru.souz.backend.agent.model.BackendAgentTurnInput.OptionAnswer -> "__option_answer__ ${input.payload}"
+                            },
+                            model = prepared.turn.config.modelAlias,
+                            contextSize = prepared.turn.config.contextSize,
+                            locale = prepared.turn.config.locale,
+                            timeZone = prepared.turn.config.timeZone,
+                            executionId = prepared.turn.executionId.toString(),
+                            temperature = prepared.turn.config.temperature,
+                            systemPrompt = prepared.turn.config.systemPrompt,
+                            streamingMessages = prepared.turn.config.streamingMessages,
+                        ),
                         eventSink = eventSink,
                     )
                 }
@@ -124,7 +137,20 @@ class AgentExecutionService internal constructor(
                         chat = chat,
                         execution = runningExecution,
                         conversationKey = prepared.conversationKey,
-                        turnRequest = prepared.runtimeRequest,
+                        turnRequest = ru.souz.backend.agent.model.BackendConversationTurnRequest(
+                            prompt = when (val input = prepared.turn.input) {
+                                is ru.souz.backend.agent.model.BackendAgentTurnInput.UserMessage -> input.content
+                                is ru.souz.backend.agent.model.BackendAgentTurnInput.OptionAnswer -> "__option_answer__ ${input.payload}"
+                            },
+                            model = prepared.turn.config.modelAlias,
+                            contextSize = prepared.turn.config.contextSize,
+                            locale = prepared.turn.config.locale,
+                            timeZone = prepared.turn.config.timeZone,
+                            executionId = prepared.turn.executionId.toString(),
+                            temperature = prepared.turn.config.temperature,
+                            systemPrompt = prepared.turn.config.systemPrompt,
+                            streamingMessages = prepared.turn.config.streamingMessages,
+                        ),
                         eventSink = eventSink,
                     )
                 }
@@ -212,7 +238,20 @@ class AgentExecutionService internal constructor(
                 chat = chat,
                 execution = runningExecution,
                 conversationKey = prepared.conversationKey,
-                turnRequest = prepared.runtimeRequest,
+                turnRequest = ru.souz.backend.agent.model.BackendConversationTurnRequest(
+                    prompt = when (val input = prepared.turn.input) {
+                        is ru.souz.backend.agent.model.BackendAgentTurnInput.UserMessage -> input.content
+                        is ru.souz.backend.agent.model.BackendAgentTurnInput.OptionAnswer -> "__option_answer__ ${input.payload}"
+                    },
+                    model = prepared.turn.config.modelAlias,
+                    contextSize = prepared.turn.config.contextSize,
+                    locale = prepared.turn.config.locale,
+                    timeZone = prepared.turn.config.timeZone,
+                    executionId = prepared.turn.executionId.toString(),
+                    temperature = prepared.turn.config.temperature,
+                    systemPrompt = prepared.turn.config.systemPrompt,
+                    streamingMessages = prepared.turn.config.streamingMessages,
+                ),
                 eventSink = eventSink,
             )
         }


### PR DESCRIPTION
### Motivation
- Capture agent execution runtime settings as a single serializable object and persist them with the execution metadata. 
- Replace ad-hoc runtime request construction with a unified internal turn model that supports both user messages and option answers. 
- Simplify metadata handling and make continuation/queued execution plumbing use the same turn/config representation.

### Description
- Add `AgentExecutionRuntimeConfig` to represent runtime settings (model alias, context size, temperature, locale, time zone, system prompt, streaming and tool-events flags). 
- Introduce `BackendAgentTurn` and sealed `BackendAgentTurnInput` (with `UserMessage` and `OptionAnswer`) and switch `AgentExecutionRequestFactory` to produce `PreparedChatTurn`/`PreparedContinuationTurn` with `turn` and `config`. 
- Store runtime config JSON under execution metadata key `runtimeConfig` and centralize metadata construction in `executionMetadata(config)` and deserialization in `executionRuntimeConfig(execution)`. 
- Convert places that previously passed `BackendConversationTurnRequest` to build it from `Prepared*.turn` on demand (including in `AgentExecutionService` launcher/finalizer paths). 
- Adjust `createEventSink` call and helper utilities (`conversationKey`, `userMessageMetadata`) and add `Option.continuationPayloadJson()` helper; remove older individual metadata keys/constants in favor of the runtime config key. 

### Testing
- Ran build and unit tests via `./gradlew build` and `./gradlew test`, and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f72affb7c08329b839b09e07ccb1bb)