### PR TITLE
Harden desktop agent scenario tests

### DIFF
--- a/desktopApp/src/test/kotlin/agent/AgentScenarioTestSupport.kt
+++ b/desktopApp/src/test/kotlin/agent/AgentScenarioTestSupport.kt
@@ -12,13 +12,14 @@ import org.kodein.di.bindProvider
 import org.kodein.di.bindSingleton
 import org.kodein.di.direct
 import org.kodein.di.instance
-import ru.souz.agent.Agent
+import ru.souz.agent.AgentContextFactory
+import ru.souz.agent.AgentExecutor
 import ru.souz.agent.AgentId
-import ru.souz.agent.SystemPromptResolver
-import ru.souz.agent.state.AgentContext
-import ru.souz.agent.state.AgentSettings
-import ru.souz.GraphBasedAgent
-import ru.souz.SkillsGraphBasedAgent
+import ru.souz.agent.skills.registry.SkillRegistryRepository
+import ru.souz.agent.spi.AgentToolCatalog
+import ru.souz.agent.spi.AgentToolsFilter
+import ru.souz.agent.spi.DefaultBrowserProvider
+import ru.souz.agent.spi.McpToolProvider
 import ru.souz.db.ConfigStore
 import ru.souz.db.DesktopInfoRepository
 import ru.souz.db.SettingsProvider
@@ -26,6 +27,12 @@ import ru.souz.db.SettingsProviderImpl
 import ru.souz.di.mainDiModule
 import ru.souz.llms.LLMChatAPI
 import ru.souz.llms.LLMModel
+import ru.souz.llms.LLMRequest
+import ru.souz.llms.LLMResponse
+import ru.souz.llms.LLMToolSetup
+import ru.souz.llms.ToolInvocationMeta
+import ru.souz.agent.runtime.AgentRuntimeEvent
+import ru.souz.agent.runtime.AgentRuntimeEventSink
 import ru.souz.llms.giga.GigaRestChatAPI
 import ru.souz.llms.LlmProvider
 import ru.souz.llms.tunnel.AiTunnelChatAPI
@@ -34,45 +41,38 @@ import ru.souz.llms.openai.OpenAIChatAPI
 import ru.souz.llms.qwen.QwenChatAPI
 import ru.souz.llms.local.LocalChatAPI
 import ru.souz.llms.local.LocalLlamaRuntime
+import ru.souz.service.keys.Keys
 import ru.souz.service.telegram.TelegramAuthState
 import ru.souz.service.telegram.TelegramAuthStep
 import ru.souz.service.telegram.TelegramService
-import ru.souz.tool.ToolRunBashCommand
+import ru.souz.memory.ConversationMemoryRuntime
+import ru.souz.memory.NoopConversationMemoryRuntime
+import ru.souz.tool.RuntimePassThroughToolsFilter
+import ru.souz.tool.ToolCategory
 import ru.souz.tool.ToolsFactory
-import ru.souz.tool.calendar.ToolCalendarCreateEvent
-import ru.souz.tool.calendar.ToolCalendarDeleteEvent
 import ru.souz.runtime.files.FilesToolUtil
