### PR TITLE
Restrict skills graph to core tools

### DIFF
--- a/agent/AGENTS.md
+++ b/agent/AGENTS.md
@@ -11,7 +11,7 @@ Before changing this module, read its [pain-point index](docs/pain-points.md) an
 ## Invariants
 
 - `AgentFacade` is a stateful, single-active-execution entry point. Starting a turn or changing its agent or context cancels the current execution. Model, prompt, temperature, and context-size setters currently update state in place, so callers must not use them concurrently with execution unless that lifecycle is changed and tested explicitly.
-- Preserve the classic graph's turn setup order: history input, classification, skill activation, MCP tools, context enrichment, then LLM execution. The skills-oriented graph instead installs its fixed core tools before context enrichment and does not classify, activate legacy skills, or inject MCP tools.
+- Preserve the classic graph's turn setup order: history input, classification, skill activation, MCP tools, context enrichment, then LLM execution. The skills-oriented agent restricts every incoming context to its fixed core tools before graph execution and does not classify, activate legacy skills, or inject MCP tools.
 - Skill selection uses user-scoped metadata; load and validate full bundles only after selection. Validation identity is user-, skill-, bundle-, and policy-scoped. Read the skill-activation pain point before changing dynamic command exposure because blocked activation does not currently provide complete command revocation.
 - Propagate coroutine cancellation. Error handling may degrade optional integrations, but must not convert cancellation into a normal result.
 

--- a/agent/docs/pain-points/skills-oriented-graph.md
+++ b/agent/docs/pain-points/skills-oriented-graph.md
@@ -2,7 +2,7 @@
 
 ## Invariant
 
-`SkillsGraphBasedAgent` exposes exactly `GetSkills`, `GetKnowledge`, and generic `RunSkillCommand`. At the start of each turn it replaces both the functions advertised to the model and the executable tool lookup with those three tools. It does not run classification, legacy skill activation, or MCP injection.
+`SkillsGraphBasedAgent` exposes exactly `GetSkills`, `GetKnowledge`, and generic `RunSkillCommand`. Its execution boundary replaces both the functions advertised to the model and the executable tool lookup before the graph starts. It does not run classification, legacy skill activation, or MCP injection.
 
 Tool results larger than 4,096 UTF-8 bytes are stored in conversation-scoped Knowledge and replaced with a compact JSON reference. A result of exactly 4,096 bytes stays inline. `GetKnowledge` results are never offloaded again. Storage unavailability and persistence failures keep the original result inline; coroutine cancellation propagates.
 
@@ -14,7 +14,7 @@ Advertising a small tool list without replacing executable lookup would let a fa
 
 ## Safe changes
 
-- Keep core-tool installation before context enrichment and run it only once per user turn; tool loops return directly to the LLM.
+- Keep core-tool restriction at the execution boundary so every graph node sees the restricted context; tool loops return directly to the LLM.
 - Keep large-result processing opt-in beside the classic `NodesCommon.toolUse()` path.
 - Preserve function-result role, name, attachments, and call ID when replacing only its content.
 - Keep Knowledge cleanup tied to destructive or local conversation-close lifecycles. Backend archive is non-destructive and does not clear Knowledge.

--- a/agent/src/main/kotlin/ru/souz/SkillsGraphBasedAgent.kt
+++ b/agent/src/main/kotlin/ru/souz/SkillsGraphBasedAgent.kt
@@ -15,6 +15,7 @@ import ru.souz.agent.nodes.NodesSummarization
 import ru.souz.agent.runtime.GraphExecutionDelegate
 import ru.souz.agent.runtime.GraphExecutionDelegateImpl
 import ru.souz.agent.state.AgentContext
+import ru.souz.agent.state.AgentTools
 import ru.souz.llms.LLMResponse
 import ru.souz.llms.LLMToolSetup
 
