### PR TITLE
test: give cancel-detach polling a 5s budget instead of 2s

### DIFF
--- a/backend/src/test/kotlin/ru/souz/backend/http/BackendPublicClientContractRouteTest.kt
+++ b/backend/src/test/kotlin/ru/souz/backend/http/BackendPublicClientContractRouteTest.kt
@@ -656,7 +656,7 @@ class BackendPublicClientContractRouteTest {
             assertEquals("cancel-1", cancelAck["requestId"].asText())
             assertEquals(threadId, cancelStatus["threadId"].asText())
             assertEquals("thread.cancelled", terminal["type"].asText())
-            withTimeout(2_000) {
+            withTimeout(5_000) {
                 while (context.clientThreadRegistry.contains(UUID.fromString(threadId))) {
                     delay(10)
                 }


### PR DESCRIPTION
The window between the client seeing thread.cancelled and the runtime coroutine unwinding to clientThreadRegistry.detach() is an inherent race (job.cancel() is fire-and-forget), so 2s is too tight under CI load. Matches the 5s convention already used for cancellation waits in AgentExecutionLauncherTest.