### PR TITLE
Show provider reasoning consistently in backend streams

### DIFF
--- a/agent/src/main/kotlin/ru/souz/agent/nodes/NodesLLM.kt
+++ b/agent/src/main/kotlin/ru/souz/agent/nodes/NodesLLM.kt
@@ -108,7 +108,18 @@ internal class NodesLLM(
                 response as LLMResponse.Chat.Ok
                 l.debug("choices: {}", response.choices)
 
-                val content = response.choices.firstOrNull()?.message?.content
+                val firstMessage = response.choices.firstOrNull()?.message
+                val reasoningContent = firstMessage?.reasoningContent
+                if (!reasoningContent.isNullOrEmpty()) {
+                    eventSink.emit(
+                        AgentRuntimeEvent.LlmMessageDelta(
+                            text = reasoningContent,
+                            kind = AgentRuntimeEvent.LlmMessageDelta.Kind.REASONING,
+                        )
+                    )
+                }
+
+                val content = firstMessage?.content
                 if (content?.isNotEmpty() == true) {
                     eventSink.emit(AgentRuntimeEvent.LlmMessageDelta(content))
                     pending.append(content)
@@ -150,6 +161,7 @@ internal class NodesLLM(
     private class ChoiceAccumulator(
         var role: LLMMessageRole,
         val content: StringBuilder = StringBuilder(),
+        val reasoningContent: StringBuilder = StringBuilder(),
         var functionCall: LLMResponse.FunctionCall? = null,
         var functionsStateId: String? = null,
         var finishReason: LLMResponse.FinishReason? = null,
@@ -158,6 +170,9 @@ internal class NodesLLM(
             val msg = choice.message
             if (msg.content.isNotBlank()) {
                 content.append(msg.content)
+            }
+            if (!msg.reasoningContent.isNullOrEmpty()) {
+                reasoningContent.append(msg.reasoningContent)
             }
             if (msg.functionCall != null) {
                 functionCall = msg.functionCall
@@ -175,6 +190,7 @@ internal class NodesLLM(
                 role = role,
                 functionCall = functionCall,
                 functionsStateId = functionsStateId,
+                reasoningContent = reasoningContent.toString().takeIf { it.isNotEmpty() },
             ),
             index = index,
             finishReason = finishReason,

--- a/agent/src/main/kotlin/ru/souz/agent/runtime/AgentRuntimeEvent.kt
+++ b/agent/src/main/kotlin/ru/souz/agent/runtime/AgentRuntimeEvent.kt
@@ -25,7 +25,13 @@ sealed interface AgentRuntimeEvent {
 
     data class LlmMessageDelta(
         val text: String,
-    ) : AgentRuntimeEvent
+        val kind: Kind = Kind.CONTENT,
+    ) : AgentRuntimeEvent {
+        enum class Kind {
+            CONTENT,
+            REASONING,
+        }
+    }
 
     data class ToolCallStarted(
         val toolCallId: String,

--- a/agent/src/test/kotlin/ru/souz/agent/nodes/NodesLLMTest.kt
+++ b/agent/src/test/kotlin/ru/souz/agent/nodes/NodesLLMTest.kt
@@ -69,7 +69,11 @@ class NodesLLMTest {
         }
         val nodes = NodesLLM(
             llmApi = StreamingChatApi(
-                chunks = listOf("Hello", " streaming", " world"),
+                chunks = listOf(
+                    StreamedMessage(content = "Hello"),
+                    StreamedMessage(content = " streaming"),
+                    StreamedMessage(content = " world"),
+                ),
                 model = "test-model",
             ),
             settingsProvider = settingsProvider,
@@ -103,6 +107,64 @@ class NodesLLMTest {
         assertEquals("Hello streaming world", result.history.last().content)
     }
 
+    @Test
+    fun `streaming chat emits typed reasoning deltas without adding reasoning to answer text`() = runTest {
+        val runtimeEvents = mutableListOf<AgentRuntimeEvent>()
+        val settingsProvider = mockk<AgentSettingsProvider> {
+            every { useStreaming } returns true
+        }
+        val nodes = NodesLLM(
+            llmApi = StreamingChatApi(
+                chunks = listOf(
+                    StreamedMessage(reasoningContent = "Compare"),
+                    StreamedMessage(reasoningContent = " "),
+                    StreamedMessage(reasoningContent = "the evidence."),
+                    StreamedMessage(content = "Option A is stronger."),
+                ),
+                model = "reasoning-model",
+            ),
+            settingsProvider = settingsProvider,
+        )
+        val context = context(
+            history = listOf(LLMRequest.Message(role = LLMMessageRole.user, content = "Prompt")),
+            runtimeEventSink = object : AgentRuntimeEventSink {
+                override suspend fun emit(event: AgentRuntimeEvent) {
+                    runtimeEvents += event
+                }
+            },
+        )
+
+        val sideEffect = async { nodes.sideEffects.first() }
+        val result = nodes.chat(streamRevision = 8L).execute(
+            ctx = context,
+            runtime = GraphRuntime(retryPolicy = RetryPolicy(), maxSteps = 10),
+        )
+
+        assertEquals(
+            listOf<AgentRuntimeEvent>(
+                AgentRuntimeEvent.LlmMessageDelta(
+                    text = "Compare",
+                    kind = AgentRuntimeEvent.LlmMessageDelta.Kind.REASONING,
+                ),
+                AgentRuntimeEvent.LlmMessageDelta(
+                    text = " ",
+                    kind = AgentRuntimeEvent.LlmMessageDelta.Kind.REASONING,
+                ),
+                AgentRuntimeEvent.LlmMessageDelta(
+                    text = "the evidence.",
+                    kind = AgentRuntimeEvent.LlmMessageDelta.Kind.REASONING,
+                ),
+                AgentRuntimeEvent.LlmMessageDelta("Option A is stronger."),
+            ),
+            runtimeEvents,
+        )
+        assertEquals(AgentStreamChunk("Option A is stronger.", 8L), sideEffect.await())
+        val response = result.input as LLMResponse.Chat.Ok
+        assertEquals("Compare the evidence.", response.choices.single().message.reasoningContent)
+        assertEquals("Option A is stronger.", response.choices.single().message.content)
+        assertEquals("Option A is stronger.", result.history.last().content)
+    }
+
     private fun context(
         history: List<LLMRequest.Message>,
         runtimeEventSink: AgentRuntimeEventSink = AgentRuntimeEventSink.NONE,
@@ -120,8 +182,13 @@ class NodesLLMTest {
     )
 }
 
+private data class StreamedMessage(
+    val content: String = "",
+    val reasoningContent: String? = null,
+)
+
 private class StreamingChatApi(
-    private val chunks: List<String>,
+    private val chunks: List<StreamedMessage>,
     private val model: String,
 ) : LLMChatAPI {
     override suspend fun message(body: LLMRequest.Chat): LLMResponse.Chat =
@@ -134,9 +201,10 @@ private class StreamingChatApi(
                     choices = listOf(
                         LLMResponse.Choice(
                             message = LLMResponse.Message(
-                                content = chunk,
+                                content = chunk.content,
                                 role = LLMMessageRole.assistant,
                                 functionsStateId = null,
+                                reasoningContent = chunk.reasoningContent,
                             ),
                             index = 0,
                             finishReason = if (index == chunks.lastIndex) {

--- a/backend/docs/pain-points/execution-openapi-and-events.md
+++ b/backend/docs/pain-points/execution-openapi-and-events.md
@@ -6,7 +6,7 @@
 
 Each initial execution snapshots its effective compiled-tool names into execution metadata, and option continuations reuse that snapshot. One immutable request-scoped catalog applies the snapshot to compiled tools, then merges built-in client operations only for Client-Souz executions. The skills graph uses that final catalog for inventory, lookup, and generic invocation while exposing only its fixed core tools to the model.
 
-The proxy-facing event API retains its internal durable events and live-only `message.delta`. The Client-Souz socket filters that stream to `tool.call.started` and exactly one terminal thread event. Public sequence values come from the shared chat-local `agent_events` sequence and can contain gaps caused by internal events.
+The proxy-facing event API retains its internal durable events and live-only `message.delta`. Content deltas omit `kind`; reasoning deltas use `kind = reasoning`. The Client-Souz socket filters that stream to `tool.call.started` and exactly one terminal thread event. Public sequence values come from the shared chat-local `agent_events` sequence and can contain gaps caused by internal events.
 
 ## Why it is fragile
 

--- a/backend/src/main/kotlin/ru/souz/backend/agent/runtime/BackendAgentRuntimeEventSink.kt
+++ b/backend/src/main/kotlin/ru/souz/backend/agent/runtime/BackendAgentRuntimeEventSink.kt
@@ -294,7 +294,14 @@ internal class BackendAgentRuntimeEventSink(
         if (publicClientThread || !streamingMessagesEnabled || event.text.isEmpty()) return
         publishLiveEvent(
             type = AgentEventType.MESSAGE_DELTA,
-            payload = MessageDeltaPayload(finalAssistantMessageId, event.text),
+            payload = MessageDeltaPayload(
+                messageId = finalAssistantMessageId,
+                delta = event.text,
+                kind = when (event.kind) {
+                    AgentRuntimeEvent.LlmMessageDelta.Kind.CONTENT -> null
+                    AgentRuntimeEvent.LlmMessageDelta.Kind.REASONING -> "reasoning"
+                },
+            ),
         )
     }
 

--- a/backend/src/main/kotlin/ru/souz/backend/events/model/AgentEventPayload.kt
+++ b/backend/src/main/kotlin/ru/souz/backend/events/model/AgentEventPayload.kt
@@ -44,6 +44,7 @@ data class MessageCreatedPayload(
 data class MessageDeltaPayload(
     val messageId: UUID,
     val delta: String,
+    val kind: String? = null,
 ) : AgentEventPayload
 
 data class MessageCompletedPayload(

--- a/backend/src/main/kotlin/ru/souz/backend/http/BackendEventOpenApi.kt
+++ b/backend/src/main/kotlin/ru/souz/backend/http/BackendEventOpenApi.kt
@@ -174,6 +174,11 @@ internal object BackendEventOpenApiSchemas {
             properties = mapOf(
                 "messageId" to value(uuidSchema()),
                 "delta" to value(stringSchema()),
+                "kind" to value(
+                    stringEnum(listOf("content", "reasoning")).copy(
+                        description = "Omitted for content deltas; reasoning deltas use reasoning.",
+                    )
+                ),
             ),
         )
 

--- a/backend/src/main/kotlin/ru/souz/backend/http/BackendV1Dtos.kt
+++ b/backend/src/main/kotlin/ru/souz/backend/http/BackendV1Dtos.kt
@@ -414,10 +414,11 @@ private fun AgentEventPayload.toTransportPayload(type: AgentEventType): Map<Stri
             "clientMessageId" to clientMessageId,
         ).withoutNulls()
 
-        is MessageDeltaPayload -> linkedMapOf(
+        is MessageDeltaPayload -> linkedMapOf<String, Any?>(
             "messageId" to messageId.toString(),
             "delta" to delta,
-        )
+            "kind" to kind,
+        ).withoutNulls()
 
         is MessageCompletedPayload -> linkedMapOf(
             "messageId" to messageId.toString(),
@@ -523,6 +524,7 @@ private fun Map<String, String>.toLegacyTransportPayload(type: AgentEventType): 
             copyIfPresent("messageId")
             copyLongIfPresent("seq")
             copyIfPresent("delta")
+            copyIfPresent("kind")
         }
 
         AgentEventType.EXECUTION_STARTED -> buildLegacyPayload {

--- a/backend/src/main/kotlin/ru/souz/backend/llm/LlmClientFactory.kt
+++ b/backend/src/main/kotlin/ru/souz/backend/llm/LlmClientFactory.kt
@@ -1,6 +1,7 @@
 package ru.souz.backend.llm
 
 import java.io.File
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import ru.souz.db.SettingsProvider
@@ -65,11 +66,15 @@ private class RoutingLlmChatApi(
     private val mutex = Mutex()
     private val apis = LinkedHashMap<LlmProvider, LLMChatAPI>()
 
-    override suspend fun message(body: LLMRequest.Chat): LLMResponse.Chat =
-        apiFor(providerFor(body.model)).message(body)
+    override suspend fun message(body: LLMRequest.Chat): LLMResponse.Chat {
+        val provider = providerFor(body.model)
+        return apiFor(provider).message(body.withBackendReasoning(provider))
+    }
 
-    override suspend fun messageStream(body: LLMRequest.Chat) =
-        apiFor(providerFor(body.model)).messageStream(body)
+    override suspend fun messageStream(body: LLMRequest.Chat): Flow<LLMResponse.Chat> {
+        val provider = providerFor(body.model)
+        return apiFor(provider).messageStream(body.withBackendReasoning(provider))
+    }
 
     override suspend fun embeddings(body: LLMRequest.Embeddings): LLMResponse.Embeddings =
         apiFor(context.settingsProvider.embeddingsModel.provider).embeddings(body)
@@ -109,7 +114,16 @@ private class RoutingLlmChatApi(
 
     private fun providerFor(model: String): LlmProvider =
         findLLMModel(model)?.provider ?: context.settingsProvider.gigaModel.provider
+
+    private fun LLMRequest.Chat.withBackendReasoning(provider: LlmProvider): LLMRequest.Chat =
+        if (provider == LlmProvider.GIGA && context.settingsProvider.useStreaming && reasoningEffort == null) {
+            copy(reasoningEffort = BACKEND_GIGA_REASONING_EFFORT)
+        } else {
+            this
+        }
 }
+
+private const val BACKEND_GIGA_REASONING_EFFORT = "medium"
 
 private class CredentialOverrideSettingsProvider(
     private val delegate: SettingsProvider,

--- a/backend/src/main/kotlin/ru/souz/backend/llm/RetryingLlmChatApi.kt
+++ b/backend/src/main/kotlin/ru/souz/backend/llm/RetryingLlmChatApi.kt
@@ -3,10 +3,7 @@ package ru.souz.backend.llm
 import java.io.File
 import kotlin.math.min
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.delay
 import ru.souz.backend.app.BackendProviderRetryPolicy
 import ru.souz.llms.LLMChatAPI
@@ -39,18 +36,34 @@ class RetryingLlmChatApi(
         return lastError ?: LLMResponse.Chat.Error(429, "Rate limited.")
     }
 
-    override suspend fun messageStream(body: LLMRequest.Chat): Flow<LLMResponse.Chat> {
+    override suspend fun messageStream(body: LLMRequest.Chat): Flow<LLMResponse.Chat> = flow {
         var attempt = 0
-        while (attempt <= retryPolicy.max429Retries) {
-            val items = delegate.messageStream(body).toList()
-            val first = items.firstOrNull()
-            if (first !is LLMResponse.Chat.Error || first.status != 429 || items.size > 1 || attempt == retryPolicy.max429Retries) {
-                return flowOf(*items.toTypedArray())
+        while (true) {
+            var hasReceivedResponse = false
+            var soleRateLimitError: LLMResponse.Chat.Error? = null
+            delegate.messageStream(body).collect { response ->
+                if (!hasReceivedResponse) {
+                    hasReceivedResponse = true
+                    if (
+                        response is LLMResponse.Chat.Error &&
+                        response.status == 429 &&
+                        attempt < retryPolicy.max429Retries
+                    ) {
+                        soleRateLimitError = response
+                    } else {
+                        emit(response)
+                    }
+                } else {
+                    soleRateLimitError?.let { emit(it) }
+                    soleRateLimitError = null
+                    emit(response)
+                }
             }
-            delayMillis(backoffForAttempt(attempt, first.message))
+
+            val rateLimitError = soleRateLimitError ?: return@flow
+            delayMillis(backoffForAttempt(attempt, rateLimitError.message))
             attempt += 1
         }
-        return flow { }
     }
 
     override suspend fun embeddings(body: LLMRequest.Embeddings): LLMResponse.Embeddings =

--- a/backend/src/test/kotlin/ru/souz/backend/agent/runtime/BackendAgentRuntimeEventSinkTest.kt
+++ b/backend/src/test/kotlin/ru/souz/backend/agent/runtime/BackendAgentRuntimeEventSinkTest.kt
@@ -52,10 +52,37 @@ class BackendAgentRuntimeEventSinkTest {
             assertEquals(AgentEventType.MESSAGE_DELTA, liveEvent.type)
             assertFalse(liveEvent.durable)
             assertNull(liveEvent.seq)
-            assertEquals("chunk-1", (liveEvent.payload as MessageDeltaPayload).delta)
+            val payload = liveEvent.payload as MessageDeltaPayload
+            assertEquals("chunk-1", payload.delta)
+            assertNull(payload.kind)
             assertTrue(replayEvents.isEmpty())
             assertTrue(messages.isEmpty())
             assertNull(execution?.assistantMessageId)
+        } finally {
+            stream.close()
+        }
+    }
+
+    @Test
+    fun `reasoning delta is tagged on the live message event`() = runTest {
+        val fixture = sinkFixture()
+        val stream = fixture.eventService.openStream(userId = fixture.chat.userId, chatId = fixture.chat.id)
+
+        try {
+            fixture.sink.emit(
+                AgentRuntimeEvent.LlmMessageDelta(
+                    text = "Check both options.",
+                    kind = AgentRuntimeEvent.LlmMessageDelta.Kind.REASONING,
+                )
+            )
+
+            val liveEvent = withTimeout(1_000) { stream.liveEvents.receive() }
+            val payload = liveEvent.payload as MessageDeltaPayload
+
+            assertEquals(AgentEventType.MESSAGE_DELTA, liveEvent.type)
+            assertEquals("Check both options.", payload.delta)
+            assertEquals("reasoning", payload.kind)
+            assertTrue(fixture.eventRepository.listByChat(fixture.chat.userId, fixture.chat.id).isEmpty())
         } finally {
             stream.close()
         }

--- a/backend/src/test/kotlin/ru/souz/backend/events/model/AgentEventPayloadSerializationTest.kt
+++ b/backend/src/test/kotlin/ru/souz/backend/events/model/AgentEventPayloadSerializationTest.kt
@@ -20,6 +20,7 @@ class AgentEventPayloadSerializationTest {
             AgentEventType.MESSAGE_DELTA to MessageDeltaPayload(
                 messageId = UUID.fromString("22222222-2222-2222-2222-222222222222"),
                 delta = "chunk",
+                kind = "reasoning",
             ),
             AgentEventType.MESSAGE_COMPLETED to MessageCompletedPayload(
                 messageId = UUID.fromString("33333333-3333-3333-3333-333333333333"),

--- a/backend/src/test/kotlin/ru/souz/backend/http/BackendOpenApiTest.kt
+++ b/backend/src/test/kotlin/ru/souz/backend/http/BackendOpenApiTest.kt
@@ -279,6 +279,16 @@ class BackendOpenApiTest {
                 setOf("seq", "durable", "chatId", "executionId", "type", "payload", "createdAt"),
                 delta["required"].map { it.asText() }.toSet(),
             )
+            val deltaPayload = schemas["BackendMessageDeltaEventPayload"]
+            assertEquals(
+                setOf("messageId", "delta"),
+                deltaPayload["required"].map { it.asText() }.toSet(),
+            )
+            assertEquals(
+                listOf("content", "reasoning"),
+                deltaPayload["properties"]["kind"]["enum"].map { it.asText() },
+            )
+            assertTrue(deltaPayload["properties"]["kind"]["description"].asText().contains("Omitted"))
 
             val replayEvent = schemas[BackendEventOpenApiSchemas.REPLAY_EVENT]
             val legacy = schemas[BackendEventOpenApiSchemas.LEGACY_DURABLE_EVENT]

--- a/backend/src/test/kotlin/ru/souz/backend/http/BackendV1EventDtoPayloadTest.kt
+++ b/backend/src/test/kotlin/ru/souz/backend/http/BackendV1EventDtoPayloadTest.kt
@@ -9,6 +9,7 @@ import ru.souz.backend.events.model.AgentEventType
 import ru.souz.backend.events.model.ChoiceRequestedPayload
 import ru.souz.backend.events.model.ChoiceOptionItemPayload
 import ru.souz.backend.events.model.MessageCreatedPayload
+import ru.souz.backend.events.model.MessageDeltaPayload
 import ru.souz.backend.events.model.RawAgentEventPayload
 import ru.souz.backend.events.model.ToolCallFinishedPayload
 import ru.souz.backend.events.model.ToolCallStartedPayload
@@ -37,6 +38,53 @@ class BackendV1EventDtoPayloadTest {
         val dto = event.toDto()
 
         assertEquals("client-42", dto.payload["clientMessageId"])
+    }
+
+    @Test
+    fun `typed reasoning delta dto exposes its kind`() {
+        val event = AgentEvent(
+            id = UUID.fromString("05050505-0505-0505-0505-050505050505"),
+            userId = "user-a",
+            chatId = UUID.fromString("06060606-0606-0606-0606-060606060606"),
+            executionId = UUID.fromString("07070707-0707-0707-0707-070707070707"),
+            seq = 3L,
+            type = AgentEventType.MESSAGE_DELTA,
+            payload = MessageDeltaPayload(
+                messageId = UUID.fromString("08080808-0808-0808-0808-080808080808"),
+                delta = "Check both options.",
+                kind = "reasoning",
+            ),
+            createdAt = Instant.parse("2026-05-02T09:59:59Z"),
+        )
+
+        val dto = event.toDto()
+
+        assertEquals("Check both options.", dto.payload["delta"])
+        assertEquals("reasoning", dto.payload["kind"])
+    }
+
+    @Test
+    fun `raw reasoning delta dto preserves its kind`() {
+        val event = AgentEvent(
+            id = UUID.fromString("09090909-0909-0909-0909-090909090909"),
+            userId = "user-a",
+            chatId = UUID.fromString("10101010-1010-1010-1010-101010101010"),
+            executionId = UUID.fromString("11111111-1111-1111-1111-111111111111"),
+            seq = 4L,
+            type = AgentEventType.MESSAGE_DELTA,
+            payload = RawAgentEventPayload(
+                values = mapOf(
+                    "messageId" to "12121212-1212-1212-1212-121212121212",
+                    "delta" to "Check both options.",
+                    "kind" to "reasoning",
+                )
+            ),
+            createdAt = Instant.parse("2026-05-02T09:59:59Z"),
+        )
+
+        val dto = event.toDto()
+
+        assertEquals("reasoning", dto.payload["kind"])
     }
 
     @Test

--- a/backend/src/test/kotlin/ru/souz/backend/llm/BackendLlmClientFactoryTest.kt
+++ b/backend/src/test/kotlin/ru/souz/backend/llm/BackendLlmClientFactoryTest.kt
@@ -104,11 +104,15 @@ class BackendLlmClientFactoryTest {
             BackendLlmExecutionContext(
                 userId = "user-a",
                 executionId = "exec-a",
-                settingsProvider = TestSettingsProvider().apply { gigaModel = LLMModel.OpenAIGpt52 },
+                settingsProvider = TestSettingsProvider().apply {
+                    gigaModel = LLMModel.OpenAIGpt52
+                    useStreaming = true
+                },
             )
         ).message(sampleRequest("GigaChat-Max"))
 
         assertEquals(LlmProvider.GIGA, builder.invocations.single().provider)
+        assertEquals("medium", builder.invocations.single().reasoningEffort)
     }
 
     @Test
@@ -161,6 +165,7 @@ private class RecordingProviderChatApiBuilder : ProviderChatApiBuilder {
                         else -> settingsProvider.openaiKey.orEmpty()
                     },
                     transport = sharedTransport,
+                    reasoningEffort = body.reasoningEffort,
                 )
                 return LLMResponse.Chat.Error(499, "recorded only")
             }
@@ -187,6 +192,7 @@ private data class ProviderClientInvocation(
     val provider: LlmProvider,
     val apiKey: String,
     val transport: SharedProviderTransport,
+    val reasoningEffort: String?,
 )
 
 private class StaticProviderCredentialResolver(

--- a/backend/src/test/kotlin/ru/souz/backend/llm/RetryingLlmChatApiTest.kt
+++ b/backend/src/test/kotlin/ru/souz/backend/llm/RetryingLlmChatApiTest.kt
@@ -1,12 +1,19 @@
 package ru.souz.backend.llm
 
 import java.io.File
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.yield
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertTrue
 import ru.souz.backend.app.BackendProviderRetryPolicy
 import ru.souz.llms.LLMChatAPI
 import ru.souz.llms.LLMMessageRole
@@ -76,6 +83,90 @@ class RetryingLlmChatApiTest {
         assertEquals("final", response.message)
     }
 
+    @Test
+    fun `successful stream emits before delegate stream completes`() = runTest {
+        val firstResponse = okResponse("first")
+        val delegateCompletion = CompletableDeferred<Unit>()
+        val delegate = object : LLMChatAPI by ScriptedRetryChatApi(listOf(firstResponse)) {
+            override suspend fun messageStream(body: LLMRequest.Chat): Flow<LLMResponse.Chat> = flow {
+                emit(firstResponse)
+                delegateCompletion.await()
+            }
+        }
+        val api = RetryingLlmChatApi(
+            delegate = delegate,
+            provider = LlmProvider.OPENAI,
+            retryPolicy = BackendProviderRetryPolicy(),
+        )
+
+        val firstChunk = backgroundScope.async {
+            api.messageStream(chatRequest()).first()
+        }
+        yield()
+
+        assertTrue(firstChunk.isCompleted)
+        assertEquals(firstResponse, firstChunk.await())
+    }
+
+    @Test
+    fun `stream retries when its only response is a 429`() = runTest {
+        val recordedDelays = mutableListOf<Long>()
+        val firstResponse = okResponse("first")
+        val finalResponse = okResponse("final")
+        val delegate = ScriptedRetryChatApi(
+            responses = listOf(firstResponse),
+            streamAttempts = listOf(
+                listOf(LLMResponse.Chat.Error(429, "rate limited; retry-after=1200")),
+                listOf(firstResponse, finalResponse),
+            ),
+        )
+        val api = RetryingLlmChatApi(
+            delegate = delegate,
+            provider = LlmProvider.OPENAI,
+            retryPolicy = BackendProviderRetryPolicy(
+                max429Retries = 2,
+                backoffBaseMs = 100L,
+                backoffMaxMs = 5_000L,
+            ),
+            delayMillis = { value -> recordedDelays.add(value) },
+        )
+
+        val responses = api.messageStream(chatRequest()).toList()
+
+        assertEquals(listOf(firstResponse, finalResponse), responses)
+        assertEquals(2, delegate.messageStreamCalls)
+        assertEquals(listOf(1_200L), recordedDelays)
+    }
+
+    @Test
+    fun `stream does not retry when a 429 is followed by another response`() = runTest {
+        val recordedDelays = mutableListOf<Long>()
+        val rateLimitError = LLMResponse.Chat.Error(429, "rate limited")
+        val finalResponse = okResponse("final")
+        val delegate = ScriptedRetryChatApi(
+            responses = listOf(finalResponse),
+            streamAttempts = listOf(listOf(rateLimitError, finalResponse)),
+        )
+        val api = RetryingLlmChatApi(
+            delegate = delegate,
+            provider = LlmProvider.OPENAI,
+            retryPolicy = BackendProviderRetryPolicy(),
+            delayMillis = { value -> recordedDelays.add(value) },
+        )
+
+        val responses = api.messageStream(chatRequest()).toList()
+
+        assertEquals(listOf(rateLimitError, finalResponse), responses)
+        assertEquals(1, delegate.messageStreamCalls)
+        assertTrue(recordedDelays.isEmpty())
+    }
+
+    private fun chatRequest(): LLMRequest.Chat =
+        LLMRequest.Chat(
+            model = "test-model",
+            messages = listOf(LLMRequest.Message(role = LLMMessageRole.user, content = "hello")),
+        )
+
     private fun okResponse(content: String): LLMResponse.Chat.Ok =
         LLMResponse.Chat.Ok(
             choices = listOf(
@@ -97,14 +188,20 @@ class RetryingLlmChatApiTest {
 
 private class ScriptedRetryChatApi(
     private val responses: List<LLMResponse.Chat>,
+    private val streamAttempts: List<List<LLMResponse.Chat>> = responses.map { listOf(it) },
 ) : LLMChatAPI {
     private var index: Int = 0
+    var messageStreamCalls: Int = 0
+        private set
 
     override suspend fun message(body: LLMRequest.Chat): LLMResponse.Chat =
         responses.getOrElse(index++) { responses.last() }
 
-    override suspend fun messageStream(body: LLMRequest.Chat): Flow<LLMResponse.Chat> =
-        flowOf(message(body))
+    override suspend fun messageStream(body: LLMRequest.Chat): Flow<LLMResponse.Chat> {
+        val responses = streamAttempts.getOrElse(messageStreamCalls) { streamAttempts.last() }
+        messageStreamCalls += 1
+        return flowOf(*responses.toTypedArray())
+    }
 
     override suspend fun embeddings(body: LLMRequest.Embeddings): LLMResponse.Embeddings =
         error("Embeddings are not used in this test.")

--- a/sharedLogic/src/commonJvmMain/kotlin/ru/souz/llms/giga/GigaRestChatAPI.kt
+++ b/sharedLogic/src/commonJvmMain/kotlin/ru/souz/llms/giga/GigaRestChatAPI.kt
@@ -385,11 +385,11 @@ internal fun parseGigaStreamChunk(data: String): LLMResponse.Chat {
 
         LLMResponse.Choice(
             message = LLMResponse.Message(
-                content = delta["content"]?.asText() ?: "",
+                content = delta["content"].toGigaMessageText().orEmpty(),
                 role = role,
                 functionCall = functionCall,
                 functionsStateId = delta["functions_state_id"]?.asText(),
-                reasoningContent = delta["reasoning_content"]?.asText(),
+                reasoningContent = delta["reasoning_content"].toGigaMessageText(),
                 created = delta["created"]?.asLong(),
                 name = delta["name"]?.asText(),
             ),
@@ -404,6 +404,11 @@ internal fun parseGigaStreamChunk(data: String): LLMResponse.Chat {
         model = node["model"]?.asText() ?: "",
         usage = node["usage"]?.takeUnless { it.isNull }?.toGigaUsage() ?: LLMResponse.Usage(0, 0, 0, 0),
     )
+}
+
+private fun JsonNode?.toGigaMessageText(): String? {
+    if (this == null || isNull) return null
+    return asText().takeUnless { it.equals("null", ignoreCase = true) }
 }
 
 private fun JsonNode.toGigaFunctionCall(): LLMResponse.FunctionCall {

--- a/sharedLogic/src/commonJvmMain/kotlin/ru/souz/llms/openai/OpenAIChatAPI.kt
+++ b/sharedLogic/src/commonJvmMain/kotlin/ru/souz/llms/openai/OpenAIChatAPI.kt
@@ -202,6 +202,7 @@ class OpenAIChatAPI(
             if (body.maxTokens > 0) {
                 put("max_completion_tokens", body.maxTokens)
             }
+            body.reasoningEffort?.let { put("reasoning_effort", it) }
             if (tools.isNotEmpty()) {
                 put("tools", tools)
                 put("tool_choice", "auto")
@@ -499,6 +500,7 @@ class OpenAIChatAPI(
             val messageNode = choiceNode[messageField]
 
             val messageContent = messageNode?.get("content").toOpenAiMessageContent()
+            val reasoningContent = messageNode?.get("reasoning_content").toOpenAiMessageContent()
             val role = messageNode?.get("role")?.asText().toOpenAiRole()
             val finishReason = choiceNode["finish_reason"]?.asText().toOpenAiFinishReasonValue()
             val choiceIndex = choiceNode["index"]?.asInt() ?: idx
@@ -528,13 +530,14 @@ class OpenAIChatAPI(
                 }
             }
 
-            if (messageContent.isNotEmpty()) {
+            if (messageContent.isNotEmpty() || reasoningContent.isNotEmpty()) {
                 choices += LLMResponse.Choice(
                     message = LLMResponse.Message(
                         content = messageContent,
                         role = role,
                         functionCall = null,
                         functionsStateId = null,
+                        reasoningContent = reasoningContent.takeIf { it.isNotEmpty() },
                     ),
                     index = choiceIndex,
                     finishReason = if (toolCallsNode != null && toolCallsNode.size() > 0) null else finishReason,
@@ -786,16 +789,18 @@ private class OpenAiStreamAccumulator {
             }
 
             // Append Content
-            val contentOrNull = delta?.get("content")?.asText()
-            if (!contentOrNull.isNullOrEmpty()) {
-                // Emit content immediately as stream
+            val content = delta?.get("content").toOpenAiMessageContent()
+            val reasoningContent = delta?.get("reasoning_content").toOpenAiMessageContent()
+            if (content.isNotEmpty() || reasoningContent.isNotEmpty()) {
+                // Emit text immediately as stream
                 resultChoices.add(
                     LLMResponse.Choice(
                         message = LLMResponse.Message(
-                            content = contentOrNull,
+                            content = content,
                             role = state.role ?: LLMMessageRole.assistant,
                             functionCall = null,
-                            functionsStateId = null
+                            functionsStateId = null,
+                            reasoningContent = reasoningContent.takeIf { it.isNotEmpty() },
                         ),
                         index = index,
                         finishReason = null

--- a/sharedLogic/src/test/kotlin/ru/souz/llms/OpenAIChatAPIRequestTest.kt
+++ b/sharedLogic/src/test/kotlin/ru/souz/llms/OpenAIChatAPIRequestTest.kt
@@ -72,6 +72,22 @@ class OpenAIChatAPIRequestTest {
     }
 
     @Test
+    fun `buildChatRequest forwards an explicit reasoning effort`() {
+        val api = createApi(openaiModel = "provider-reasoning-model")
+        val request = invokeBuildChatRequest(
+            api = api,
+            body = LLMRequest.Chat(
+                model = LLMModel.OpenAICompatibleCustom.alias,
+                messages = listOf(LLMRequest.Message(role = LLMMessageRole.user, content = "Hello")),
+                reasoningEffort = "medium",
+            ),
+            stream = true,
+        )
+
+        assertEquals("medium", request["reasoning_effort"])
+    }
+
+    @Test
     fun `OpenAI endpoint uses configured compatible base url`() {
         val settingsProvider = mockk<SettingsProvider>(relaxed = true)
         every { settingsProvider.openaiBaseUrl } returns "https://example.test/openai/v1/"
@@ -430,6 +446,36 @@ class OpenAIChatAPIRequestTest {
     }
 
     @Test
+    fun `parseCompletionsResponse preserves reasoning content separately from answer`() {
+        val api = createApi()
+        val response = invokeParseCompletionsResponse(
+            api = api,
+            text = """
+                {
+                  "created": 1739900000,
+                  "model": "provider-reasoning-model",
+                  "choices": [
+                    {
+                      "index": 0,
+                      "finish_reason": "stop",
+                      "message": {
+                        "role": "assistant",
+                        "reasoning_content": "Check the relevant facts.",
+                        "content": "The answer is 42."
+                      }
+                    }
+                  ]
+                }
+            """.trimIndent(),
+            requestModel = LLMModel.OpenAICompatibleCustom.alias,
+        )
+
+        val message = (response as LLMResponse.Chat.Ok).choices.single().message
+        assertEquals("Check the relevant facts.", message.reasoningContent)
+        assertEquals("The answer is 42.", message.content)
+    }
+
+    @Test
     fun `buildEmbeddingsRequest includes float encoding format`() {
         val api = createApi()
         val request = invokeBuildEmbeddingsRequest(
@@ -491,15 +537,7 @@ class OpenAIChatAPIRequestTest {
 
     @Test
     fun `stream accumulator emits distinct indexes for multiple tool calls in one choice`() {
-        val classLoader = OpenAIChatAPI::class.java.classLoader
-        val clazz = Class.forName("ru.souz.llms.openai.OpenAiStreamAccumulator", true, classLoader)
-        val ctor = clazz.getDeclaredConstructor()
-        ctor.isAccessible = true
-        val accumulator = ctor.newInstance()
-        val processChunk = clazz.getDeclaredMethod("processChunk", com.fasterxml.jackson.databind.JsonNode::class.java)
-        processChunk.isAccessible = true
-
-        val node = restJsonMapper.readTree(
+        val choices = processStreamChunk(
             """
                 {
                   "choices": [
@@ -533,12 +571,35 @@ class OpenAIChatAPIRequestTest {
             """.trimIndent()
         )
 
-        @Suppress("UNCHECKED_CAST")
-        val choices = processChunk.invoke(accumulator, node) as List<LLMResponse.Choice>
         val toolChoices = choices.filter { it.message.functionCall != null }
         assertEquals(2, toolChoices.size)
         assertNotEquals(toolChoices[0].index, toolChoices[1].index)
         assertEquals(setOf("call_a", "call_b"), toolChoices.mapNotNull { it.message.functionsStateId }.toSet())
+    }
+
+    @Test
+    fun `stream accumulator preserves reasoning delta separately from answer content`() {
+        val choices = processStreamChunk(
+            """
+                {
+                  "choices": [
+                    {
+                      "index": 0,
+                      "delta": {
+                        "role": "assistant",
+                        "reasoning_content": "Consider both possibilities.",
+                        "content": null
+                      },
+                      "finish_reason": null
+                    }
+                  ]
+                }
+            """.trimIndent()
+        )
+
+        val message = choices.single().message
+        assertEquals("Consider both possibilities.", message.reasoningContent)
+        assertEquals("", message.content)
     }
 
     private fun createApi(openaiModel: String? = null): OpenAIChatAPI {
@@ -593,6 +654,18 @@ class OpenAIChatAPIRequestTest {
         )
         method.isAccessible = true
         return method.invoke(api, text, requestModel) as LLMResponse.Chat
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun processStreamChunk(text: String): List<LLMResponse.Choice> {
+        val classLoader = OpenAIChatAPI::class.java.classLoader
+        val clazz = Class.forName("ru.souz.llms.openai.OpenAiStreamAccumulator", true, classLoader)
+        val constructor = clazz.getDeclaredConstructor()
+        constructor.isAccessible = true
+        val accumulator = constructor.newInstance()
+        val processChunk = clazz.getDeclaredMethod("processChunk", com.fasterxml.jackson.databind.JsonNode::class.java)
+        processChunk.isAccessible = true
+        return processChunk.invoke(accumulator, restJsonMapper.readTree(text)) as List<LLMResponse.Choice>
     }
 
     private fun function(name: String): LLMRequest.Function = LLMRequest.Function(

--- a/sharedLogic/src/test/kotlin/ru/souz/llms/giga/GigaChatApiContractTest.kt
+++ b/sharedLogic/src/test/kotlin/ru/souz/llms/giga/GigaChatApiContractTest.kt
@@ -1,0 +1,54 @@
+package ru.souz.llms.giga
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import ru.souz.llms.LLMResponse
+
+class GigaChatApiContractTest {
+    @Test
+    fun `stream chunks keep reasoning separate from answer content`() {
+        val reasoningChunk = parseGigaStreamChunk(
+            """
+                {
+                  "choices": [
+                    {
+                      "index": 0,
+                      "delta": {
+                        "role": "assistant",
+                        "reasoning_content": "Compare the available evidence.",
+                        "content": null
+                      },
+                      "finish_reason": null
+                    }
+                  ],
+                  "created": 1739900000,
+                  "model": "GigaChat-3-Ultra"
+                }
+            """.trimIndent()
+        ) as LLMResponse.Chat.Ok
+        val answerChunk = parseGigaStreamChunk(
+            """
+                {
+                  "choices": [
+                    {
+                      "index": 0,
+                      "delta": {
+                        "reasoning_content": null,
+                        "content": "The evidence supports option A."
+                      },
+                      "finish_reason": "stop"
+                    }
+                  ],
+                  "created": 1739900001,
+                  "model": "GigaChat-3-Ultra"
+                }
+            """.trimIndent()
+        ) as LLMResponse.Chat.Ok
+
+        assertEquals("Compare the available evidence.", reasoningChunk.choices.single().message.reasoningContent)
+        assertEquals("", reasoningChunk.choices.single().message.content)
+        assertNull(answerChunk.choices.single().message.reasoningContent)
+        assertEquals("The evidence supports option A.", answerChunk.choices.single().message.content)
+    }
+}


### PR DESCRIPTION
## Summary

- parse and preserve `reasoning_content` from Giga and OpenAI-compatible responses
- deliver reasoning through live `message.delta` events with `kind: reasoning`, while keeping final answer content unchanged
- enable Giga reasoning for streaming backend requests and keep retry-wrapped provider streams progressive

## Root cause

Provider reasoning was either discarded while parsing OpenAI-compatible responses or dropped by the agent stream before it reached backend events. The backend retry wrapper also buffered complete provider streams, preventing reasoning deltas from arriving live.

## Impact

Trusted backend consumers can distinguish reasoning from answer content without breaking existing content-delta handling. Persisted messages, conversation history, and the terminal-only public Client-Souz socket remain answer-only.

## Validation

- `./gradlew :sharedLogic:jvmTest :agent:test :backend:test`
- `git diff --check`

Closes #621