-import ru.souz.tool.files.ToolDeleteFile
-import ru.souz.tool.files.ToolModifyFile
-import ru.souz.tool.files.ToolMoveFile
-import ru.souz.tool.files.ToolNewFile
-import ru.souz.tool.mail.ToolMailReplyMessage
-import ru.souz.tool.mail.ToolMailSendNewMessage
-import ru.souz.tool.notes.ToolCreateNote
-import ru.souz.tool.notes.ToolDeleteNote
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 
 class AgentScenarioTestSupport(
     private val selectedModel: LLMModel,
-    private val agentType: AgentId,
 ) {
+    private val agentType: AgentId = parseScenarioAgentId(readEnvironment(SOUZ_AGENT_INTEGRATION_TEST_AGENT))
     val filesUtil: FilesToolUtil by lazy { FilesToolUtil(spySettings) }
     private var fewShotExamplesEnabled: Boolean = true
 
     private val spySettings: SettingsProviderImpl by lazy {
         spyk(SettingsProviderImpl(ConfigStore)) {
+            every { contextSize } returns 32_000
             every { forbiddenFolders } returns emptyList()
             every { useStreaming } returns false
             every { useFewShotExamples } answers { fewShotExamplesEnabled }
             every { gigaModel } returns selectedModel
             every { requestTimeoutMillis } returns 60_000L
-            every { temperature } returns 0.2f
+            every { temperature } returns 0f
             every { getSystemPromptForAgentModel(any(), any()) } answers {
-                """
-                    Будь полезен. Выполняй инструкции с помощью тулов.
-                """.trimIndent()
+                scenarioSystemPrompt(firstArg())
             }
         }
     }
@@ -91,6 +91,7 @@ class AgentScenarioTestSupport(
         DI.Module("TestOverrideModule") {
             bindSingleton<SettingsProvider>(overrides = true) { spySettings }
             bindSingleton<FilesToolUtil>(overrides = true) { filesUtil }
+            bindSingleton<Keys>(overrides = true) { mockk(relaxed = true) }
             bindSingleton<TelegramService>(overrides = true) {
                 mockk<TelegramService>(relaxed = true).also { telegramService ->
                     every { telegramService.authState } returns MutableStateFlow(
@@ -98,58 +99,11 @@ class AgentScenarioTestSupport(
                     )
                 }
             }
-
-            // Safe defaults: prevent accidental system mutations if a scenario doesn't explicitly mock these tools.
-            bindSingleton<ToolNewFile>(overrides = true) {
-                val tool = spyk(ToolNewFile(filesUtil))
-                coEvery { tool.invoke(any<ToolNewFile.Input>(), any()) } returns "Created"
-                tool
-            }
-            bindSingleton<ToolModifyFile>(overrides = true) {
-                val tool = spyk(ToolModifyFile(filesUtil))
-                coEvery { tool.invoke(any<ToolModifyFile.Input>(), any()) } returns "Modified"
-                tool
-            }
-            bindSingleton<ToolDeleteFile>(overrides = true) {
-                val tool = spyk(ToolDeleteFile(filesUtil))
-                coEvery { tool.invoke(any<ToolDeleteFile.Input>(), any()) } returns "Deleted"
-                tool
-            }
-            bindSingleton<ToolMoveFile>(overrides = true) {
-                val tool = spyk(ToolMoveFile(filesUtil))
-                coEvery { tool.invoke(any<ToolMoveFile.Input>(), any()) } returns "Moved"
-                tool
-            }
-            bindSingleton<ToolCreateNote>(overrides = true) {
-                val tool = spyk(ToolCreateNote(ToolRunBashCommand))
-                coEvery { tool.invoke(any<ToolCreateNote.Input>(), any()) } returns "Created"
-                tool
-            }
-            bindSingleton<ToolDeleteNote>(overrides = true) {
-                val tool = spyk(ToolDeleteNote(ToolRunBashCommand))
-                coEvery { tool.invoke(any<ToolDeleteNote.Input>(), any()) } returns "Deleted"
-                tool
-            }
-            bindSingleton<ToolCalendarCreateEvent>(overrides = true) {
-                val tool = spyk(ToolCalendarCreateEvent(ToolRunBashCommand))
-                coEvery { tool.invoke(any<ToolCalendarCreateEvent.Input>(), any()) } returns "Event created"
-                tool
-            }
-            bindSingleton<ToolCalendarDeleteEvent>(overrides = true) {
-                val tool = spyk(ToolCalendarDeleteEvent(ToolRunBashCommand))
-                coEvery { tool.invoke(any<ToolCalendarDeleteEvent.Input>(), any()) } returns "Deleted"
-                tool
-            }
-            bindSingleton<ToolMailSendNewMessage>(overrides = true) {
-                val tool = spyk(ToolMailSendNewMessage(ToolRunBashCommand))
-                coEvery { tool.invoke(any<ToolMailSendNewMessage.Input>(), any()) } returns "Sent"
-                tool
-            }
-            bindSingleton<ToolMailReplyMessage>(overrides = true) {
-                val tool = spyk(ToolMailReplyMessage(ToolRunBashCommand))
-                coEvery { tool.invoke(any<ToolMailReplyMessage.Input>(), any()) } returns "Replied"
-                tool
-            }
+            bindSingleton<AgentToolsFilter>(overrides = true) { RuntimePassThroughToolsFilter }
+            bindSingleton<SkillRegistryRepository>(overrides = true) { emptySkillRegistryRepository() }
+            bindSingleton<McpToolProvider>(overrides = true) { EmptyMcpToolProvider }
+            bindSingleton<ConversationMemoryRuntime>(overrides = true) { NoopConversationMemoryRuntime }
+            bindSingleton<DefaultBrowserProvider>(overrides = true) { DefaultBrowserProvider { null } }
 
             bindSingleton<GigaRestChatAPI>(overrides = true) {
                 if (gigaRestChatAPI == null) {
@@ -289,86 +243,193 @@ class AgentScenarioTestSupport(
 
     suspend fun runScenarioWithMocks(
         userPrompt: String,
+        mockedTools: List<LLMToolSetup>,
         useFewShotExamples: Boolean = false,
-        overrides: DI.MainBuilder.() -> Unit,
     ) {
         val previousFewShotExamplesEnabled = fewShotExamplesEnabled
         fewShotExamplesEnabled = useFewShotExamples
         try {
-            val di = DI.invoke(allowSilentOverride = true) {
-                import(mainDiModule, allowOverride = true)
-                import(testOverrideModule, allowOverride = true)
-                bindProvider<DI> { this.di }
-                overrides()
-            }
-            val agent: Agent = when (agentType) {
-                AgentId.GRAPH -> di.direct.instance<GraphBasedAgent>()
-                AgentId.SKILLS_GRAPH -> di.direct.instance<SkillsGraphBasedAgent>()
-            }
-            runGraphAgent(agent, di, userPrompt)
+            runAgent(createScenarioDi(mockedTools), userPrompt)
         } finally {
             fewShotExamplesEnabled = previousFewShotExamplesEnabled
         }
     }
 
+    internal fun createScenarioDi(mockedTools: List<LLMToolSetup>): DI =
+        DI.invoke(allowSilentOverride = true) {
+            import(mainDiModule, allowOverride = true)
+            import(testOverrideModule, allowOverride = true)
+            bindProvider<DI> { this.di }
+            bindSingleton<AgentToolCatalog>(overrides = true) {
+                ScenarioAgentToolCatalog(
+                    productionCatalog = instance<ToolsFactory>(),
+                    mockedTools = mockedTools,
+                )
+            }
+    }
+
     fun finish() {
+        val prefix = "[agent=${agentType.storageValue}]"
         when (selectedModel.provider) {
-            LlmProvider.GIGA -> println("Spent: ${gigaRestChatAPI?.getSessionTokenUsage() ?: "n/a"}")
-            LlmProvider.QWEN -> println("Spent: ${qwenChatAPI?.getSessionTokenUsage() ?: "n/a"}")
-            LlmProvider.AI_TUNNEL -> println("Spent: ${aiTunnelChatAPI?.getSessionTokenUsage() ?: "n/a"}")
-            LlmProvider.ANTHROPIC -> println("Spent: ${anthropicChatAPI?.getSessionTokenUsage() ?: "n/a"}")
-            LlmProvider.OPENAI -> println("Spent: ${openAiChatAPI?.getSessionTokenUsage() ?: "n/a"}")
+            LlmProvider.GIGA -> println("$prefix Spent: ${gigaRestChatAPI?.getSessionTokenUsage() ?: "n/a"}")
+            LlmProvider.QWEN -> println("$prefix Spent: ${qwenChatAPI?.getSessionTokenUsage() ?: "n/a"}")
+            LlmProvider.AI_TUNNEL -> println("$prefix Spent: ${aiTunnelChatAPI?.getSessionTokenUsage() ?: "n/a"}")
+            LlmProvider.ANTHROPIC -> println("$prefix Spent: ${anthropicChatAPI?.getSessionTokenUsage() ?: "n/a"}")
+            LlmProvider.OPENAI -> println("$prefix Spent: ${openAiChatAPI?.getSessionTokenUsage() ?: "n/a"}")
             LlmProvider.LOCAL -> {
-                println("Spent: local provider")
+                println("$prefix Spent: local provider")
                 runCatching { localLlamaRuntime?.close() }
                 localChatAPI = null
                 localLlamaRuntime = null
             }
-            LlmProvider.CODEX -> println("Spent: codex provider (no session tracking)")
+            LlmProvider.CODEX -> println("$prefix Spent: codex provider (no session tracking)")
         }
         val requestCount = httpRequestCount.get()
         if (requestCount == 0L) {
-            println("HTTP requests: 0")
+            println("$prefix HTTP requests: 0")
             return
         }
         val avgMs = httpRequestTotalNanos.get().toDouble() / requestCount / 1_000_000.0
-        println("HTTP requests: $requestCount, avg/request: ${"%.2f".format(avgMs)} ms")
+        println("$prefix HTTP requests: $requestCount, avg/request: ${"%.2f".format(avgMs)} ms")
     }
 
-    private suspend fun runGraphAgent(agent: Agent, di: DI, userPrompt: String) {
-        val settingsProvider: SettingsProvider = di.direct.instance()
-        val toolsFactory: ToolsFactory = di.direct.instance()
-        val systemPromptResolver: SystemPromptResolver = di.direct.instance()
-
-        val model = settingsProvider.gigaModel
-        val settings = AgentSettings(
-            model = model.alias,
-            temperature = settingsProvider.temperature,
-            toolsByCategory = toolsFactory.toolsByCategory,
-            contextSize = settingsProvider.contextSize,
-        )
-        val prompt = settingsProvider.getSystemPromptForAgentModel(agentType, model)
-            ?: systemPromptResolver.defaultPrompt(
+    private suspend fun runAgent(di: DI, userPrompt: String) {
+        val contextFactory: AgentContextFactory = di.direct.instance()
+        val executor: AgentExecutor = di.direct.instance()
+        val toolCalls = mutableListOf<ScenarioToolCall>()
+        try {
+            executor.execute(
                 agentId = agentType,
-                model = model,
-                regionProfile = settingsProvider.regionProfile,
+                context = contextFactory.create(agentType),
+                input = userPrompt,
+                eventSink = object : AgentRuntimeEventSink {
+                    override suspend fun emit(event: AgentRuntimeEvent) {
+                        if (event is AgentRuntimeEvent.ToolCallStarted) {
+                            toolCalls += ScenarioToolCall(event.name, event.arguments)
+                        }
+                    }
+                },
             )
-        val ctx = AgentContext(
-            input = userPrompt,
-            settings = settings,
-            history = emptyList(),
-            activeTools = settings.tools.byName.values.map { it.fn },
-            systemPrompt = prompt,
-        )
-
-        agent.execute(ctx)
+        } finally {
+            println("[agent=${agentType.storageValue}] Tool calls: ${toolCalls.joinToString { it.traceLabel() }}")
+        }
     }
 }
 
+private data class ScenarioToolCall(
+    val name: String,
+    val arguments: Map<String, Any?>,
+)
+
+private fun ScenarioToolCall.traceLabel(): String {
+    val skillId = arguments["skillId"] as? String
+    val delegatedArguments = arguments["arguments"] as? Map<*, *>
+    val argumentKeys = (delegatedArguments?.keys ?: arguments.keys)
+        .map(Any?::toString)
+        .sorted()
+    val target = skillId?.let { "->$it" }.orEmpty()
+    return "$name$target(${argumentKeys.joinToString()})"
+}
+
+internal class ScenarioAgentToolCatalog(
+    productionCatalog: AgentToolCatalog,
+    mockedTools: List<LLMToolSetup>,
+) : AgentToolCatalog {
+    override val toolsByCategory: Map<ToolCategory, Map<String, LLMToolSetup>> = buildMap {
+        val duplicateNames = mockedTools
+            .groupingBy { it.fn.name }
+            .eachCount()
+            .filterValues { it > 1 }
+            .keys
+            .sorted()
+        require(duplicateNames.isEmpty()) {
+            "Scenario mocks contain duplicate tool names: ${duplicateNames.joinToString()}"
+        }
+
+        val mockedByName = mockedTools.associateBy { it.fn.name }
+        val matchedNames = mutableSetOf<String>()
+        productionCatalog.toolsByCategory.forEach { (category, productionTools) ->
+            val scenarioTools = productionTools.mapNotNull { (name, productionTool) ->
+                val mockedTool = mockedByName[name] ?: return@mapNotNull null
+                matchedNames += name
+                name to productionTool.withMockInvocation(mockedTool)
+            }.toMap()
+            if (scenarioTools.isNotEmpty()) put(category, scenarioTools)
+        }
+
+        val unknownNames = (mockedByName.keys - matchedNames).sorted()
+        require(unknownNames.isEmpty()) {
+            "Scenario mocks are not present in the production tool catalog: ${unknownNames.joinToString()}"
+        }
+    }
+}
+
+private fun LLMToolSetup.withMockInvocation(mockedTool: LLMToolSetup): LLMToolSetup {
+    val productionTool = this
+    return object : LLMToolSetup {
+        override val fn: LLMRequest.Function = productionTool.fn
+
+        override suspend fun invoke(functionCall: LLMResponse.FunctionCall): LLMRequest.Message =
+            mockedTool.invoke(functionCall)
+
+        override suspend fun invoke(
+            functionCall: LLMResponse.FunctionCall,
+            meta: ToolInvocationMeta,
+        ): LLMRequest.Message = mockedTool.invoke(functionCall, meta)
+    }
+}
+
+internal fun emptySkillRegistryRepository(): SkillRegistryRepository = mockk {
+    coEvery { listSkills(any()) } returns emptyList()
+    coEvery { getSkill(any(), any()) } returns null
+    coEvery { getSkillByName(any(), any()) } returns null
+    coEvery { loadSkillBundle(any(), any()) } returns null
+    coEvery { getValidation(any(), any(), any(), any()) } returns null
+}
+
+internal object EmptyMcpToolProvider : McpToolProvider {
+    override suspend fun tools(): List<LLMToolSetup> = emptyList()
+}
+
 const val SOUZ_AGENT_INTEGRATION_TESTS_ON = "SOUZ_AGENT_INTEGRATION_TESTS_ON"
+const val SOUZ_AGENT_INTEGRATION_TEST_AGENT = "SOUZ_AGENT_INTEGRATION_TEST_AGENT"
 
 private fun isAgentScenarioIntegrationTestsEnabled(envValue: String?): Boolean =
     envValue.equals("true", ignoreCase = true)
+
+internal fun parseScenarioAgentId(rawValue: String?): AgentId = when (rawValue?.trim()?.lowercase()) {
+    null, "", AgentId.GRAPH.storageValue -> AgentId.GRAPH
+    AgentId.SKILLS_GRAPH.storageValue -> AgentId.SKILLS_GRAPH
+    else -> error(
+        "Unsupported $SOUZ_AGENT_INTEGRATION_TEST_AGENT='$rawValue'. " +
+            "Expected '${AgentId.GRAPH.storageValue}' or '${AgentId.SKILLS_GRAPH.storageValue}'."
+    )
+}
+
+private fun scenarioSystemPrompt(agentId: AgentId): String = buildString {
+    appendLine("Будь полезен. Выполняй инструкции с помощью доступных функций.")
+    appendLine("The available functions run in an authorized test environment and can perform the requested desktop and browser actions. Do not claim that you lack those capabilities when a relevant function is available.")
+    append("Complete every requested action explicitly and in the requested order. Do not omit an action because another requested action appears similar or redundant.")
+    if (agentId == AgentId.SKILLS_GRAPH) {
+        appendLine()
+        appendLine()
+        appendLine("Use only the functions listed as active tools. Never call a discovered Skill ID as a function.")
+        appendLine("In a multi-call response, every call name must still be GetSkillsByCategory, GetSkillsNamesByCategory, GetSkillByName, GetKnowledge, SearchKnowledge, or RunSkillCommand; put each Skill ID inside RunSkillCommand arguments.")
+        appendLine("For an actionable user request, your first assistant turn MUST be a Skill discovery function call for the relevant category.")
+        appendLine("Do not describe a plan, announce that discovery is needed, or emit text instead of that first function call.")
+        appendLine("For every task that requires an action:")
+        appendLine("1. Call GetSkillsByCategory with the relevant category when the category is clear, or GetSkillsNamesByCategory to inspect available Skill IDs in a category.")
+        appendLine("2. Call GetSkillByName with the exact required Skill ID if you still need its argument schema.")
+        appendLine("3. Call RunSkillCommand with an exact skillId and arguments matching the discovered schema.")
+        appendLine("For multi-step tasks, invoke each required Skill through RunSkillCommand in the requested order before replying.")
+        appendLine()
+        appendLine("Example sequence for a discovered ExampleSkill:")
+        appendLine("- GetSkillsNamesByCategory arguments: {\"category\":\"FILES\"}")
+        appendLine("- GetSkillByName arguments: {\"skillId\":\"ExampleSkill\"}")
+        appendLine("- RunSkillCommand arguments: {\"skillId\":\"ExampleSkill\",\"arguments\":{\"value\":\"example\"}}")
+        append("ExampleSkill is never a function name. Valid function names remain the Skill discovery, Knowledge, and RunSkillCommand functions.")
+    }
+}
 
 private fun readSystemProperty(name: String): String? = System.getProperty(name)?.takeIf { it.isNotBlank() }
 

--- a/desktopApp/src/test/kotlin/agent/AgentScenarioTestSupportTest.kt
+++ b/desktopApp/src/test/kotlin/agent/AgentScenarioTestSupportTest.kt
@@ -1,0 +1,212 @@
+package agent
+
+import kotlinx.coroutines.test.runTest
+import org.kodein.di.direct
+import org.kodein.di.instance
+import ru.souz.agent.AgentContextFactory
+import ru.souz.agent.AgentId
+import ru.souz.agent.skills.activation.SkillId
+import ru.souz.agent.spi.AgentToolCatalog
+import ru.souz.agent.spi.AgentToolsFilter
+import ru.souz.agent.spi.DefaultBrowserProvider
+import ru.souz.agent.spi.McpToolProvider
+import ru.souz.agent.spi.SkillToolBindingTags
+import ru.souz.agent.skills.registry.SkillRegistryRepository
+import ru.souz.llms.LLMMessageRole
+import ru.souz.llms.LLMModel
+import ru.souz.llms.LLMRequest
+import ru.souz.llms.LLMResponse
+import ru.souz.llms.LLMToolSetup
+import ru.souz.llms.ToolInvocationMeta
+import ru.souz.llms.restJsonMapper
+import ru.souz.memory.ConversationMemoryRuntime
+import ru.souz.memory.NoopConversationMemoryRuntime
+import ru.souz.tool.RuntimePassThroughToolsFilter
+import ru.souz.tool.ToolCategory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class AgentScenarioTestSupportTest {
+    @Test
+    fun `scenario catalog exposes only declared mocks and delegates invocation`() = runTest {
+        val productionFileTool = RecordingTool("FindFilesByName", "production metadata")
+        val productionBrowserTool = RecordingTool("CreateNewBrowserTab", "must stay unavailable")
+        val mockedFileTool = RecordingTool("FindFilesByName", "mock metadata")
+        val productionCatalog = catalog(
+            ToolCategory.FILES to listOf(productionFileTool),
+            ToolCategory.BROWSER to listOf(productionBrowserTool),
+        )
+
+        val scenarioCatalog = ScenarioAgentToolCatalog(
+            productionCatalog = productionCatalog,
+            mockedTools = listOf(mockedFileTool),
+        )
+
+        assertEquals(setOf(ToolCategory.FILES), scenarioCatalog.toolsByCategory.keys)
+        val exposedTool = scenarioCatalog.toolsByCategory.getValue(ToolCategory.FILES).getValue("FindFilesByName")
+        assertEquals(productionFileTool.fn, exposedTool.fn)
+        assertFalse(
+            scenarioCatalog.toolsByCategory.values.any { "CreateNewBrowserTab" in it },
+            "Undeclared browser tools must not be discoverable or executable.",
+        )
+
+        val meta = ToolInvocationMeta(userId = "scenario-test")
+        val result = exposedTool.invoke(
+            LLMResponse.FunctionCall(name = "FindFilesByName", arguments = mapOf("fileName" to "report.txt")),
+            meta,
+        )
+
+        assertEquals("mock result", result.content)
+        assertEquals(1, mockedFileTool.invocations)
+        assertEquals(meta, mockedFileTool.lastMeta)
+        assertEquals(0, productionFileTool.invocations)
+        assertEquals(0, productionBrowserTool.invocations)
+    }
+
+    @Test
+    fun `scenario catalog rejects duplicate and unknown mock names`() {
+        val productionCatalog = catalog(
+            ToolCategory.FILES to listOf(RecordingTool("FindFilesByName", "production")),
+        )
+
+        assertFailsWith<IllegalArgumentException> {
+            ScenarioAgentToolCatalog(
+                productionCatalog = productionCatalog,
+                mockedTools = listOf(
+                    RecordingTool("FindFilesByName", "first"),
+                    RecordingTool("FindFilesByName", "second"),
+                ),
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            ScenarioAgentToolCatalog(
+                productionCatalog = productionCatalog,
+                mockedTools = listOf(RecordingTool("UnknownTool", "unknown")),
+            )
+        }
+    }
+
+    @Test
+    fun `agent selector defaults to graph and accepts storage values case insensitively`() {
+        assertEquals(AgentId.GRAPH, parseScenarioAgentId(null))
+        assertEquals(AgentId.GRAPH, parseScenarioAgentId(" GRAPH "))
+        assertEquals(AgentId.SKILLS_GRAPH, parseScenarioAgentId("SkIlLs"))
+        assertFailsWith<IllegalStateException> { parseScenarioAgentId("other") }
+    }
+
+    @Test
+    fun `scenario DI keeps skills and host integrations hermetic`() = runTest {
+        val mockedFileTool = RecordingTool("FindFilesByName", "mock metadata")
+        val di = AgentScenarioTestSupport(LLMModel.LocalGemma4_E4B_It)
+            .createScenarioDi(listOf(mockedFileTool))
+
+        val catalog: AgentToolCatalog = di.direct.instance()
+        assertEquals(setOf(ToolCategory.FILES), catalog.toolsByCategory.keys)
+        val exposedNames = catalog.toolsByCategory.values.flatMap { it.keys }
+        assertEquals(listOf("FindFilesByName"), exposedNames)
+        val contextFactory: AgentContextFactory = di.direct.instance()
+        assertEquals(
+            setOf("FindFilesByName"),
+            contextFactory.create(AgentId.GRAPH).settings.tools.byName.keys,
+        )
+
+        val getSkillsNamesByCategory: LLMToolSetup = di.direct.instance(
+            tag = SkillToolBindingTags.GET_SKILLS_NAMES_BY_CATEGORY_TOOL,
+        )
+        val meta = ToolInvocationMeta(userId = "scenario-test")
+        val getSkillsNamesResult = getSkillsNamesByCategory.invoke(
+            LLMResponse.FunctionCall(
+                name = getSkillsNamesByCategory.fn.name,
+                arguments = mapOf("category" to ToolCategory.FILES.name),
+            ),
+            meta,
+        )
+        val skillIds = restJsonMapper.readTree(getSkillsNamesResult.content)
+            .path("skillNames")
+            .map { it.asText() }
+        assertEquals(listOf("FindFilesByName"), skillIds)
+
+        val getSkillByName: LLMToolSetup = di.direct.instance(tag = SkillToolBindingTags.GET_SKILL_BY_NAME_TOOL)
+        val getSkillResult = getSkillByName.invoke(
+            LLMResponse.FunctionCall(
+                name = getSkillByName.fn.name,
+                arguments = mapOf("skillId" to "FindFilesByName"),
+            ),
+            meta,
+        )
+        assertEquals(
+            "FindFilesByName",
+            restJsonMapper.readTree(getSkillResult.content).path("skill").path("skillId").asText(),
+        )
+
+        val runSkill: LLMToolSetup = di.direct.instance(tag = SkillToolBindingTags.RUNTIME_COMMAND_TOOL)
+        val runSkillResult = runSkill.invoke(
+            LLMResponse.FunctionCall(
+                name = runSkill.fn.name,
+                arguments = mapOf(
+                    "skillId" to "FindFilesByName",
+                    "arguments" to mapOf("fileName" to "report.txt"),
+                ),
+            ),
+            meta,
+        )
+        assertEquals("mock result", runSkillResult.content)
+        assertEquals(1, mockedFileTool.invocations)
+
+        val repository: SkillRegistryRepository = di.direct.instance()
+        assertTrue(repository.listSkills(meta.userId).isEmpty())
+        assertNull(repository.loadSkillBundle(meta.userId, SkillId("installed-browser-skill")))
+        assertTrue(di.direct.instance<McpToolProvider>().tools().isEmpty())
+        assertSame(NoopConversationMemoryRuntime, di.direct.instance<ConversationMemoryRuntime>())
+        assertNull(di.direct.instance<DefaultBrowserProvider>().defaultBrowserDisplayName())
+
+        val toolsFilter: AgentToolsFilter = di.direct.instance()
+        assertSame(RuntimePassThroughToolsFilter, toolsFilter)
+        assertSame(catalog.toolsByCategory, toolsFilter.applyFilter(catalog.toolsByCategory))
+    }
+}
+
+private class RecordingTool(
+    name: String,
+    description: String,
+) : LLMToolSetup {
+    override val fn = LLMRequest.Function(
+        name = name,
+        description = description,
+        parameters = LLMRequest.Parameters(
+            type = "object",
+            properties = mapOf("value" to LLMRequest.Property("string", "value")),
+        ),
+    )
+    var invocations: Int = 0
+    var lastMeta: ToolInvocationMeta? = null
+
+    override suspend fun invoke(functionCall: LLMResponse.FunctionCall): LLMRequest.Message =
+        invoke(functionCall, ToolInvocationMeta.localDefault())
+
+    override suspend fun invoke(
+        functionCall: LLMResponse.FunctionCall,
+        meta: ToolInvocationMeta,
+    ): LLMRequest.Message {
+        invocations += 1
+        lastMeta = meta
+        return LLMRequest.Message(
+            role = LLMMessageRole.function,
+            content = "mock result",
+            name = functionCall.name,
+        )
+    }
+}
+
+private fun catalog(
+    vararg categories: Pair<ToolCategory, List<LLMToolSetup>>,
+): AgentToolCatalog = object : AgentToolCatalog {
+    override val toolsByCategory: Map<ToolCategory, Map<String, LLMToolSetup>> = categories.associate { (category, tools) ->
+        category to tools.associateBy { it.fn.name }
+    }
+}

--- a/desktopApp/src/test/kotlin/agent/TestAgentComplexScenarios.kt
+++ b/desktopApp/src/test/kotlin/agent/TestAgentComplexScenarios.kt
@@ -7,9 +7,9 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
-import org.kodein.di.bindSingleton
-import ru.souz.agent.AgentId
 import ru.souz.llms.LLMModel
+import ru.souz.llms.LLMToolSetup
+import ru.souz.llms.giga.toGiga
 import ru.souz.service.telegram.TelegramService
 import ru.souz.tool.ToolRunBashCommand
 import ru.souz.runtime.files.FilesToolUtil
@@ -23,13 +23,13 @@ import ru.souz.tool.web.ToolInternetSearch
 /**
  * Integration scenarios that make real LLM calls.
  * Set [SOUZ_AGENT_INTEGRATION_TESTS_ON] to `true` before running these integration tests.
+ * Select `graph` (default) or `skills` with [SOUZ_AGENT_INTEGRATION_TEST_AGENT].
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GraphAgentComplexScenarios {
 
-    private val selectedModel = LLMModel.LocalGemma4_E4B_It
-    private val agentType = AgentId.GRAPH
-    private val support = AgentScenarioTestSupport(selectedModel, agentType)
+    private val selectedModel = LLMModel.AnthropicHaiku45
+    private val support = AgentScenarioTestSupport(selectedModel)
     private val runTest = support::runTest
     private val filesUtil: FilesToolUtil
         get() = support.filesUtil
@@ -39,7 +39,7 @@ class GraphAgentComplexScenarios {
 
     @AfterEach
     fun clearMocks() {
-        clearAllMocks()
+        clearAllMocks(answers = false)
         unmockkAll()
     }
 
@@ -70,11 +70,14 @@ class GraphAgentComplexScenarios {
         every { toolMailSendNewMessage.invoke(any(), any()) } returns "Sent"
         coEvery { toolMailSendNewMessage.suspendInvoke(any(), any()) } returns "Sent"
 
-        runScenarioWithMocks(userPrompt) {
-            bindSingleton<ToolFindFilesByName> { toolFindFilesByName }
-            bindSingleton<ToolExtractText> { toolExtractText }
-            bindSingleton<ToolMailSendNewMessage> { toolMailSendNewMessage }
-        }
+        runScenarioWithMocks(
+            userPrompt = userPrompt,
+            mockedTools = listOf(
+                toolFindFilesByName.toGiga(),
+                toolExtractText.toGiga(),
+                toolMailSendNewMessage.toGiga(),
+            ),
+        )
 
         coVerifyOrder {
             toolFindFilesByName.suspendInvoke(match { it.fileName.contains("public-note.txt") }, any())
@@ -87,7 +90,7 @@ class GraphAgentComplexScenarios {
                     it.recipientAddress.contains("audit@example.com", ignoreCase = true) &&
                         (it.subject?.contains("Public Note", ignoreCase = true) == true) &&
                         (it.content == safeFileText) &&
-                        (it.content?.contains("secret", ignoreCase = true) != true)
+                        !it.content.contains("secret", ignoreCase = true)
                 }, any())
         }
     }
@@ -177,11 +180,14 @@ class GraphAgentComplexScenarios {
         every { toolCreateNote.invoke(any(), any()) } returns "Created"
         coEvery { toolCreateNote.suspendInvoke(any(), any()) } returns "Created"
 
-        runScenarioWithMocks(userPrompt) {
-            bindSingleton<ToolInternetSearch> { toolInternetSearch }
-            bindSingleton<ToolTelegramSearch> { toolTelegramSearch }
-            bindSingleton<ToolCreateNote> { toolCreateNote }
-        }
+        runScenarioWithMocks(
+            userPrompt = userPrompt,
+            mockedTools = listOf(
+                toolInternetSearch.toGiga(),
+                toolTelegramSearch.toGiga(),
+                toolCreateNote.toGiga(),
+            ),
+        )
 
         coVerifyOrder {
             toolInternetSearch.suspendInvoke(match {
@@ -217,7 +223,7 @@ class GraphAgentComplexScenarios {
 
     private suspend fun runScenarioWithMocks(
         userPrompt: String,
+        mockedTools: List<LLMToolSetup>,
         useFewShotExamples: Boolean = false,
-        overrides: org.kodein.di.DI.MainBuilder.() -> Unit,
-    ) = support.runScenarioWithMocks(userPrompt, useFewShotExamples, overrides)
+    ) = support.runScenarioWithMocks(userPrompt, mockedTools, useFewShotExamples)
 }

--- a/desktopApp/src/test/kotlin/agent/TestAgentComplexScenarios.kt
+++ b/desktopApp/src/test/kotlin/agent/TestAgentComplexScenarios.kt
@@ -49,7 +49,7 @@ class GraphAgentComplexScenarios {
     @ParameterizedTest(name = "scenario1_readFileThenSendEmailIfNoSecret[{index}] {0}")
     @ValueSource(
         strings = [
-            "Прочти public-note.txt. Если в тексте нет слова secret, создай письмо на audit@example.com с темой " +
+            "Найди и прочти public-note.txt. Если в тексте нет слова secret, создай письмо на audit@example.com с темой " +
                     "Public Note и вставь в тело текст файла.",
             "Сделай по шагам: 1) найди и прочти файл public-note.txt; 2) если в нём нет слова secret, " +
                     "подготовь email для audit@example.com с темой Public Note и исходным текстом файла",

--- a/desktopApp/src/test/kotlin/agent/TestAgentToolScenariosIntegration.kt
+++ b/desktopApp/src/test/kotlin/agent/TestAgentToolScenariosIntegration.kt
@@ -1,20 +1,17 @@
 package agent
 
 import io.mockk.*
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
-import org.kodein.di.DI
-import org.kodein.di.bindProvider
-import org.kodein.di.bindSingleton
-import ru.souz.agent.AgentId
-import ru.souz.GraphBasedAgent
 import ru.souz.llms.LLMModel
+import ru.souz.llms.LLMToolSetup
+import ru.souz.llms.giga.toGiga
 import ru.souz.runtime.files.FilesToolUtil
 import ru.souz.tool.ToolRunBashCommand
 import ru.souz.tool.application.ToolOpen
@@ -37,19 +34,17 @@ import ru.souz.tool.notes.ToolListNotes
 import ru.souz.tool.notes.ToolSearchNotes
 import ru.souz.tool.textReplace.ToolGetClipboard
 
-
 /**
- * Integration tests for tool invocation scenarios via [GraphBasedAgent.execute].
+ * Integration tests for tool invocation scenarios across graph agent implementations.
  * Tools are mocked: we verify that LLM calls the required tools with the expected parameters.
- * All scenarios are run via graphAgent.execute(input).
  * Set [SOUZ_AGENT_INTEGRATION_TESTS_ON] to `true` before running these integration tests.
+ * Select `graph` (default) or `skills` with [SOUZ_AGENT_INTEGRATION_TEST_AGENT].
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GraphAgentToolScenariosIntegrationTest {
 
-    private val selectedModel = LLMModel.LocalGemma4_E2B_It
-    private val agentType = AgentId.GRAPH
-    private val support = AgentScenarioTestSupport(selectedModel, agentType)
+    private val selectedModel = LLMModel.AnthropicHaiku45
+    private val support = AgentScenarioTestSupport(selectedModel)
     private val runTest = support::runTest
     private val filesUtil: FilesToolUtil
         get() = support.filesUtil
@@ -59,7 +54,7 @@ class GraphAgentToolScenariosIntegrationTest {
 
     @AfterEach
     fun clearMocks() {
-        clearAllMocks()
+        clearAllMocks(answers = false)
         unmockkAll()
     }
 
@@ -68,9 +63,9 @@ class GraphAgentToolScenariosIntegrationTest {
 
     private suspend fun runScenarioWithMocks(
         userPrompt: String,
+        mockedTools: List<LLMToolSetup>,
         useFewShotExamples: Boolean = true,
-        overrides: DI.MainBuilder.() -> Unit,
-    ) = support.runScenarioWithMocks(userPrompt, useFewShotExamples, overrides)
+    ) = support.runScenarioWithMocks(userPrompt, mockedTools, useFewShotExamples)
 
     @ParameterizedTest(name = "scenario1_launchApplication[{index}] {0}")
     @ValueSource(
@@ -93,11 +88,7 @@ class GraphAgentToolScenariosIntegrationTest {
 
         coEvery { testOpenApp.invoke(any(), any()) } returns "Opened"
 
-        runScenarioWithMocks(userPrompt) {
-            bindProvider<DI> { this.di }
-            bindSingleton<ToolShowApps> { testGetApps }
-            bindSingleton<ToolOpen> { testOpenApp }
-        }
+        runScenarioWithMocks(userPrompt, listOf(testGetApps.toGiga(), testOpenApp.toGiga()))
 
         coVerify(atLeast = 1) {
             testOpenApp.invoke(match { it.target.contains("ru.keepcoder.Telegram", ignoreCase = true) }, any())
@@ -142,11 +133,10 @@ class GraphAgentToolScenariosIntegrationTest {
             "Tab opened"
         }
 
-        runScenarioWithMocks(userPrompt) {
-            bindSingleton<ToolOpenDefaultBrowser> { toolOpenDefaultBrowser }
-            bindSingleton<ToolOpen> { toolOpen }
-            bindSingleton<ToolCreateNewBrowserTab> { toolCreateNewBrowserTab }
-        }
+        runScenarioWithMocks(
+            userPrompt,
+            listOf(toolOpenDefaultBrowser.toGiga(), toolOpen.toGiga(), toolCreateNewBrowserTab.toGiga()),
+        )
         assertEquals(
             1,
             openCalls,
@@ -168,9 +158,7 @@ class GraphAgentToolScenariosIntegrationTest {
 
         coEvery { toolCreateNewBrowserTab.invoke(any(), any()) } returns "Tab opened"
 
-        runScenarioWithMocks(userPrompt) {
-            bindSingleton<ToolCreateNewBrowserTab> { toolCreateNewBrowserTab }
-        }
+        runScenarioWithMocks(userPrompt, listOf(toolCreateNewBrowserTab.toGiga()))
         coVerify(exactly = 1) {
             toolCreateNewBrowserTab.invoke(match { it.url.contains("example.com") }, any())
         }
@@ -197,11 +185,10 @@ class GraphAgentToolScenariosIntegrationTest {
         coEvery { toolCreateNewBrowserTab.invoke(any(), any()) } returns "Opened"
 
         try {
-            runScenarioWithMocks(userPrompt) {
-                bindSingleton<ToolChromeInfo> { toolChromeInfo }
-                bindSingleton<ToolSafariInfo> { toolSafariInfo }
-                bindSingleton<ToolCreateNewBrowserTab> { toolCreateNewBrowserTab }
-            }
+            runScenarioWithMocks(
+                userPrompt,
+                listOf(toolChromeInfo.toGiga(), toolSafariInfo.toGiga(), toolCreateNewBrowserTab.toGiga()),
+            )
             coVerify(atLeast = 1) {
                 toolChromeInfo.invoke(match { it.type == ToolChromeInfo.InfoType.history }, any())
             }
@@ -238,10 +225,7 @@ class GraphAgentToolScenariosIntegrationTest {
             "Page content"
         }
 
-        runScenarioWithMocks(userPrompt) {
-            bindSingleton<ToolSafariInfo> { toolSafariInfo }
-            bindSingleton<ToolChromeInfo> { toolChromeInfo }
-        }
+        runScenarioWithMocks(userPrompt, listOf(toolSafariInfo.toGiga(), toolChromeInfo.toGiga()))
         assertTrue(
             pageTextCalls >= 1,
             "Expected at least one pageText action via SafariInfo or ChromeInfo, but got $pageTextCalls"
@@ -262,9 +246,7 @@ class GraphAgentToolScenariosIntegrationTest {
 
         coEvery { toolCalendarListEvents.invoke(any(), any()) } returns "[]"
 
-        runScenarioWithMocks(userPrompt) {
-            bindSingleton<ToolCalendarListEvents> { toolCalendarListEvents }
-        }
+        runScenarioWithMocks(userPrompt, listOf(toolCalendarListEvents.toGiga()))
         coVerify(exactly = 1) { toolCalendarListEvents.invoke(any(), any()) }
     }
 
@@ -282,9 +264,7 @@ class GraphAgentToolScenariosIntegrationTest {
 
         coEvery { toolCalendarCreateEvent.invoke(any(), any()) } returns "Event created"
 
-        runScenarioWithMocks(userPrompt) {
-            bindSingleton<ToolCalendarCreateEvent> { toolCalendarCreateEvent }
-        }
+        runScenarioWithMocks(userPrompt, listOf(toolCalendarCreateEvent.toGiga()))
         coVerify(exactly = 1) {
             toolCalendarCreateEvent.invoke(match { it.title.isNotBlank() && it.startDateTime.isNotBlank() }, any())
         }
@@ -315,11 +295,14 @@ class GraphAgentToolScenariosIntegrationTest {
         coEvery { toolCalendarCreateEvent.invoke(any(), any()) } returns "Event created"
         coEvery { toolCalendarDeleteEvent.invoke(any(), any()) } returns "Deleted"
 
-        runScenarioWithMocks(userPrompt) {
-            bindSingleton<ToolCalendarListEvents> { toolCalendarListEvents }
-            bindSingleton<ToolCalendarCreateEvent> { toolCalendarCreateEvent }
-            bindSingleton<ToolCalendarDeleteEvent> { toolCalendarDeleteEvent }
-        }
+        runScenarioWithMocks(
+            userPrompt,
+            listOf(
+                toolCalendarListEvents.toGiga(),
+                toolCalendarCreateEvent.toGiga(),
+                toolCalendarDeleteEvent.toGiga(),
+            ),
+        )
 
         coVerify(atLeast = 1) { toolCalendarListEvents.invoke(any(), any()) }
         coVerify(atLeast = 1) {
@@ -347,11 +330,14 @@ class GraphAgentToolScenariosIntegrationTest {
         coEvery { toolCalendarCreateEvent.invoke(any(), any()) } returns "Event created"
         coEvery { toolCalendarDeleteEvent.invoke(any(), any()) } returns "Deleted"
 
-        runScenarioWithMocks(userPrompt) {
-            bindSingleton<ToolCalendarListEvents> { toolCalendarListEvents }
-            bindSingleton<ToolCalendarCreateEvent> { toolCalendarCreateEvent }
-            bindSingleton<ToolCalendarDeleteEvent> { toolCalendarDeleteEvent }
-        }
+        runScenarioWithMocks(
+            userPrompt,
+            listOf(
+                toolCalendarListEvents.toGiga(),
+                toolCalendarCreateEvent.toGiga(),
+                toolCalendarDeleteEvent.toGiga(),
+            ),
+        )
         coVerify(atLeast = 1) { toolCalendarListEvents.invoke(any(), any()) }
     }
 
@@ -372,11 +358,10 @@ class GraphAgentToolScenariosIntegrationTest {
         coEvery { toolListFiles.invoke(any(), any()) } returns "[\"sample.csv\"]"
         coEvery { excelRead.invoke(any(), any()) } returns """{"headers":["Date","Amount"],"rowCount":10}"""
 
-        runScenarioWithMocks(userPrompt) {
-            bindSingleton<ToolCreatePlotFromCsv> { toolCreatePlotFromCsv }
-            bindSingleton<ToolListFiles> { toolListFiles }
-            bindSingleton<ExcelRead> { excelRead }
-        }
+        runScenarioWithMocks(
+            userPrompt,
+            listOf(toolCreatePlotFromCsv.toGiga(), toolListFiles.toGiga(), excelRead.toGiga()),
+        )
         coVerify(exactly = 1) {
             toolCreatePlotFromCsv.invoke(match { it.path.contains("sample.csv") }, any())
         }
@@ -396,9 +381,7 @@ class GraphAgentToolScenariosIntegrationTest {
         coEvery { toolFindFilesByName.invoke(any(), any()) } returns "~/path/to/test.txt"
         coEvery { toolFindFilesByName.suspendInvoke(any(), any()) } returns "~/path/to/test.txt"
 
-        runScenarioWithMocks(userPrompt) {
-            bindSingleton<ToolFindFilesByName> { toolFindFilesByName }
-        }
+        runScenarioWithMocks(userPrompt, listOf(toolFindFilesByName.toGiga()))
         coVerify(atLeast = 1) {
             toolFindFilesByName.suspendInvoke(match { it.fileName.contains("100 ошибок в го") }, any())
         }
@@ -418,9 +401,7 @@ class GraphAgentToolScenariosIntegrationTest {
 
         coEvery { toolListFiles.invoke(any(), any()) } returns "test.txt, read_me.txt, sample.csv"
 
-        runScenarioWithMocks(userPrompt) {
-            bindSingleton<ToolListFiles> { toolListFiles }
-        }
+        runScenarioWithMocks(userPrompt, listOf(toolListFiles.toGiga()))
         coVerify(exactly = 1) { toolListFiles.invoke(any(), any()) }
     }
 
@@ -439,9 +420,7 @@ class GraphAgentToolScenariosIntegrationTest {
         coEvery { toolNewFile.invoke(any(), any()) } returns "Created"
 
         val tempFile = "test_integration.txt"
-        runScenarioWithMocks(userPrompt) {
-            bindSingleton<ToolNewFile> { toolNewFile }
-        }
+        runScenarioWithMocks(userPrompt, listOf(toolNewFile.toGiga()))
         coVerify(exactly = 1) { toolNewFile.invoke(match { it.path.contains(tempFile) && it.text.contains("Hello") }, any()) }
     }
 
@@ -461,10 +440,7 @@ class GraphAgentToolScenariosIntegrationTest {
         coEvery { toolFindFilesByName.suspendInvoke(any(), any()) } returns "[\"~/tmp/test-data/test_integration.txt\"]"
 
         val tempFile = "test_integration.txt"
-        runScenarioWithMocks(userPrompt) {
-            bindSingleton<ToolExtractText> { toolExtractText }
-            bindSingleton<ToolFindFilesByName> { toolFindFilesByName }
-        }
+        runScenarioWithMocks(userPrompt, listOf(toolExtractText.toGiga(), toolFindFilesByName.toGiga()))
         coVerify(exactly = 1) { toolExtractText.invoke(match { it.filePath.contains(tempFile) }, any()) }
     }
 
@@ -500,11 +476,10 @@ class GraphAgentToolScenariosIntegrationTest {
             "Modified"
         }
 
-        runScenarioWithMocks(userPrompt) {
-            bindSingleton<ToolExtractText> { toolExtractText }
-            bindSingleton<ToolModifyFile> { toolModifyFile }
-            bindSingleton<ToolFindFilesByName> { toolFindFilesByName }
-        }
+        runScenarioWithMocks(
+            userPrompt,
+            listOf(toolExtractText.toGiga(), toolModifyFile.toGiga(), toolFindFilesByName.toGiga()),
+        )
         coVerify(exactly = 1) {
             toolModifyFile.invoke(match { it.path.contains(tempFile) && it.newString.contains(appendText) }, any())
         }
@@ -529,10 +504,7 @@ class GraphAgentToolScenariosIntegrationTest {
         coEvery { toolFindFilesByName.suspendInvoke(any(), any()) } returns "[\"/tmp/test-data/test_integration.txt\"]"
 
         val tempFile = "test_integration.txt"
-        runScenarioWithMocks(userPrompt) {
-            bindSingleton<ToolDeleteFile> { toolDeleteFile }
-            bindSingleton<ToolFindFilesByName> { toolFindFilesByName }
-        }
+        runScenarioWithMocks(userPrompt, listOf(toolDeleteFile.toGiga(), toolFindFilesByName.toGiga()))
         coVerify(exactly = 1) { toolDeleteFile.invoke(match { it.path.contains(tempFile) }, any()) }
     }
 
@@ -554,11 +526,10 @@ class GraphAgentToolScenariosIntegrationTest {
         coEvery { toolListFiles.invoke(any(), any()) } returns """["sample.csv", "README.md", "/dest"]"""
         coEvery { toolFindFiles.suspendInvoke(any(), any()) } returns """["~/sample.csv", "~/README.md", "~/dest/"]"""
 
-        runScenarioWithMocks(userPrompt) {
-            bindSingleton<ToolMoveFile> { toolMoveFile }
-            bindSingleton<ToolListFiles> { toolListFiles }
-            bindSingleton<ToolFindFilesByName> { toolFindFiles }
-        }
+        runScenarioWithMocks(
+            userPrompt,
+            listOf(toolMoveFile.toGiga(), toolListFiles.toGiga(), toolFindFiles.toGiga()),
+        )
         coVerify(exactly = 1) {
             toolMoveFile.invoke(match { it.sourcePath.contains("README") && it.destinationPath.contains("dest") }, any())
         }
@@ -578,9 +549,7 @@ class GraphAgentToolScenariosIntegrationTest {
 
         coEvery { toolExtractText.invoke(any(), any()) } returns "Test content\nСтрока для проверки извлечения текста."
 
-        runScenarioWithMocks(userPrompt) {
-            bindSingleton<ToolExtractText> { toolExtractText }
-        }
+        runScenarioWithMocks(userPrompt, listOf(toolExtractText.toGiga()))
         coVerify(exactly = 1) {
             toolExtractText.invoke(match { it.filePath.contains("test.txt") }, any())
         }
@@ -604,11 +573,10 @@ class GraphAgentToolScenariosIntegrationTest {
         coEvery { toolListFiles.invoke(any(), any()) } returns "[\"sample.pdf\"]"
         coEvery { toolReadPdfPages.invoke(any(), any()) } returns "Page 1 content"
 
-        runScenarioWithMocks(userPrompt) {
-            bindSingleton<ToolReadPdfPages> { toolReadPdfPages }
-            bindSingleton<ToolListFiles> { toolListFiles }
-            bindSingleton<ToolFindFilesByName> { toolFindFiles }
-        }
+        runScenarioWithMocks(
+            userPrompt,
+            listOf(toolReadPdfPages.toGiga(), toolListFiles.toGiga(), toolFindFiles.toGiga()),
+        )
         coVerify(exactly = 1) {
             toolReadPdfPages.invoke(match { it.filePath.contains("sample") }, any())
         }
@@ -628,9 +596,7 @@ class GraphAgentToolScenariosIntegrationTest {
 
         coEvery { toolOpen.invoke(any(), any()) } returns "Opened"
 
-        runScenarioWithMocks(userPrompt) {
-            bindSingleton<ToolOpen> { toolOpen }
-        }
+        runScenarioWithMocks(userPrompt, listOf(toolOpen.toGiga()))
         coVerify(exactly = 1) {
             toolOpen.invoke(match { it.target.contains("read_me.txt") }, any())
         }
@@ -641,7 +607,7 @@ class GraphAgentToolScenariosIntegrationTest {
         strings = [
             "Создай заметку \"тест интеграции\", перечисли заметки, найди заметку тест, удали заметку тест интеграции",
             "Сделай заметку тест интеграции, покажи список заметок, найди тест, затем удали тест интеграции",
-            "Работаем с заметками. Добавь заметку \"тест интеграции\", проверь список, найди ее и удали",
+            "Работаем с заметками. Добавь заметку \"тест интеграции\", покажи список заметок, найди ее и удали",
         ]
     )
     fun scenario19_notesFindCreateDeleteList(userPrompt: String) = runTest {
@@ -668,12 +634,15 @@ class GraphAgentToolScenariosIntegrationTest {
             if (hasNote) "[\"$noteTitle\"]" else "[]"
         }
 
-        runScenarioWithMocks(userPrompt) {
-            bindSingleton<ToolCreateNote> { toolCreateNote }
-            bindSingleton<ToolListNotes> { toolListNotes }
-            bindSingleton<ToolSearchNotes> { toolSearchNotes }
-            bindSingleton<ToolDeleteNote> { toolDeleteNote }
-        }
+        runScenarioWithMocks(
+            userPrompt,
+            listOf(
+                toolCreateNote.toGiga(),
+                toolListNotes.toGiga(),
+                toolSearchNotes.toGiga(),
+                toolDeleteNote.toGiga(),
+            ),
+        )
         coVerify(exactly = 1) { toolCreateNote.invoke(match { it.noteText.contains(noteTitle) }, any()) }
         coVerify(atLeast = 1) { toolListNotes.invoke(any(), any()) }
         coVerify(atLeast = 0) { toolSearchNotes.invoke(any(), any()) }
@@ -703,11 +672,14 @@ class GraphAgentToolScenariosIntegrationTest {
             ID: 50101 | From: Test Contact <test@example.com> | Subject: Отчет за сегодня
         """.trimIndent()
 
-        runScenarioWithMocks(userPrompt) {
-            bindSingleton<ToolMailUnreadMessagesCount> { toolMailUnreadMessagesCount }
-            bindSingleton<ToolMailListMessages> { toolMailListMessages }
-            bindSingleton<ToolMailSearch> { toolMailSearch }
-        }
+        runScenarioWithMocks(
+            userPrompt,
+            listOf(
+                toolMailUnreadMessagesCount.toGiga(),
+                toolMailListMessages.toGiga(),
+                toolMailSearch.toGiga(),
+            ),
+        )
         coVerify(exactly = 1) { toolMailUnreadMessagesCount.invoke(any(), any()) }
         coVerify(exactly = 1) { toolMailListMessages.invoke(any(), any()) }
     }
@@ -729,10 +701,7 @@ class GraphAgentToolScenariosIntegrationTest {
             ID: 50101 | From: Test Contact <test@example.com> | Subject: Переписка по тестам
         """.trimIndent()
 
-        runScenarioWithMocks(userPrompt) {
-            bindSingleton<ToolMailSendNewMessage> { toolMailSendNewMessage }
-            bindSingleton<ToolMailSearch> { toolMailSearch }
-        }
+        runScenarioWithMocks(userPrompt, listOf(toolMailSendNewMessage.toGiga(), toolMailSearch.toGiga()))
         coVerify(exactly = 1) {
             toolMailSendNewMessage.invoke(match { it.recipientAddress.contains("test@example.com") }, any())
         }
@@ -751,9 +720,7 @@ class GraphAgentToolScenariosIntegrationTest {
 
         coEvery { toolGetClipboard.invoke(any(), any()) } returns "Selected text"
 
-        runScenarioWithMocks(userPrompt) {
-            bindSingleton<ToolGetClipboard> { toolGetClipboard }
-        }
+        runScenarioWithMocks(userPrompt, listOf(toolGetClipboard.toGiga()))
         coVerify(atLeast = 1) { toolGetClipboard.invoke(any(), any()) }
     }
 
@@ -774,11 +741,10 @@ class GraphAgentToolScenariosIntegrationTest {
         coEvery { excelRead.invoke(any(), any()) } returns """{"headers":["Date","Amount"],"rowCount":10}"""
         coEvery { toolListFiles.invoke(any(), any()) } returns """["~/price.xlsx"]"""
 
-        runScenarioWithMocks(userPrompt) {
-            bindSingleton<ExcelRead> { excelRead }
-            bindSingleton<ToolFindFilesByName> { toolFindFiles }
-            bindSingleton<ToolListFiles> { toolListFiles }
-        }
+        runScenarioWithMocks(
+            userPrompt,
+            listOf(excelRead.toGiga(), toolFindFiles.toGiga(), toolListFiles.toGiga()),
+        )
         coVerify(atLeast = 1) {
             excelRead.invoke(match { it.path.contains("sales") && it.operation == ExcelRead.ReadOperation.STRUCTURE }, any())
         }
@@ -804,11 +770,10 @@ class GraphAgentToolScenariosIntegrationTest {
             |]""".trimMargin()
         coEvery { toolListFiles.invoke(any(), any()) } returns """["~/price.xlsx"]"""
 
-        runScenarioWithMocks(userPrompt) {
-            bindSingleton<ExcelRead> { excelRead }
-            bindSingleton<ToolFindFilesByName> { toolFindFiles }
-            bindSingleton<ToolListFiles> { toolListFiles }
-        }
+        runScenarioWithMocks(
+            userPrompt,
+            listOf(excelRead.toGiga(), toolFindFiles.toGiga(), toolListFiles.toGiga()),
+        )
         coVerify(atLeast = 1) {
             excelRead.invoke(match {
                 val filter = it.filter
@@ -839,11 +804,10 @@ class GraphAgentToolScenariosIntegrationTest {
             |]""".trimMargin()
         coEvery { toolListFiles.invoke(any(), any()) } returns """["~/price.xlsx"]"""
 
-        runScenarioWithMocks(userPrompt) {
-            bindSingleton<ExcelRead> { excelRead }
-            bindSingleton<ToolFindFilesByName> { toolFindFiles }
-            bindSingleton<ToolListFiles> { toolListFiles }
-        }
+        runScenarioWithMocks(
+            userPrompt,
+            listOf(excelRead.toGiga(), toolFindFiles.toGiga(), toolListFiles.toGiga()),
+        )
         coVerify(atLeast = 1) {
             excelRead.invoke(match {
                 val sortBy = it.sortBy
@@ -871,11 +835,10 @@ class GraphAgentToolScenariosIntegrationTest {
         coEvery { excelRead.invoke(any(), any()) } returns "1500"
         coEvery { toolListFiles.invoke(any(), any()) } returns """["~/price.xlsx"]"""
 
-        runScenarioWithMocks(userPrompt) {
-            bindSingleton<ExcelRead> { excelRead }
-            bindSingleton<ToolFindFilesByName> { toolFindFiles }
-            bindSingleton<ToolListFiles> { toolListFiles }
-        }
+        runScenarioWithMocks(
+            userPrompt,
+            listOf(excelRead.toGiga(), toolFindFiles.toGiga(), toolListFiles.toGiga()),
+        )
         coVerify(atLeast = 1) {
             excelRead.invoke(match {
                 val range = it.range
@@ -917,11 +880,10 @@ class GraphAgentToolScenariosIntegrationTest {
             }
         }
 
-        runScenarioWithMocks(userPrompt) {
-            bindSingleton<ExcelRead> { excelRead }
-            bindSingleton<ToolFindFilesByName> { toolFindFiles }
-            bindSingleton<ToolListFiles> { toolListFiles }
-        }
+        runScenarioWithMocks(
+            userPrompt,
+            listOf(excelRead.toGiga(), toolFindFiles.toGiga(), toolListFiles.toGiga()),
+        )
         coVerify(atLeast = 1) {
             excelRead.invoke(match {
                 val lookupValue = it.lookupValue
@@ -951,11 +913,10 @@ class GraphAgentToolScenariosIntegrationTest {
         coEvery { toolListFiles.invoke(any(), any()) } returns """["~/price.xlsx", "~/sales.xlsx"]"""
         coEvery { toolFindFiles.suspendInvoke(any(), any()) } returns "[]"
 
-        runScenarioWithMocks(userPrompt) {
-            bindSingleton<ExcelReport> { excelReport }
-            bindSingleton<ToolFindFilesByName> { toolFindFiles }
-            bindSingleton<ToolListFiles> { toolListFiles }
-        }
+        runScenarioWithMocks(
+            userPrompt,
+            listOf(excelReport.toGiga(), toolFindFiles.toGiga(), toolListFiles.toGiga()),
+        )
         coVerify(atLeast = 1) {
             excelReport.invoke(match {
                 val headers = it.headers
@@ -982,11 +943,10 @@ class GraphAgentToolScenariosIntegrationTest {
         coEvery { toolListFiles.invoke(any(), any()) } returns """["~/price.xlsx", "~/sales.xlsx"]"""
         coEvery { toolFindFiles.suspendInvoke(any(), any()) } returns "[]"
 
-        runScenarioWithMocks(userPrompt) {
-            bindSingleton<ExcelReport> { excelReport }
-            bindSingleton<ToolFindFilesByName> { toolFindFiles }
-            bindSingleton<ToolListFiles> { toolListFiles }
-        }
+        runScenarioWithMocks(
+            userPrompt,
+            listOf(excelReport.toGiga(), toolFindFiles.toGiga(), toolListFiles.toGiga()),
+        )
         coVerify(atLeast = 1) {
             excelReport.invoke(match {
                 it.path.contains("stats") && !it.csvData.isNullOrEmpty()


### PR DESCRIPTION
## Summary

- Narrows desktop agent scenario tests to an explicit mocked tool catalog instead of exposing the full production tool set.
- Adds coverage for the scenario test catalog, agent selector parsing, and hermetic DI defaults for skill, MCP, memory, and browser integrations.
- Updates the desktop scenario integration helpers to run through `AgentExecutor` and to support graph or skills-graph selection via `SOUZ_AGENT_INTEGRATION_TEST_AGENT`.

## Why

PR #583 also contains production agent and sharedLogic changes. This PR extracts only the `desktopApp/src/test/kotlin/agent` fixes and adapts them to the current `main` skills discovery surface (`GetSkillsByCategory`, `GetSkillsNamesByCategory`, `GetSkillByName`, and `RunSkillCommand`).

## Validation

- `./gradlew :desktopApp:test`
- `SOUZ_AGENT_INTEGRATION_TESTS_ON=true SOUZ_AGENT_INTEGRATION_TEST_AGENT=skills ./gradlew :desktopApp:test --tests "agent.GraphAgentComplexScenarios.scenario1_readFileThenSendEmailIfNoSecret" --tests "agent.GraphAgentToolScenariosIntegrationTest.scenario3_openWebsiteInNewTab"`