### PR TITLE
Enforce backend tool policy and explicit agent selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ Skill bundles and runtime sandbox workspaces remain filesystem-backed and are in
 SOUZ_BACKEND_HOST=127.0.0.1
 SOUZ_BACKEND_PORT=8080
 SOUZ_BACKEND_PROXY_TOKEN=replace-with-shared-proxy-secret
+SOUZ_BACKEND_AGENT=graph # graph or skills
 
 # Feature flags
 SOUZ_FEATURE_WS_EVENTS=true
@@ -384,7 +385,9 @@ SOUZ_BACKEND_DB_MAX_POOL_SIZE=10
 SOUZ_BACKEND_DB_CONNECTION_TIMEOUT_MS=30000
 ```
 
-The server host must not be blank, and the port must be between `1` and `65535`; invalid values fail configuration validation during startup. Without `SOUZ_BACKEND_PROXY_TOKEN`, public routes remain available but `/v1/**` requests return `backend_misconfigured`.
+The server host must not be blank, and the port must be between `1` and `65535`; invalid values fail configuration validation during startup. `SOUZ_BACKEND_AGENT` and `souz.backend.agent` select `graph` or `skills` for new conversations and default to `graph`; persisted conversations retain their stored agent. Without `SOUZ_BACKEND_PROXY_TOKEN`, public routes remain available but `/v1/**` requests return `backend_misconfigured`.
+
+Backend executions snapshot each user's effective `enabledTools`. The snapshot controls compiled-tool classification, `GetSkills` discovery, and generic `RunSkillCommand` delegation, and is retained when an execution resumes from an option. Core skill tools and user-installed file-backed skills remain available.
 
 Run the backend:
 

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -8,6 +8,8 @@ Before changing this module, read the [pain-point index](docs/pain-points.md) an
 
 - Treat proxy-provided identity as the only user identity and scope every user-owned operation accordingly.
 - Expose only backend-safe runtime tools; desktop integrations and UI dependencies must stay outside this module.
+- Apply each execution's immutable enabled-tool snapshot through request-scoped filters; keep core skill tools and user-scoped file-backed skills outside compiled-tool filtering.
+- Select the agent for new conversations from backend configuration and retain the agent stored in existing conversation state.
 - Keep product messages, execution lifecycle, agent continuation state, and durable/live events in their existing ownership layers.
 - PostgreSQL is the structured repository store. User skill bundles and sandbox workspaces remain filesystem-backed and user-scoped.
 - Give each ordinary HTTP route explicit OpenAPI metadata. Keep WebSocket routes out of the generated document.

--- a/backend/docs/pain-points/execution-openapi-and-events.md
+++ b/backend/docs/pain-points/execution-openapi-and-events.md
@@ -4,6 +4,8 @@
 
 `AgentExecutionService` owns product execution lifecycle, cancellation, and option continuation. Product messages are stored separately from runtime continuation state, and `conversationId = chatId.toString()` is the stable agent-session identity. Request-scoped runtimes rebuild from persisted session state, while storage enforces one active execution per chat.
 
+New conversations use the configured backend agent; persisted conversations retain their stored agent. Each initial execution snapshots its effective compiled-tool names into execution metadata, and option continuations reuse that snapshot. Request-scoped immutable filters apply the snapshot to classic graph classification and to the skills graph's `GetSkills` and generic `RunSkillCommand`; core tools and user-installed file-backed skills remain available.
+
 `message.delta` is live-only for current executions. Execution lifecycle, completed message, tool-call, option, failure, and cancellation events are durable and replayable. Compatibility replay may expose older partial or durable-delta rows, but those rows must remain a disjoint fallback rather than weakening the canonical typed durable-event variants.
 
 ## Why it is fragile
@@ -15,6 +17,7 @@ Generated OpenAPI is also easy to drift: route helpers and deferred registration
 ## Safe-change guidance
 
 - Keep execution launch/finalization in `AgentExecutionService` and session reconstruction in the runtime factory/repository layer.
+- Do not read the shared JVM agent preference or mutate singleton tool policy. Build agent selection and compiled-tool filtering from backend configuration, persisted session state, and execution metadata.
 - Publish new deltas only on the live bus; persist only canonical durable events unless a migration explicitly changes the contract.
 - Preserve the canonical-or-legacy replay union and keep compatibility payloads structurally distinct.
 - Give every ordinary HTTP route a stable operation ID, tag, inputs, success responses, structured errors, and trusted-proxy security where applicable.

--- a/backend/docs/pain-points/trusted-proxy.md
+++ b/backend/docs/pain-points/trusted-proxy.md
@@ -16,6 +16,7 @@ Accepting identity from a body, query, route parameter, or unverified header let
 - Apply ownership checks to every user resource, including nested chat, execution, option, event, Telegram, and provider-key operations.
 - Pass `ToolInvocationMeta.userId` into backend runtime work. Backend sandbox scope is user-scoped and does not currently add conversation scope.
 - Keep the backend tool catalog limited to backend-safe categories and exclude desktop-only tools and `WebImageSearch`.
+- Restrict compiled tools with the trusted user's effective `enabledTools` snapshot for discovery and invocation without hiding core or user-installed file-backed skills.
 - Document both proxy headers as jointly required OpenAPI security schemes for every `/v1` operation.
 
 ## Verification

--- a/backend/src/main/kotlin/ru/souz/backend/agent/model/BackendAgentModels.kt
+++ b/backend/src/main/kotlin/ru/souz/backend/agent/model/BackendAgentModels.kt
@@ -19,4 +19,5 @@ internal data class BackendConversationTurnRequest(
     val streamingMessages: Boolean? = null,
     val requestTimeoutMillis: Long? = null,
     val useFewShotExamples: Boolean? = null,
+    val enabledTools: Set<String>? = null,
 )

--- a/backend/src/main/kotlin/ru/souz/backend/agent/runtime/BackendAgentHostAdapters.kt
+++ b/backend/src/main/kotlin/ru/souz/backend/agent/runtime/BackendAgentHostAdapters.kt
@@ -7,7 +7,6 @@ import ru.souz.agent.spi.AgentDesktopInfoRepository
 import ru.souz.agent.spi.AgentErrorMessages
 import ru.souz.agent.spi.AgentRuntimeEnvironment
 import ru.souz.agent.spi.AgentToolCatalog
-import ru.souz.agent.spi.AgentToolsFilter
 import ru.souz.agent.spi.DefaultBrowserProvider
 import ru.souz.agent.spi.McpToolProvider
 import ru.souz.backend.agent.model.BackendConversationTurnRequest
@@ -141,13 +140,6 @@ object BackendNoopAgentDesktopInfoRepository : AgentDesktopInfoRepository {
 /** Backend fallback tool catalog used when no shared catalog is bound. */
 object BackendNoopAgentToolCatalog : AgentToolCatalog {
     override val toolsByCategory: Map<ToolCategory, Map<String, LLMToolSetup>> = emptyMap()
-}
-
-/** Backend fallback filter that leaves the bound tool catalog unchanged. */
-object BackendNoopAgentToolsFilter : AgentToolsFilter {
-    override fun applyFilter(
-        toolsByCategory: Map<ToolCategory, Map<String, LLMToolSetup>>,
-    ): Map<ToolCategory, Map<String, LLMToolSetup>> = toolsByCategory
 }
 
 /** Backend implementation for hosts without a meaningful default browser. */