@@ -38,11 +39,15 @@ class SkillsGraphBasedAgent internal constructor(
 ) : TraceableAgent {
     override val sideEffects: Flow<String> = nodesLLM.sideEffects
 
+    private val coreTools = listOf(getSkillsTool, getKnowledgeTool, runtimeCommandTool)
+    private val coreFunctions = coreTools.map { it.fn }
+    private val coreToolRegistry = AgentTools(
+        byCategory = emptyMap(),
+        byName = coreTools.associateBy { it.fn.name },
+    )
+
     private val graph: Graph<String, String> = buildGraph(name = "Skills Agent") {
         val inputToHistory = nodesCommon.inputToHistory()
-        val installCoreTools = nodesCommon.installCoreTools(
-            listOf(getSkillsTool, getKnowledgeTool, runtimeCommandTool)
-        )
         val contextEnrich = nodesCommon.nodeAppendAdditionalData()
         val chat = nodesLLM.chat("LLM")
         val chatOk: Node<LLMResponse.Chat, LLMResponse.Chat.Ok> = Node("Chat.Ok") { ctx ->
@@ -53,8 +58,7 @@ class SkillsGraphBasedAgent internal constructor(
         val chatErrorToFinish = nodesErrorHandling.chatErrorToFinish()
 
         nodeInput.edgeTo(inputToHistory)
-        inputToHistory.edgeTo(installCoreTools)
-        installCoreTools.edgeTo(contextEnrich)
+        inputToHistory.edgeTo(contextEnrich)
         contextEnrich.edgeTo(chat)
         chat.edgeTo { ctx ->
             when (ctx.input) {
@@ -78,7 +82,13 @@ class SkillsGraphBasedAgent internal constructor(
     override suspend fun executeWithTrace(
         ctx: AgentContext<String>,
         onStep: GraphStepCallback?,
-    ): AgentExecutionResult = executionDelegate.executeWithTrace(graph = graph, ctx = ctx, onStep = onStep)
+    ): AgentExecutionResult {
+        val restrictedContext = ctx.copy(
+            settings = ctx.settings.copy(tools = coreToolRegistry),
+            activeTools = coreFunctions,
+        )
+        return executionDelegate.executeWithTrace(graph = graph, ctx = restrictedContext, onStep = onStep)
+    }
 
     private val LLMResponse.Chat.Ok.isToolUse get() = choices.any { it.message.functionCall != null }
 }

--- a/agent/src/main/kotlin/ru/souz/agent/nodes/NodesCommon.kt
+++ b/agent/src/main/kotlin/ru/souz/agent/nodes/NodesCommon.kt
@@ -10,7 +10,6 @@ import ru.souz.agent.runtime.AgentRuntimeEventSink
 import ru.souz.agent.runtime.AgentToolExecutor
 import ru.souz.agent.state.AgentContext
 import ru.souz.agent.state.AgentSettings
-import ru.souz.agent.state.AgentTools
 import ru.souz.agent.spi.AgentDesktopInfoRepository
 import ru.souz.agent.spi.AgentRuntimeEnvironment
 import ru.souz.agent.spi.AgentSettingsProvider
@@ -20,7 +19,6 @@ import ru.souz.db.StorredType
 import ru.souz.llms.LLMMessageRole
 import ru.souz.llms.LLMRequest
 import ru.souz.llms.LLMResponse
-import ru.souz.llms.LLMToolSetup
 import ru.souz.llms.ToolInvocationMeta
 import ru.souz.llms.restJsonMapper
 import ru.souz.llms.toSystemPromptMessage
@@ -133,24 +131,6 @@ internal class NodesCommon(
         }
         val history = ArrayList(ctx.history).apply { addAll(fnCallMessages) }
         ctx.map(history = history) { ctx.history.last().content }
-    }
-
-    /** Replaces both advertised and executable tools with the skills graph's core tool set. */
-    fun installCoreTools(
-        coreTools: List<LLMToolSetup>,
-        name: String = "Install core tools",
-    ): Node<String, String> = Node(name) { ctx ->
-        val toolsByName = coreTools.associateBy { it.fn.name }
-        ctx.map(
-            settings = ctx.settings.copy(
-                tools = AgentTools(
-                    byCategory = emptyMap(),
-                    byName = toolsByName,
-                    categoryByName = emptyMap(),
-                )
-            ),
-            activeTools = coreTools.map { it.fn },
-        )
     }
 
     /**

--- a/agent/src/test/kotlin/ru/souz/SkillsGraphBasedAgentTest.kt
+++ b/agent/src/test/kotlin/ru/souz/SkillsGraphBasedAgentTest.kt
@@ -11,17 +11,19 @@ import ru.souz.agent.nodes.NodesLLM
 import ru.souz.agent.nodes.NodesSummarization
 import ru.souz.agent.state.AgentContext
 import ru.souz.agent.state.AgentSettings
+import ru.souz.agent.state.AgentTools
 import ru.souz.llms.LLMMessageRole
 import ru.souz.llms.LLMRequest
 import ru.souz.llms.LLMResponse
 import ru.souz.llms.LLMToolSetup
 import ru.souz.llms.restJsonMapper
+import ru.souz.tool.ToolCategory
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class SkillsGraphBasedAgentTest {
     @Test
-    fun `graph installs core tools once and loops tool calls directly back to chat`() = runTest {
+    fun `graph starts with only core tools and loops tool calls directly back to chat`() = runTest {
         val nodesLLM = mockk<NodesLLM>()
         val nodesCommon = mockk<NodesCommon>()
         val nodesErrorHandling = mockk<NodesErrorHandling>()
@@ -29,14 +31,16 @@ class SkillsGraphBasedAgentTest {
         val getSkills = tool("GetSkills")
         val getKnowledge = tool("GetKnowledge")
         val runtimeCommand = tool("RunSkillCommand")
+        val coreTools = listOf(getSkills, getKnowledge, runtimeCommand)
         val executed = mutableListOf<String>()
         var chatCount = 0
 
         every { nodesLLM.sideEffects } returns emptyFlow()
-        every { nodesCommon.inputToHistory() } returns passthrough("Input->History", executed)
-        every {
-            nodesCommon.installCoreTools(listOf(getSkills, getKnowledge, runtimeCommand))
-        } returns passthrough("Install core tools", executed)
+        every { nodesCommon.inputToHistory() } returns coreToolsPassthrough(
+            name = "Input->History",
+            executed = executed,
+            coreTools = coreTools,
+        )
         every { nodesCommon.nodeAppendAdditionalData() } returns passthrough("appendActualInformation", executed)
         every { nodesLLM.chat("LLM") } returns Node("LLM") { ctx ->
             executed += "LLM"
@@ -69,7 +73,6 @@ class SkillsGraphBasedAgentTest {
         assertEquals(
             listOf(
                 "Input->History",
-                "Install core tools",
                 "appendActualInformation",
                 "LLM",
                 "toolUse",
@@ -95,9 +98,6 @@ class SkillsGraphBasedAgentTest {
 
         every { nodesLLM.sideEffects } returns emptyFlow()
         every { nodesCommon.inputToHistory() } returns passthrough("Input->History", executed)
-        every {
-            nodesCommon.installCoreTools(listOf(getSkills, getKnowledge, runtimeCommand))
-        } returns passthrough("Install core tools", executed)
         every { nodesCommon.nodeAppendAdditionalData() } returns passthrough("appendActualInformation", executed)
         every { nodesLLM.chat("LLM") } returns Node("LLM") { ctx ->
             executed += "LLM"
@@ -119,7 +119,7 @@ class SkillsGraphBasedAgentTest {
 
         assertEquals("friendly error", result.output)
         assertEquals(
-            listOf("Input->History", "Install core tools", "appendActualInformation", "LLM", "Chat.Error"),
+            listOf("Input->History", "appendActualInformation", "LLM", "Chat.Error"),
             executed,
         )
     }
@@ -145,6 +145,19 @@ class SkillsGraphBasedAgentTest {
 
     private fun passthrough(name: String, executed: MutableList<String>) = Node<String, String>(name) { ctx ->
         executed += name
+        ctx
+    }
+
+    private fun coreToolsPassthrough(
+        name: String,
+        executed: MutableList<String>,
+        coreTools: List<LLMToolSetup>,
+    ) = Node<String, String>(name) { ctx ->
+        executed += name
+        assertEquals(coreTools.map { it.fn }, ctx.activeTools)
+        assertEquals(coreTools.associateBy { it.fn.name }, ctx.settings.tools.byName)
+        assertEquals(emptyMap(), ctx.settings.tools.byCategory)
+        assertEquals(emptyMap(), ctx.settings.tools.categoryByName)
         ctx
     }
 
@@ -199,11 +212,22 @@ class SkillsGraphBasedAgentTest {
         usage = LLMResponse.Usage(1, 1, 2, 0),
     )
 
-    private fun baseContext() = AgentContext(
-        input = "Hello",
-        settings = AgentSettings(model = "test", temperature = 0f, toolsByCategory = emptyMap()),
-        history = emptyList(),
-        activeTools = emptyList(),
-        systemPrompt = "system",
-    )
+    private fun baseContext(): AgentContext<String> {
+        val catalogTool = tool("CatalogTool")
+        return AgentContext(
+            input = "Hello",
+            settings = AgentSettings(
+                model = "test",
+                temperature = 0f,
+                tools = AgentTools(
+                    byCategory = mapOf(
+                        ToolCategory.FILES to mapOf(catalogTool.fn.name to catalogTool),
+                    ),
+                ),
+            ),
+            history = emptyList(),
+            activeTools = listOf(catalogTool.fn),
+            systemPrompt = "system",
+        )
+    }
 }

--- a/agent/src/test/kotlin/ru/souz/agent/nodes/NodesCommonKnowledgeTest.kt
+++ b/agent/src/test/kotlin/ru/souz/agent/nodes/NodesCommonKnowledgeTest.kt
@@ -25,7 +25,6 @@ import ru.souz.llms.LLMResponse
 import ru.souz.llms.LLMToolSetup
 import ru.souz.llms.ToolInvocationMeta
 import ru.souz.llms.restJsonMapper
-import ru.souz.tool.ToolCategory
 import java.time.ZoneId
 import java.util.Locale
 import kotlin.test.Test
@@ -143,36 +142,6 @@ class NodesCommonKnowledgeTest {
         }
     }
 
-    @Test
-    fun `core tools replace advertised and executable catalog tools`() = runTest {
-        val catalogTool = FixedResultTool("CatalogTool", "catalog")
-        val coreTools = listOf(
-            FixedResultTool("GetSkills", "skills"),
-            FixedResultTool("GetKnowledge", "knowledge"),
-            FixedResultTool("RunSkillCommand", "command"),
-        )
-        val nodes = nodesCommon(knowledgeStore = null)
-        val context = stringContext(
-            tools = AgentTools(
-                byCategory = mapOf(ToolCategory.FILES to mapOf(catalogTool.fn.name to catalogTool)),
-            )
-        ).copy(activeTools = listOf(catalogTool.fn))
-
-        val result = nodes.installCoreTools(coreTools).execute(context, runtime())
-
-        assertEquals(coreTools.map { it.fn }, result.activeTools)
-        assertEquals(coreTools.associateBy { it.fn.name }, result.settings.tools.byName)
-        assertTrue(result.settings.tools.byCategory.isEmpty())
-        assertTrue(result.settings.tools.categoryByName.isEmpty())
-        assertFalse(result.settings.tools.byName.containsKey(catalogTool.fn.name))
-
-        val fabricatedCallResult = AgentToolExecutor().execute(
-            settings = result.settings,
-            functionCall = LLMResponse.FunctionCall(catalogTool.fn.name, emptyMap()),
-        )
-        assertTrue(fabricatedCallResult.content.contains("no such function CatalogTool"))
-    }
-
     private suspend fun executeToolResult(
         content: String,
         store: ConversationKnowledgeStore,
@@ -225,14 +194,6 @@ class NodesCommonKnowledgeTest {
             ),
         )
     }
-
-    private fun stringContext(tools: AgentTools): AgentContext<String> = AgentContext(
-        input = "input",
-        settings = AgentSettings(model = "test", temperature = 0f, tools = tools),
-        history = emptyList(),
-        activeTools = emptyList(),
-        systemPrompt = "system",
-    )
 
     private fun nodesCommon(knowledgeStore: ConversationKnowledgeStore?): NodesCommon = NodesCommon(
         desktopInfoRepository = mockk<AgentDesktopInfoRepository>(relaxed = true),


### PR DESCRIPTION
## Summary

- Normalize every `SkillsGraphBasedAgent` input context to the three core tools before graph execution.
- Remove the `Install core tools` graph node and the obsolete `NodesCommon.installCoreTools` helper.
- Verify the first graph node receives only `GetSkills`, `GetKnowledge`, and `RunSkillCommand` in both advertised and executable tool collections.
- Update the agent invariants and skills-graph maintenance guidance.

## Why

The shared context can arrive populated with the complete tool catalog. Restricting tools inside the graph added an unnecessary setup node and allowed the initial graph state to contain unrelated functions. Applying the restriction at the agent boundary keeps the graph smaller and makes tool isolation true before any graph node runs, including for restored or manually supplied contexts.

## Impact

The skills-oriented agent exposes and executes only its three core tools. The classic graph and shared context factory retain their existing behavior.

## Validation

- `./gradlew :agent:test`
- `./gradlew :backend:test --tests 'ru.souz.backend.agent.runtime.BackendConversationRuntimeSettingsTest.runtime resolves skills graph with only its core tools'`
- `git diff --check`