### PR TITLE
Avoid auto-opening Calendar and Notes

### DIFF
--- a/desktopApp/src/main/kotlin/ru/souz/db/DesktopDataExtractor.kt
+++ b/desktopApp/src/main/kotlin/ru/souz/db/DesktopDataExtractor.kt
@@ -116,13 +116,19 @@ class DesktopDataExtractor(
     }
 
     fun notes(): List<StorredData> = runCatching {
+        val notesRunning = runCatching { ToolRunBashCommand.sh("pgrep -x Notes") }.isSuccess
+        if (!notesRunning) return@runCatching emptyList<StorredData>()
+
         val script = """
 set AppleScript's text item delimiters to linefeed
 tell application "Notes" to set xs to name of notes
 return xs as text
             """.trimIndent()
         val raw = ToolRunBashCommand.apple(script)
-        raw.lines().map { StorredData(it, StorredType.NOTES) }
+        raw.lines()
+            .map { it.trim() }
+            .filter { it.isNotBlank() }
+            .map { StorredData(it, StorredType.NOTES) }
     }.getOrElse { emptyList() }
 
     val facts: List<StorredData> = listOf(

--- a/sharedUI/src/commonJvmMain/kotlin/ru/souz/ui/settings/SettingsViewModel.kt
+++ b/sharedUI/src/commonJvmMain/kotlin/ru/souz/ui/settings/SettingsViewModel.kt
@@ -322,7 +322,6 @@ class SettingsViewModel(
                 flushPendingKeySaves()
                 refreshFromProvider()
                 fetchBalance()
-                fetchCalendars()
             }
             ChooseVoice -> {
                 runCatching { speechPlayer.chooseVoice() }
@@ -887,6 +886,7 @@ class SettingsViewModel(
     }
 
     private fun fetchCalendars() = viewModelScope.launch(Dispatchers.IO) {
+        if (currentState.isLoadingCalendars) return@launch
         setState { copy(isLoadingCalendars = true) }
 
         val result = runCatching {

--- a/sharedUI/src/jvmMain/kotlin/ru/souz/ui/settings/SettingsContent.kt
+++ b/sharedUI/src/jvmMain/kotlin/ru/souz/ui/settings/SettingsContent.kt
@@ -333,6 +333,7 @@ fun ModelsSettingsContent(
 fun GeneralSettingsContent(
     state: SettingsState,
     onDefaultCalendarChange: (String?) -> Unit,
+    onCalendarDropdownOpen: () -> Unit,
     onUseStreamingChange: (Boolean) -> Unit,
     onNotificationSoundEnabledChange: (Boolean) -> Unit,
     onVoiceInputReviewEnabledChange: (Boolean) -> Unit,
@@ -390,6 +391,7 @@ fun GeneralSettingsContent(
                 selectedCalendar = state.defaultCalendar,
                 availableCalendars = state.availableCalendars,
                 isLoading = state.isLoadingCalendars,
+                onDropdownOpen = onCalendarDropdownOpen,
                 onCalendarSelected = onDefaultCalendarChange
             )
 
@@ -1516,6 +1518,7 @@ fun CalendarDropdown(
     selectedCalendar: String?,
     availableCalendars: List<String>,
     isLoading: Boolean,
+    onDropdownOpen: () -> Unit,
     onCalendarSelected: (String?) -> Unit
 ) {
     var expanded by remember { mutableStateOf(false) }
@@ -1534,7 +1537,12 @@ fun CalendarDropdown(
         Box {
             SettingsHoverTooltip(text = stringResource(Res.string.hint_calendar_usage)) {
                 OutlinedButton(
-                    onClick = { expanded = !expanded },
+                    onClick = {
+                        if (!expanded && availableCalendars.isEmpty() && !isLoading) {
+                            onDropdownOpen()
+                        }
+                        expanded = !expanded
+                    },
                     modifier = Modifier.fillMaxWidth().height(SettingsControlHeight),
                     colors = ButtonDefaults.outlinedButtonColors(
                         containerColor = SettingsFieldBackground,
@@ -2217,6 +2225,7 @@ private fun GeneralSettingsContentPreview() {
         GeneralSettingsContent(
             state = PreviewSettingsState,
             onDefaultCalendarChange = {},
+            onCalendarDropdownOpen = {},
             onUseStreamingChange = {},
             onNotificationSoundEnabledChange = {},
             onVoiceInputReviewEnabledChange = {},

--- a/sharedUI/src/jvmMain/kotlin/ru/souz/ui/settings/SettingsScreen.kt
+++ b/sharedUI/src/jvmMain/kotlin/ru/souz/ui/settings/SettingsScreen.kt
@@ -228,6 +228,7 @@ fun SettingsScreenMain(
                         SettingsSection.GENERAL -> GeneralSettingsContent(
                             state = state,
                             onDefaultCalendarChange = { viewModel.send(SettingsEvent.SelectDefaultCalendar(it)) },
+                            onCalendarDropdownOpen = { viewModel.send(SettingsEvent.FetchCalendars) },
                             onUseStreamingChange = { viewModel.send(SettingsEvent.InputUseStreaming(it)) },
                             onNotificationSoundEnabledChange = { viewModel.send(SettingsEvent.InputNotificationSoundEnabled(it)) },
                             onVoiceInputReviewEnabledChange = { viewModel.send(SettingsEvent.InputVoiceInputReviewEnabled(it)) },

--- a/sharedUI/src/jvmTest/kotlin/ru/souz/ui/settings/SettingsViewModelTest.kt
+++ b/sharedUI/src/jvmTest/kotlin/ru/souz/ui/settings/SettingsViewModelTest.kt
@@ -173,6 +173,7 @@ class SettingsViewModelTest {
         val localLlamaRuntime = mockk<LocalLlamaRuntime>(relaxed = true)
         val desktopInfoRepository = mockk<BackgroundIndexRefresher>(relaxed = true)
         coEvery { desktopInfoRepository.rebuildIndexNow() } returns Unit
+        var calendarListProviderCalls = 0
 
         val di = DI {
             bindSingleton<SettingsProvider> { settingsProvider }
@@ -196,7 +197,12 @@ class SettingsViewModelTest {
             bindSingleton<PrivacyPolicyOpener> { NoopPrivacyPolicyOpener }
             bindSingleton<SettingsHostPreferences> { InMemorySettingsHostPreferences() }
             bindSingleton<ExternalLinkOpener> { ExternalLinkOpener { Result.success(Unit) } }
-            bindSingleton<CalendarListProvider> { { emptyList() } }
+            bindSingleton<CalendarListProvider> {
+                {
+                    calendarListProviderCalls += 1
+                    listOf("Work")
+                }
+            }
             bindSingleton<UiSpeechPlayer> { mockk(relaxed = true) }
         }
 
@@ -229,6 +235,7 @@ class SettingsViewModelTest {
         assertEquals(expectedVoiceRecognitionModel, voiceRecognitionModelValue)
         assertEquals("prompt-for-${expectedLlmModel.alias}", state.systemPrompt)
         assertIs<ApiKeyFieldState.StoredHidden>(state.apiKeyFields.getValue(ApiKeyField.QWEN_CHAT))
+        assertEquals(0, calendarListProviderCalls)
 
         verify(exactly = 0) { settingsProvider.gigaChatKey }
         verify(exactly = 0) { settingsProvider.qwenChatKey }


### PR DESCRIPTION
## What changed

- Stop refreshing the macOS Calendar list during settings screen refresh.
- Load calendars lazily only when the default-calendar dropdown is opened.
- Avoid reading Notes during background desktop indexing unless Notes is already running.
- Add ViewModel coverage that settings refresh does not call the calendar provider.

## Why

Opening Souz could trigger macOS Calendar and Notes indirectly through startup/settings refresh and the background desktop indexer. These OS apps should only be touched when the user explicitly asks for calendar/notes actions or interacts with calendar selection.

## Impact

Souz startup is quieter and no longer launches Calendar or Notes as a side effect. Explicit Calendar and Notes tools keep working.

## Validation

- `./gradlew :sharedUI:jvmTest :desktopApp:test`
- `git diff --check`