--- a/backend/src/main/kotlin/ru/souz/backend/agent/runtime/BackendConversationRuntime.kt
+++ b/backend/src/main/kotlin/ru/souz/backend/agent/runtime/BackendConversationRuntime.kt
@@ -2,6 +2,7 @@ package ru.souz.backend.agent.runtime
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import ru.souz.agent.AgentContextFactory
+import ru.souz.agent.AgentId
 import ru.souz.agent.AgentExecutionKernelFactory
 import ru.souz.agent.AgentExecutor
 import ru.souz.agent.knowledge.ConversationKnowledgeStore
@@ -14,7 +15,6 @@ import ru.souz.agent.skills.validation.SkillValidationRecord
 import ru.souz.agent.skills.validation.SkillValidationStatus
 import ru.souz.agent.spi.AgentTelemetry
 import ru.souz.agent.spi.AgentToolCatalog
-import ru.souz.agent.spi.AgentToolsFilter
 import ru.souz.backend.agent.model.AgentConversationKey
 import ru.souz.backend.agent.model.BackendConversationTurnRequest
 import ru.souz.backend.agent.session.AgentConversationSession
@@ -124,13 +124,11 @@ class BackendConversationRuntimeFactory(
     private val sessionRepository: AgentSessionRepository,
     private val logObjectMapper: ObjectMapper,
     private val systemPrompt: String,
+    private val configuredAgentId: AgentId = AgentId.default,
     private val toolCatalog: AgentToolCatalog = BackendNoopAgentToolCatalog,
-    private val toolsFilter: AgentToolsFilter = BackendNoopAgentToolsFilter,
     private val skillRegistryRepository: SkillRegistryRepository? = null,
     private val skillCommandTool: LLMToolSetup? = null,
-    private val getSkillsTool: LLMToolSetup,
-    private val getKnowledgeTool: LLMToolSetup,
-    private val runtimeCommandTool: LLMToolSetup,
+    private val skillCoreToolsFactory: BackendSkillCoreToolsFactory,
     private val knowledgeStore: ConversationKnowledgeStore,
     private val agentBackgroundScope: kotlinx.coroutines.CoroutineScope,
 ) {
@@ -147,9 +145,19 @@ class BackendConversationRuntimeFactory(
             useFewShotExamples = request.useFewShotExamples ?: baseSettingsProvider.useFewShotExamples,
             requestTimeoutMillis = request.requestTimeoutMillis ?: baseSettingsProvider.requestTimeoutMillis,
         )
+        settingsProvider.activeAgentId = persistedSession?.activeAgentId ?: configuredAgentId
         val requestScopedToolCatalog = BackendFewShotAwareToolCatalog(
             delegate = toolCatalog,
             settingsProvider = settingsProvider,
+        )
+        val requestToolsFilter = BackendRequestToolsFilter(request.enabledTools)
+        val filteredToolCatalog = BackendRequestToolCatalog(
+            delegate = requestScopedToolCatalog,
+            toolsFilter = requestToolsFilter,
+        )
+        val skillCoreTools = skillCoreToolsFactory.create(
+            toolCatalog = requestScopedToolCatalog,
+            toolsFilter = requestToolsFilter,
         )
         val delegateApi = llmApiFactory(
             BackendLlmExecutionContext(
@@ -166,8 +174,8 @@ class BackendConversationRuntimeFactory(
             logObjectMapper = logObjectMapper,
             settingsProvider = settingsProvider,
             desktopInfoRepository = BackendNoopAgentDesktopInfoRepository,
-            toolCatalog = requestScopedToolCatalog,
-            toolsFilter = toolsFilter,
+            toolCatalog = filteredToolCatalog,
+            toolsFilter = requestToolsFilter,
             defaultBrowserProvider = BackendNoopDefaultBrowserProvider,
             runtimeEnvironment = BackendRequestRuntimeEnvironment(
                 localeTag = request.locale,
@@ -175,9 +183,9 @@ class BackendConversationRuntimeFactory(
             ),
             mcpToolProvider = BackendNoopMcpToolProvider,
             skillCommandTool = skillCommandTool,
-            getSkillsTool = getSkillsTool,
-            getKnowledgeTool = getKnowledgeTool,
-            runtimeCommandTool = runtimeCommandTool,
+            getSkillsTool = skillCoreTools.getSkillsTool,
+            getKnowledgeTool = skillCoreTools.getKnowledgeTool,
+            runtimeCommandTool = skillCoreTools.runtimeCommandTool,
             knowledgeStore = knowledgeStore,
             telemetry = AgentTelemetry.NONE,
             errorMessages = BackendAgentErrorMessages,

--- a/backend/src/main/kotlin/ru/souz/backend/agent/runtime/BackendRequestToolsFilter.kt
+++ b/backend/src/main/kotlin/ru/souz/backend/agent/runtime/BackendRequestToolsFilter.kt
@@ -1,0 +1,33 @@
+package ru.souz.backend.agent.runtime
+
+import ru.souz.agent.spi.AgentToolCatalog
+import ru.souz.agent.spi.AgentToolsFilter
+import ru.souz.llms.LLMToolSetup
+import ru.souz.tool.ToolCategory
+
+/** Immutable compiled-tool policy captured for one backend execution request. */
+internal class BackendRequestToolsFilter(
+    enabledToolNames: Set<String>?,
+) : AgentToolsFilter {
+    private val enabledToolNames: Set<String>? = enabledToolNames?.toSet()
+
+    override fun applyFilter(
+        toolsByCategory: Map<ToolCategory, Map<String, LLMToolSetup>>,
+    ): Map<ToolCategory, Map<String, LLMToolSetup>> =
+        enabledToolNames?.let { enabled ->
+            toolsByCategory.mapValues { (_, tools) ->
+                tools.filterKeys { toolName -> toolName in enabled }
+            }
+        } ?: toolsByCategory
+}
+
+/** Request-scoped execution catalog with the compiled-tool policy applied eagerly. */
+internal class BackendRequestToolCatalog(
+    delegate: AgentToolCatalog,
+    toolsFilter: AgentToolsFilter,
+) : AgentToolCatalog {
+    override val toolsByCategory: Map<ToolCategory, Map<String, LLMToolSetup>> =
+        toolsFilter.applyFilter(delegate.toolsByCategory)
+            .mapValues { (_, tools) -> tools.toMap() }
+            .toMap()
+}

--- a/backend/src/main/kotlin/ru/souz/backend/agent/runtime/BackendSkillCoreToolsFactory.kt
+++ b/backend/src/main/kotlin/ru/souz/backend/agent/runtime/BackendSkillCoreToolsFactory.kt
@@ -1,0 +1,42 @@
+package ru.souz.backend.agent.runtime
+
+import ru.souz.agent.skills.registry.SkillRegistryRepository
+import ru.souz.agent.spi.AgentToolCatalog
+import ru.souz.agent.spi.AgentToolsFilter
+import ru.souz.llms.LLMToolSetup
+import ru.souz.tool.skills.ToolGetSkills
+import ru.souz.tool.skills.ToolInvokeSkill
+import ru.souz.tool.skills.ToolRunSkillCommand
+
+data class BackendSkillCoreTools(
+    val getSkillsTool: LLMToolSetup,
+    val getKnowledgeTool: LLMToolSetup,
+    val runtimeCommandTool: LLMToolSetup,
+)
+
+/** Creates the skills-oriented graph's filtered tools for one backend request. */
+class BackendSkillCoreToolsFactory(
+    private val skillRegistryRepository: SkillRegistryRepository,
+    private val legacyCommandTool: LLMToolSetup,
+    private val getKnowledgeTool: LLMToolSetup,
+    private val commandTool: ToolRunSkillCommand,
+) {
+    fun create(
+        toolCatalog: AgentToolCatalog,
+        toolsFilter: AgentToolsFilter,
+    ): BackendSkillCoreTools = BackendSkillCoreTools(
+        getSkillsTool = ToolGetSkills(
+            toolCatalog = toolCatalog,
+            toolsFilter = toolsFilter,
+            repository = skillRegistryRepository,
+            legacyCommandTool = legacyCommandTool,
+        ),
+        getKnowledgeTool = getKnowledgeTool,
+        runtimeCommandTool = ToolInvokeSkill(
+            toolCatalog = toolCatalog,
+            toolsFilter = toolsFilter,
+            repository = skillRegistryRepository,
+            commandTool = commandTool,
+        ),
+    )
+}

--- a/backend/src/main/kotlin/ru/souz/backend/app/BackendAppConfig.kt
+++ b/backend/src/main/kotlin/ru/souz/backend/app/BackendAppConfig.kt
@@ -1,5 +1,6 @@
 package ru.souz.backend.app
 
+import ru.souz.agent.AgentId
 import ru.souz.backend.common.BackendConfigurationException
 import ru.souz.backend.config.BackendConfigSource
 import ru.souz.backend.config.BackendFeatureFlags
@@ -109,6 +110,7 @@ data class BackendAppConfig(
     val telegramPollingMaxConcurrency: Int = 4,
     val llmLimits: BackendLlmLimits = BackendLlmLimits(),
     val providerRetryPolicy: BackendProviderRetryPolicy = BackendProviderRetryPolicy(),
+    val agentId: AgentId = AgentId.default,
 ) {
     fun validate(): BackendAppConfig {
         server.validate()
@@ -241,6 +243,10 @@ data class BackendAppConfig(
                         default = 5_000L,
                     ),
                 ),
+                agentId = source.agentIdValue(
+                    envKey = "SOUZ_BACKEND_AGENT",
+                    propertyKey = "souz.backend.agent",
+                ),
             )
     }
 }
@@ -270,4 +276,19 @@ private fun BackendConfigSource.longValue(
     val rawValue = value(envKey, propertyKey)?.trim()?.takeIf { it.isNotEmpty() } ?: return default
     return rawValue.toLongOrNull()
         ?: throw BackendConfigurationException("Invalid long value '$rawValue' for $envKey / $propertyKey.")
+}
+
+private fun BackendConfigSource.agentIdValue(
+    envKey: String,
+    propertyKey: String,
+): AgentId {
+    val rawValue = value(envKey, propertyKey)?.trim()?.takeIf { it.isNotEmpty() }
+        ?: return AgentId.default
+    return when (rawValue.lowercase()) {
+        AgentId.GRAPH.storageValue -> AgentId.GRAPH
+        AgentId.SKILLS_GRAPH.storageValue -> AgentId.SKILLS_GRAPH
+        else -> throw BackendConfigurationException(
+            "Invalid value '$rawValue' for $envKey / $propertyKey. Expected one of: graph, skills."
+        )
+    }
 }

--- a/backend/src/main/kotlin/ru/souz/backend/app/BackendDiModule.kt
+++ b/backend/src/main/kotlin/ru/souz/backend/app/BackendDiModule.kt
@@ -16,6 +16,7 @@ import ru.souz.backend.app.BackendAppConfig
 import ru.souz.backend.agent.runtime.BackendSandboxScopeResolver
 import ru.souz.backend.agent.runtime.BackendConversationRuntimeFactory
 import ru.souz.backend.agent.runtime.BackendConversationRuntimeTurnRunner
+import ru.souz.backend.agent.runtime.BackendSkillCoreToolsFactory
 import ru.souz.backend.agent.session.AgentStateRepository
 import ru.souz.backend.agent.session.AgentSessionRepository
 import ru.souz.backend.bootstrap.BackendBootstrapService
@@ -75,6 +76,7 @@ import ru.souz.backend.telegram.TelegramBotTokenCrypto
 import ru.souz.skills.registry.FileSystemSkillRegistryConfig
 import ru.souz.skills.registry.SkillStorageScope
 import ru.souz.tool.runtimeToolsDiModule
+import ru.souz.tool.skills.ToolRunSkillCommand
 
 private object BackendDiTags {
     const val LOG_OBJECT_MAPPER = "backendLogObjectMapper"
@@ -198,18 +200,24 @@ fun backendDiModule(
         )
     }
     bindSingleton {
+        BackendSkillCoreToolsFactory(
+            skillRegistryRepository = instance(),
+            legacyCommandTool = instance(tag = SkillToolBindingTags.COMMAND_TOOL),
+            getKnowledgeTool = instance(tag = SkillToolBindingTags.GET_KNOWLEDGE_TOOL),
+            commandTool = instance<ToolRunSkillCommand>(),
+        )
+    }
+    bindSingleton {
         BackendConversationRuntimeFactory(
             baseSettingsProvider = instance(),
             llmApiFactory = { executionContext -> instance<LlmClientFactory>().create(executionContext) },
             sessionRepository = instance(),
             logObjectMapper = instance(BackendDiTags.LOG_OBJECT_MAPPER),
             systemPrompt = systemPrompt,
+            configuredAgentId = appConfig.agentId,
             toolCatalog = instance(),
-            toolsFilter = instance(),
             skillCommandTool = instance(tag = SkillToolBindingTags.COMMAND_TOOL),
-            getSkillsTool = instance(tag = SkillToolBindingTags.GET_SKILLS_TOOL),
-            getKnowledgeTool = instance(tag = SkillToolBindingTags.GET_KNOWLEDGE_TOOL),
-            runtimeCommandTool = instance(tag = SkillToolBindingTags.RUNTIME_COMMAND_TOOL),
+            skillCoreToolsFactory = instance(),
             knowledgeStore = instance<ConversationKnowledgeStore>(),
             skillRegistryRepository = instance(),
             agentBackgroundScope = instance<BackendApplicationScope>(),

--- a/backend/src/main/kotlin/ru/souz/backend/execution/service/AgentExecutionRequestFactory.kt
+++ b/backend/src/main/kotlin/ru/souz/backend/execution/service/AgentExecutionRequestFactory.kt
@@ -77,6 +77,7 @@ internal class AgentExecutionRequestFactory(
                 showToolEvents = effectiveSettings.showToolEvents,
                 requestTimeoutMillis = effectiveSettings.requestTimeoutMillis,
                 useFewShotExamples = effectiveSettings.useFewShotExamples,
+                enabledTools = effectiveSettings.enabledTools,
             ),
         )
 
@@ -97,6 +98,7 @@ internal class AgentExecutionRequestFactory(
                 streamingMessages = effectiveSettings.streamingMessages,
                 requestTimeoutMillis = effectiveSettings.requestTimeoutMillis,
                 useFewShotExamples = effectiveSettings.useFewShotExamples,
+                enabledTools = effectiveSettings.enabledTools.toSet(),
             ),
             userMessageMetadata = userMessageMetadata(normalizedClientMessageId),
             shouldReturnRunning = effectiveSettings.streamingMessages && featureFlags.wsEvents,
@@ -136,6 +138,7 @@ internal class AgentExecutionRequestFactory(
             streamingMessages = executionMetadataBoolean(execution, METADATA_STREAMING_MESSAGES),
             requestTimeoutMillis = executionMetadataLong(execution, METADATA_REQUEST_TIMEOUT_MILLIS),
             useFewShotExamples = executionMetadataBoolean(execution, METADATA_USE_FEW_SHOT_EXAMPLES),
+            enabledTools = executionMetadataStringSet(execution, METADATA_ENABLED_TOOLS),
         )
 
     fun createEventSink(
@@ -184,6 +187,7 @@ internal class AgentExecutionRequestFactory(
         showToolEvents: Boolean,
         requestTimeoutMillis: Long,
         useFewShotExamples: Boolean,
+        enabledTools: Set<String>,
     ): Map<String, String> = buildMap {
         put(METADATA_CONTEXT_SIZE, contextSize.toString())
         put(METADATA_TEMPERATURE, temperature.toString())
@@ -193,6 +197,7 @@ internal class AgentExecutionRequestFactory(
         put(METADATA_SHOW_TOOL_EVENTS, showToolEvents.toString())
         put(METADATA_REQUEST_TIMEOUT_MILLIS, requestTimeoutMillis.toString())
         put(METADATA_USE_FEW_SHOT_EXAMPLES, useFewShotExamples.toString())
+        put(METADATA_ENABLED_TOOLS, restJsonMapper.writeValueAsString(enabledTools.sorted()))
         systemPrompt?.let { put(METADATA_SYSTEM_PROMPT, it) }
     }
 
@@ -215,6 +220,18 @@ internal class AgentExecutionRequestFactory(
         execution: AgentExecution,
         key: String,
     ): Boolean? = execution.metadata[key]?.toBooleanStrictOrNull()
+
+    private fun executionMetadataStringSet(
+        execution: AgentExecution,
+        key: String,
+    ): Set<String>? {
+        val raw = execution.metadata[key] ?: return null
+        return runCatching {
+            restJsonMapper.readValue(raw, Array<String>::class.java).toSet()
+        }.getOrElse {
+            throw internalError("Execution $key metadata is invalid.")
+        }
+    }
 }
 
 private fun Option.toContinuationInput(): String {
@@ -256,4 +273,5 @@ private const val METADATA_STREAMING_MESSAGES = "streamingMessages"
 private const val METADATA_SHOW_TOOL_EVENTS = "showToolEvents"
 private const val METADATA_REQUEST_TIMEOUT_MILLIS = "requestTimeoutMillis"
 private const val METADATA_USE_FEW_SHOT_EXAMPLES = "useFewShotExamples"
+private const val METADATA_ENABLED_TOOLS = "enabledTools"
 private const val OPTION_CONTINUATION_PREFIX = "__option_answer__"

--- a/backend/src/test/kotlin/ru/souz/backend/AgentCoreTestFixtures.kt
+++ b/backend/src/test/kotlin/ru/souz/backend/AgentCoreTestFixtures.kt
@@ -3,11 +3,15 @@ package ru.souz.backend
 import ru.souz.agent.knowledge.ConversationKnowledgeStore
 import ru.souz.agent.knowledge.KnowledgeEntry
 import ru.souz.agent.knowledge.KnowledgeWriteResult
+import ru.souz.agent.skills.registry.SkillRegistryRepository
+import ru.souz.backend.agent.runtime.BackendSkillCoreToolsFactory
 import ru.souz.llms.LLMMessageRole
 import ru.souz.llms.LLMRequest
 import ru.souz.llms.LLMResponse
 import ru.souz.llms.LLMToolSetup
 import ru.souz.llms.ToolInvocationMeta
+import ru.souz.runtime.sandbox.ToolInvocationRuntimeSandboxResolver
+import ru.souz.tool.skills.ToolRunSkillCommand
 
 internal fun testCoreTool(name: String): LLMToolSetup = object : LLMToolSetup {
     override val fn: LLMRequest.Function = LLMRequest.Function(
@@ -23,6 +27,19 @@ internal fun testCoreTool(name: String): LLMToolSetup = object : LLMToolSetup {
             name = functionCall.name,
         )
 }
+
+internal fun testSkillCoreToolsFactory(
+    skillRegistryRepository: SkillRegistryRepository = TestSkillRegistryRepository,
+): BackendSkillCoreToolsFactory = BackendSkillCoreToolsFactory(
+    skillRegistryRepository = skillRegistryRepository,
+    legacyCommandTool = testCoreTool("RunSkillCommand"),
+    getKnowledgeTool = testCoreTool("GetKnowledge"),
+    commandTool = ToolRunSkillCommand(
+        ToolInvocationRuntimeSandboxResolver {
+            error("The test skill command sandbox is not configured.")
+        }
+    ),
+)
 
 internal object TestConversationKnowledgeStore : ConversationKnowledgeStore {
     override suspend fun put(

--- a/backend/src/test/kotlin/ru/souz/backend/agent/runtime/BackendConversationRuntimeSettingsTest.kt
+++ b/backend/src/test/kotlin/ru/souz/backend/agent/runtime/BackendConversationRuntimeSettingsTest.kt
@@ -14,9 +14,10 @@ import ru.souz.agent.AgentId
 import ru.souz.agent.runtime.AgentRuntimeEventSink
 import ru.souz.backend.TestSettingsProvider
 import ru.souz.backend.TestConversationKnowledgeStore
-import ru.souz.backend.testCoreTool
+import ru.souz.backend.testSkillCoreToolsFactory
 import ru.souz.backend.agent.model.AgentConversationKey
 import ru.souz.backend.agent.model.BackendConversationTurnRequest
+import ru.souz.backend.agent.session.AgentConversationSession
 import ru.souz.backend.agent.session.InMemoryAgentSessionRepository
 import ru.souz.llms.LLMChatAPI
 import ru.souz.llms.LLMMessageRole
@@ -32,7 +33,7 @@ class BackendConversationRuntimeSettingsTest {
         val api = ReplyingChatApi()
         val settings = TestSettingsProvider().apply {
             gigaChatKey = "giga-key"
-            activeAgentId = AgentId.SKILLS_GRAPH
+            activeAgentId = AgentId.GRAPH
         }
         val runtimeFactory = runtimeFactory(
             settingsProvider = settings,
@@ -41,6 +42,7 @@ class BackendConversationRuntimeSettingsTest {
                 category = ToolCategory.FILES,
                 tool = fakeTool(name = "ListFiles", fewShotExamples = emptyList()),
             ),
+            configuredAgentId = AgentId.SKILLS_GRAPH,
         )
         val request = turnRequest()
 
@@ -54,6 +56,68 @@ class BackendConversationRuntimeSettingsTest {
             listOf("GetSkills", "GetKnowledge", "RunSkillCommand"),
             api.finalRequests.single().functions.map { it.name },
         )
+    }
+
+    @Test
+    fun `new runtime uses configured graph instead of shared jvm preference`() = runTest {
+        val api = ReplyingChatApi(classificationResponse = "FILES 100")
+        val settings = TestSettingsProvider().apply {
+            gigaChatKey = "giga-key"
+            activeAgentId = AgentId.SKILLS_GRAPH
+        }
+        val runtimeFactory = runtimeFactory(
+            settingsProvider = settings,
+            llmApiFactory = { api },
+            toolCatalog = singleToolCatalog(
+                category = ToolCategory.FILES,
+                tool = fakeTool(name = "ListFiles", fewShotExamples = emptyList()),
+            ),
+            configuredAgentId = AgentId.GRAPH,
+        )
+        val request = turnRequest()
+
+        runtimeFactory.create(conversationKey(), request).execute(
+            request = request,
+            persistSession = false,
+            eventSink = AgentRuntimeEventSink.NONE,
+        )
+
+        assertEquals(listOf("ListFiles"), api.finalRequests.single().functions.map { it.name })
+    }
+
+    @Test
+    fun `persisted conversation agent takes precedence over backend configuration`() = runTest {
+        val api = ReplyingChatApi(classificationResponse = "FILES 100")
+        val sessionRepository = InMemoryAgentSessionRepository()
+        val key = conversationKey()
+        sessionRepository.save(
+            key,
+            AgentConversationSession(
+                activeAgentId = AgentId.GRAPH,
+                history = emptyList(),
+                temperature = 0.4f,
+                locale = "en-US",
+                timeZone = "UTC",
+            )
+        )
+        val runtimeFactory = runtimeFactory(
+            llmApiFactory = { api },
+            toolCatalog = singleToolCatalog(
+                category = ToolCategory.FILES,
+                tool = fakeTool(name = "ListFiles", fewShotExamples = emptyList()),
+            ),
+            configuredAgentId = AgentId.SKILLS_GRAPH,
+            sessionRepository = sessionRepository,
+        )
+        val request = turnRequest()
+
+        runtimeFactory.create(key, request).execute(
+            request = request,
+            persistSession = false,
+            eventSink = AgentRuntimeEventSink.NONE,
+        )
+
+        assertEquals(listOf("ListFiles"), api.finalRequests.single().functions.map { it.name })
     }
 
     @Test
@@ -140,23 +204,68 @@ class BackendConversationRuntimeSettingsTest {
             api.finalRequests.single().functions.single().fewShotExamples.orEmpty(),
         )
     }
+
+    @Test
+    fun `runtime applies enabled tool snapshot to compiled tools`() = runTest {
+        val api = ReplyingChatApi(classificationResponse = "FILES 100")
+        val runtimeFactory = runtimeFactory(
+            llmApiFactory = { api },
+            toolCatalog = singleToolCatalog(
+                category = ToolCategory.FILES,
+                tool = fakeTool(name = "ListFiles", fewShotExamples = emptyList()),
+            ),
+        )
+        val enabledTools = linkedSetOf<String>()
+        val request = turnRequest().copy(enabledTools = enabledTools)
+        val runtime = runtimeFactory.create(conversationKey(), request)
+        enabledTools += "ListFiles"
+
+        runtime.execute(
+            request = request,
+            persistSession = false,
+            eventSink = AgentRuntimeEventSink.NONE,
+        )
+
+        assertEquals(emptyList(), api.finalRequests.single().functions)
+    }
+
+    @Test
+    fun `request tool catalog captures an immutable enabled tool snapshot`() {
+        val sourceCatalog = singleToolCatalog(
+            category = ToolCategory.FILES,
+            tool = fakeTool(name = "ListFiles", fewShotExamples = emptyList()),
+        )
+        val enabledTools = linkedSetOf("ListFiles")
+        val requestCatalog = BackendRequestToolCatalog(
+            delegate = sourceCatalog,
+            toolsFilter = BackendRequestToolsFilter(enabledTools),
+        )
+
+        enabledTools.clear()
+
+        assertEquals(
+            setOf("ListFiles"),
+            requestCatalog.toolsByCategory.values.flatMap { it.keys }.toSet(),
+        )
+    }
 }
 
 private fun runtimeFactory(
     settingsProvider: TestSettingsProvider = TestSettingsProvider().apply { gigaChatKey = "giga-key" },
     llmApiFactory: suspend (ru.souz.backend.llm.BackendLlmExecutionContext) -> LLMChatAPI,
     toolCatalog: ru.souz.agent.spi.AgentToolCatalog = BackendNoopAgentToolCatalog,
+    configuredAgentId: AgentId = AgentId.GRAPH,
+    sessionRepository: InMemoryAgentSessionRepository = InMemoryAgentSessionRepository(),
 ): BackendConversationRuntimeFactory =
     BackendConversationRuntimeFactory(
         baseSettingsProvider = settingsProvider,
         llmApiFactory = llmApiFactory,
-        sessionRepository = InMemoryAgentSessionRepository(),
+        sessionRepository = sessionRepository,
         logObjectMapper = jacksonObjectMapper(),
         systemPrompt = "backend test prompt",
+        configuredAgentId = configuredAgentId,
         toolCatalog = toolCatalog,
-        getSkillsTool = testCoreTool("GetSkills"),
-        getKnowledgeTool = testCoreTool("GetKnowledge"),
-        runtimeCommandTool = testCoreTool("RunSkillCommand"),
+        skillCoreToolsFactory = testSkillCoreToolsFactory(),
         knowledgeStore = TestConversationKnowledgeStore,
         agentBackgroundScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
     )

--- a/backend/src/test/kotlin/ru/souz/backend/agent/runtime/BackendConversationRuntimeTurnRunnerTest.kt
+++ b/backend/src/test/kotlin/ru/souz/backend/agent/runtime/BackendConversationRuntimeTurnRunnerTest.kt
@@ -17,7 +17,7 @@ import ru.souz.backend.TestSkillRegistryRepository
 import ru.souz.backend.TestConversationKnowledgeStore
 import ru.souz.agent.runtime.AgentRuntimeEventSink
 import ru.souz.backend.TestSettingsProvider
-import ru.souz.backend.testCoreTool
+import ru.souz.backend.testSkillCoreToolsFactory
 import ru.souz.backend.agent.model.AgentConversationKey
 import ru.souz.backend.agent.model.BackendConversationTurnRequest
 import ru.souz.backend.agent.session.InMemoryAgentSessionRepository
@@ -83,9 +83,7 @@ private fun runtimeTurnRunner(failure: Throwable): BackendConversationRuntimeTur
             logObjectMapper = jacksonObjectMapper(),
             systemPrompt = "backend test prompt",
             skillRegistryRepository = TestSkillRegistryRepository,
-            getSkillsTool = testCoreTool("GetSkills"),
-            getKnowledgeTool = testCoreTool("GetKnowledge"),
-            runtimeCommandTool = testCoreTool("RunSkillCommand"),
+            skillCoreToolsFactory = testSkillCoreToolsFactory(),
             knowledgeStore = TestConversationKnowledgeStore,
             agentBackgroundScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
         )

--- a/backend/src/test/kotlin/ru/souz/backend/agent/runtime/BackendSkillCoreToolsFactoryTest.kt
+++ b/backend/src/test/kotlin/ru/souz/backend/agent/runtime/BackendSkillCoreToolsFactoryTest.kt
@@ -1,0 +1,257 @@
+package ru.souz.backend.agent.runtime
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Instant
+import java.util.Base64
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import ru.souz.agent.skills.activation.SkillId
+import ru.souz.agent.skills.bundle.SkillBundle
+import ru.souz.agent.skills.bundle.SkillBundleHasher
+import ru.souz.agent.skills.bundle.SkillFile
+import ru.souz.agent.skills.bundle.SkillManifest
+import ru.souz.agent.skills.registry.SkillRegistryRepository
+import ru.souz.agent.skills.registry.StoredSkill
+import ru.souz.agent.skills.validation.SkillValidationRecord
+import ru.souz.agent.skills.validation.SkillValidationStatus
+import ru.souz.agent.spi.AgentToolCatalog
+import ru.souz.backend.TestSettingsProvider
+import ru.souz.backend.testCoreTool
+import ru.souz.llms.LLMMessageRole
+import ru.souz.llms.LLMRequest
+import ru.souz.llms.LLMResponse
+import ru.souz.llms.LLMToolSetup
+import ru.souz.llms.ToolInvocationMeta
+import ru.souz.llms.giga.toGiga
+import ru.souz.llms.restJsonMapper
+import ru.souz.runtime.sandbox.SandboxCommandRuntime
+import ru.souz.runtime.sandbox.SandboxScope
+import ru.souz.runtime.sandbox.ToolInvocationRuntimeSandboxResolver
+import ru.souz.runtime.sandbox.local.LocalRuntimeSandbox
+import ru.souz.skills.registry.SkillStorageScope
+import ru.souz.tool.ToolCategory
+import ru.souz.tool.skills.ToolRunSkillCommand
+
+class BackendSkillCoreToolsFactoryTest {
+    private val createdPaths = mutableListOf<Path>()
+
+    @AfterTest
+    fun cleanup() {
+        createdPaths.asReversed().forEach { path ->
+            runCatching { path.toFile().deleteRecursively() }
+        }
+    }
+
+    @Test
+    fun `request tool snapshot hides disabled compiled tools and keeps file skills`() = runTest {
+        val enabledTool = RecordingTool("EnabledTool")
+        val disabledTool = RecordingTool("DisabledTool")
+        val catalog = catalog(enabledTool, disabledTool)
+        val fileSkill = fileSkillBundle()
+        val repository = SingleBundleRepository(fileSkill)
+        val home = Files.createTempDirectory("backend-skill-tools-").also(createdPaths::add)
+        val stateRoot = home.resolve("state").also(Files::createDirectories)
+        createUserScopedBundleRoot(stateRoot, USER_ID, fileSkill)
+        val sandbox = LocalRuntimeSandbox(
+            scope = SandboxScope(userId = USER_ID),
+            settingsProvider = TestSettingsProvider(),
+            homePath = home,
+            stateRoot = stateRoot,
+        )
+        val commandTool = ToolRunSkillCommand(
+            sandboxResolver = ToolInvocationRuntimeSandboxResolver.fixed(sandbox),
+            skillStorageScope = SkillStorageScope.USER_SCOPED,
+        )
+        val factory = BackendSkillCoreToolsFactory(
+            skillRegistryRepository = repository,
+            legacyCommandTool = commandTool.toGiga(),
+            getKnowledgeTool = testCoreTool("GetKnowledge"),
+            commandTool = commandTool,
+        )
+        val mutableEnabledTools = linkedSetOf("EnabledTool")
+        val toolsFilter = BackendRequestToolsFilter(mutableEnabledTools)
+        mutableEnabledTools += "DisabledTool"
+
+        val coreTools = factory.create(catalog, toolsFilter)
+        val meta = ToolInvocationMeta(userId = USER_ID, conversationId = "conversation-a")
+        val summaries = coreTools.getSkillsTool.invoke(
+            LLMResponse.FunctionCall(name = "GetSkills", arguments = emptyMap()),
+            meta,
+        ).contentJson()
+
+        assertEquals(
+            listOf("EnabledTool", FILE_SKILL_ID),
+            summaries["results"].map { it["skillId"].asText() },
+        )
+        assertFalse(summaries.toString().contains("DisabledTool"))
+        assertEquals(
+            listOf("GetSkills", "GetKnowledge", "RunSkillCommand"),
+            listOf(
+                coreTools.getSkillsTool.fn.name,
+                coreTools.getKnowledgeTool.fn.name,
+                coreTools.runtimeCommandTool.fn.name,
+            ),
+        )
+
+        val enabledResult = coreTools.runtimeCommandTool.invoke(
+            skillCall("EnabledTool", mapOf("value" to "ok")),
+            meta,
+        )
+        val disabledResult = coreTools.runtimeCommandTool.invoke(
+            skillCall("DisabledTool"),
+            meta,
+        ).contentJson()
+        val fileResult = coreTools.runtimeCommandTool.invoke(
+            skillCall(
+                FILE_SKILL_ID,
+                mapOf(
+                    "runtime" to SandboxCommandRuntime.BASH.name,
+                    "script" to "printf 'file-skill-ok'",
+                ),
+            ),
+            meta,
+        ).contentJson()
+
+        assertEquals("enabled-ok", enabledResult.content)
+        assertEquals(mapOf("value" to "ok"), enabledTool.lastArguments)
+        assertEquals(1, enabledTool.invocationCount)
+        assertEquals("skill_disabled", disabledResult["error"]["code"].asText())
+        assertEquals(0, fileResult["exitCode"].asInt())
+        assertEquals("file-skill-ok", fileResult["stdout"].asText())
+        assertEquals(0, disabledTool.invocationCount)
+    }
+
+    private fun createUserScopedBundleRoot(
+        stateRoot: Path,
+        userId: String,
+        bundle: SkillBundle,
+    ) {
+        val encodedUserId = Base64.getUrlEncoder()
+            .withoutPadding()
+            .encodeToString(userId.toByteArray(StandardCharsets.UTF_8))
+        Files.createDirectories(
+            stateRoot.resolve("skills/users/$encodedUserId/skills/${bundle.skillId.value}/bundles/${SkillBundleHasher.hash(bundle)}")
+        )
+    }
+
+    private fun skillCall(
+        skillId: String,
+        arguments: Map<String, Any> = emptyMap(),
+    ): LLMResponse.FunctionCall = LLMResponse.FunctionCall(
+        name = "RunSkillCommand",
+        arguments = mapOf("skillId" to skillId, "arguments" to arguments),
+    )
+
+    private companion object {
+        const val USER_ID = "backend-user"
+        const val FILE_SKILL_ID = "file-skill"
+    }
+}
+
+private class RecordingTool(name: String) : LLMToolSetup {
+    var lastArguments: Map<String, Any> = emptyMap()
+    var invocationCount: Int = 0
+
+    override val fn: LLMRequest.Function = LLMRequest.Function(
+        name = name,
+        description = "Description $name",
+        parameters = LLMRequest.Parameters(
+            type = "object",
+            properties = mapOf("value" to LLMRequest.Property("string")),
+        ),
+    )
+
+    override suspend fun invoke(functionCall: LLMResponse.FunctionCall): LLMRequest.Message =
+        invoke(functionCall, ToolInvocationMeta.localDefault())
+
+    override suspend fun invoke(
+        functionCall: LLMResponse.FunctionCall,
+        meta: ToolInvocationMeta,
+    ): LLMRequest.Message {
+        invocationCount += 1
+        lastArguments = functionCall.arguments
+        return LLMRequest.Message(
+            role = LLMMessageRole.function,
+            content = "enabled-ok",
+            name = functionCall.name,
+        )
+    }
+}
+
+private fun catalog(vararg tools: LLMToolSetup): AgentToolCatalog = object : AgentToolCatalog {
+    override val toolsByCategory: Map<ToolCategory, Map<String, LLMToolSetup>> =
+        mapOf(ToolCategory.FILES to tools.associateBy { it.fn.name })
+}
+
+private fun fileSkillBundle(): SkillBundle {
+    val manifest = SkillManifest(
+        name = "File Skill",
+        description = "A user-installed file-backed skill.",
+        rawFrontmatter = "name: File Skill",
+    )
+    return SkillBundle(
+        skillId = SkillId("file-skill"),
+        manifest = manifest,
+        files = listOf(SkillFile("SKILL.md", "Use the file skill.".toByteArray())),
+        skillMarkdownBody = "Use the file skill.",
+    )
+}
+
+private class SingleBundleRepository(
+    private val bundle: SkillBundle,
+) : SkillRegistryRepository {
+    private val stored = StoredSkill(
+        userId = "backend-user",
+        skillId = bundle.skillId,
+        manifest = bundle.manifest,
+        bundleHash = SkillBundleHasher.hash(bundle),
+        createdAt = Instant.EPOCH,
+    )
+
+    override suspend fun listSkills(userId: String): List<StoredSkill> = listOf(stored)
+
+    override suspend fun getSkill(userId: String, skillId: SkillId): StoredSkill? =
+        stored.takeIf { it.skillId == skillId }
+
+    override suspend fun getSkillByName(userId: String, name: String): StoredSkill? =
+        stored.takeIf { it.manifest.name == name }
+
+    override suspend fun saveSkillBundle(userId: String, bundle: SkillBundle): StoredSkill = stored
+
+    override suspend fun loadSkillBundle(userId: String, skillId: SkillId): SkillBundle? =
+        bundle.takeIf { it.skillId == skillId }
+
+    override suspend fun getValidation(
+        userId: String,
+        skillId: SkillId,
+        bundleHash: String,
+        policyVersion: String,
+    ): SkillValidationRecord? = null
+
+    override suspend fun saveValidation(record: SkillValidationRecord) = Unit
+
+    override suspend fun markValidationStatus(
+        userId: String,
+        skillId: SkillId,
+        bundleHash: String,
+        policyVersion: String,
+        status: SkillValidationStatus,
+        reason: String?,
+    ) = Unit
+
+    override suspend fun invalidateOtherValidations(
+        userId: String,
+        skillId: SkillId,
+        activeBundleHash: String,
+        policyVersion: String,
+        reason: String?,
+    ) = Unit
+}
+
+private fun LLMRequest.Message.contentJson() = restJsonMapper.readTree(content)

--- a/backend/src/test/kotlin/ru/souz/backend/config/BackendFeatureFlagsTest.kt
+++ b/backend/src/test/kotlin/ru/souz/backend/config/BackendFeatureFlagsTest.kt
@@ -6,6 +6,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import ru.souz.agent.AgentId
 import ru.souz.backend.app.BackendAppConfig
 import ru.souz.backend.app.BackendLlmLimits
 import ru.souz.backend.app.BackendPostgresConfig
@@ -50,6 +51,49 @@ class BackendFeatureFlagsTest {
 }
 
 class BackendAppConfigTest {
+    @Test
+    fun `backend agent defaults to graph and reads env or property`() {
+        val defaultConfig = BackendAppConfig.load(
+            MapBackendConfigSource(env = mapOf("SOUZ_MASTER_KEY" to "test-master-key"))
+        )
+        val envConfig = BackendAppConfig.load(
+            MapBackendConfigSource(
+                env = mapOf(
+                    "SOUZ_MASTER_KEY" to "test-master-key",
+                    "SOUZ_BACKEND_AGENT" to " skills ",
+                ),
+                properties = mapOf("souz.backend.agent" to "graph"),
+            )
+        )
+        val propertyConfig = BackendAppConfig.load(
+            MapBackendConfigSource(
+                env = mapOf("SOUZ_MASTER_KEY" to "test-master-key"),
+                properties = mapOf("souz.backend.agent" to "SKILLS"),
+            )
+        )
+
+        assertEquals(AgentId.GRAPH, defaultConfig.agentId)
+        assertEquals(AgentId.SKILLS_GRAPH, envConfig.agentId)
+        assertEquals(AgentId.SKILLS_GRAPH, propertyConfig.agentId)
+    }
+
+    @Test
+    fun `backend agent rejects unsupported values`() {
+        val error = assertFailsWith<BackendConfigurationException> {
+            BackendAppConfig.load(
+                MapBackendConfigSource(
+                    env = mapOf(
+                        "SOUZ_MASTER_KEY" to "test-master-key",
+                        "SOUZ_BACKEND_AGENT" to "desktop",
+                    )
+                )
+            )
+        }
+
+        assertTrue(error.message.orEmpty().contains("SOUZ_BACKEND_AGENT"))
+        assertTrue(error.message.orEmpty().contains("graph, skills"))
+    }
+
     @Test
     fun `server config reads defaults and explicit settings`() {
         val defaultConfig = BackendAppConfig.load(

--- a/backend/src/test/kotlin/ru/souz/backend/execution/service/AgentExecutionRequestFactoryTest.kt
+++ b/backend/src/test/kotlin/ru/souz/backend/execution/service/AgentExecutionRequestFactoryTest.kt
@@ -11,6 +11,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
 import ru.souz.backend.TestSettingsProvider
+import ru.souz.backend.testCoreTool
 import ru.souz.backend.agent.model.AgentConversationKey
 import ru.souz.backend.agent.runtime.BackendNoopAgentToolCatalog
 import ru.souz.backend.config.BackendFeatureFlags
@@ -25,9 +26,11 @@ import ru.souz.backend.settings.service.EffectiveSettingsResolver
 import ru.souz.backend.settings.service.UserSettingsOverrides
 import ru.souz.backend.testutil.repository.MemoryUserProviderKeyRepository
 import ru.souz.backend.testutil.repository.MemoryUserSettingsRepository
+import ru.souz.agent.spi.AgentToolCatalog
 import ru.souz.llms.LLMModel
 import ru.souz.llms.LocalModelAvailability
 import ru.souz.llms.restJsonMapper
+import ru.souz.tool.ToolCategory
 
 class AgentExecutionRequestFactoryTest {
     @Test
@@ -50,7 +53,7 @@ class AgentExecutionRequestFactoryTest {
                 userSettingsRepository = MemoryUserSettingsRepository(),
                 userProviderKeyRepository = MemoryUserProviderKeyRepository(),
                 featureFlags = featureFlags,
-                toolCatalog = BackendNoopAgentToolCatalog,
+                toolCatalog = toolCatalog("ListFiles", "InternetSearch"),
                 localModelAvailability = unavailableLocalModels(),
             ),
             featureFlags = featureFlags,
@@ -73,6 +76,7 @@ class AgentExecutionRequestFactoryTest {
                 interfaceLanguage = "en",
                 requestTimeoutMillis = 45_000L,
                 useFewShotExamples = false,
+                enabledTools = setOf("ListFiles"),
             ),
         )
 
@@ -96,6 +100,7 @@ class AgentExecutionRequestFactoryTest {
         assertEquals("en", effectiveSettings.interfaceLanguage)
         assertEquals(45_000L, effectiveSettings.requestTimeoutMillis)
         assertFalse(effectiveSettings.useFewShotExamples)
+        assertEquals(setOf("ListFiles"), effectiveSettings.enabledTools)
 
         val execution = prepared.execution
         assertEquals(AgentExecutionStatus.QUEUED, execution.status)
@@ -111,6 +116,7 @@ class AgentExecutionRequestFactoryTest {
         assertEquals("false", execution.metadata.getValue("showToolEvents"))
         assertEquals("45000", execution.metadata.getValue("requestTimeoutMillis"))
         assertEquals("false", execution.metadata.getValue("useFewShotExamples"))
+        assertEquals("[\"ListFiles\"]", execution.metadata.getValue("enabledTools"))
 
         val runtimeRequest = prepared.runtimeRequest
         assertEquals("Summarize this chat.", runtimeRequest.prompt)
@@ -124,6 +130,7 @@ class AgentExecutionRequestFactoryTest {
         assertEquals(true, runtimeRequest.streamingMessages)
         assertEquals(45_000L, runtimeRequest.requestTimeoutMillis)
         assertEquals(false, runtimeRequest.useFewShotExamples)
+        assertEquals(setOf("ListFiles"), runtimeRequest.enabledTools)
     }
 
     @Test
@@ -161,6 +168,7 @@ class AgentExecutionRequestFactoryTest {
                 "showToolEvents" to "true",
                 "requestTimeoutMillis" to "46000",
                 "useFewShotExamples" to "false",
+                "enabledTools" to "[\"ListFiles\",\"InternetSearch\"]",
             ),
         )
         val option = Option(
@@ -199,6 +207,7 @@ class AgentExecutionRequestFactoryTest {
         assertEquals(true, request.streamingMessages)
         assertEquals(46_000L, request.requestTimeoutMillis)
         assertEquals(false, request.useFewShotExamples)
+        assertEquals(setOf("ListFiles", "InternetSearch"), request.enabledTools)
         assertTrue(request.prompt.startsWith("__option_answer__ "))
 
         val payload = restJsonMapper.readTree(request.prompt.removePrefix("__option_answer__ "))
@@ -234,4 +243,10 @@ class AgentExecutionRequestFactoryTest {
 
             override fun defaultGigaModel(): LLMModel? = null
         }
+}
+
+private fun toolCatalog(vararg toolNames: String): AgentToolCatalog = object : AgentToolCatalog {
+    override val toolsByCategory = mapOf(
+        ToolCategory.FILES to toolNames.associateWith(::testCoreTool)
+    )
 }

--- a/backend/src/test/kotlin/ru/souz/backend/http/BackendStage3RouteTest.kt
+++ b/backend/src/test/kotlin/ru/souz/backend/http/BackendStage3RouteTest.kt
@@ -34,7 +34,7 @@ import ru.souz.agent.spi.AgentToolCatalog
 import ru.souz.backend.TestSettingsProvider
 import ru.souz.backend.TestConversationKnowledgeStore
 import ru.souz.backend.TestSkillRegistryRepository
-import ru.souz.backend.testCoreTool
+import ru.souz.backend.testSkillCoreToolsFactory
 import ru.souz.backend.agent.model.AgentConversationKey
 import ru.souz.backend.agent.runtime.BackendConversationRuntimeFactory
 import ru.souz.backend.agent.session.AgentConversationState
@@ -1264,9 +1264,7 @@ internal fun routeTestContext(
         systemPrompt = "global backend prompt",
         toolCatalog = toolCatalog,
         skillRegistryRepository = TestSkillRegistryRepository,
-        getSkillsTool = testCoreTool("GetSkills"),
-        getKnowledgeTool = testCoreTool("GetKnowledge"),
-        runtimeCommandTool = testCoreTool("RunSkillCommand"),
+        skillCoreToolsFactory = testSkillCoreToolsFactory(),
         knowledgeStore = TestConversationKnowledgeStore,
         agentBackgroundScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
     )

--- a/sharedLogic/src/commonJvmMain/kotlin/ru/souz/tool/skills/ToolGetSkills.kt
+++ b/sharedLogic/src/commonJvmMain/kotlin/ru/souz/tool/skills/ToolGetSkills.kt
@@ -23,7 +23,7 @@ import ru.souz.llms.restJsonMapper
  *
  * This tool returns structured JSON, so using [ru.souz.tool.ToolSetup] would double-encode the response.
  */
-class ToolGetSkills internal constructor(
+class ToolGetSkills(
     private val toolCatalog: AgentToolCatalog,
     private val toolsFilter: AgentToolsFilter,
     private val repository: SkillRegistryRepository,

--- a/sharedLogic/src/commonJvmMain/kotlin/ru/souz/tool/skills/ToolInvokeSkill.kt
+++ b/sharedLogic/src/commonJvmMain/kotlin/ru/souz/tool/skills/ToolInvokeSkill.kt
@@ -21,7 +21,7 @@ import ru.souz.llms.restJsonMapper
  * structured command results without the additional String serialization performed by
  * [ru.souz.llms.giga.toGiga].
  */
-class ToolInvokeSkill internal constructor(
+class ToolInvokeSkill(
     private val toolCatalog: AgentToolCatalog,
     private val toolsFilter: AgentToolsFilter,
     private val repository: SkillRegistryRepository,


### PR DESCRIPTION
## What changed

- Snapshot each user's effective `enabledTools` into execution metadata and restore it for option continuations.
- Build immutable request-scoped compiled-tool catalogs and skill wrappers so disabled tools are neither advertised by `GetSkills` nor callable through `RunSkillCommand`.
- Keep the three core skill tools and user-installed file-backed skills available.
- Add `SOUZ_BACKEND_AGENT` / `souz.backend.agent` with `graph` and `skills` values, defaulting to `graph`.
- Use backend configuration for new conversations while preserving the agent stored by existing conversations.
- Document the backend behavior and add focused regression coverage.

## Why

The backend previously used shared singleton tool/filter wiring and the shared JVM agent preference. As a result, per-user tool settings were not enforced by the skills graph, and new backend conversations had no explicit host-owned agent selection.

The new wiring captures both decisions at backend request/conversation boundaries without mutating singleton state.

## Impact

Backend users can only discover and invoke compiled tools enabled in their effective settings. Continuations keep the original execution's tool set, and changing backend agent configuration affects only new conversations.

## Validation

- `./gradlew :agent:test :sharedLogic:jvmTest :sharedLogic:compileAndroidMain`
- `JAVA_TOOL_OPTIONS=-Dapi.version=1.44 ./gradlew :backend:test --rerun-tasks --no-daemon` — 221 tests passed against local Docker/PostgreSQL
- `SOUZ_TEST_DOCKER=1 ./gradlew :sharedLogic:jvmTest --tests ru.souz.runtime.sandbox.docker.DockerRuntimeSandboxIntegrationTest --rerun-tasks --no-daemon` — 8 Docker sandbox tests passed
- `git diff --check`
