### PR TITLE
Add source-set boundary quality gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,13 @@ Only these direct production project dependencies are allowed. Standard test-sou
 - `:backend` `main` → `:agent`, `:llms`, `:native`, `:sharedLogic`, `:skill-oauth-api`, `:skill-oauth-impl`.
 - `:desktopApp` `main` → `:ambientAgent`, `:sharedLogic`, `:sharedUI`, `:agent`, `:llms`, `:native`.
 
+## Production source boundaries
+
+- `commonMain` must not import JVM, Android, native-platform, desktop-window, or host-implementation APIs.
+- `:sharedUI` `commonJvmMain` must not import AWT/Swing, desktop-only Compose window APIs, backend or desktop implementations, or native-model implementations. Portable `Dialog` and `Popup` APIs are allowed.
+- `:graph-engine`, `:llms`, `:agent`, and `:skill-oauth-api` production code must not import Compose, UI, backend, native-model, host-DI, or host-service implementations.
+- `:backend` production code must not import Compose, UI, host-DI, AWT/Swing, or desktop service and tool implementations.
+
 ## Verification
 
 - Use the Gradle wrapper and the Java 21 toolchain configured by the build.

--- a/build-logic/README.md
+++ b/build-logic/README.md
@@ -2,8 +2,9 @@
 
 This included Gradle build contains the `souz.quality` plugin used by the root
 project. It owns repository-contract checks, production module-boundary checks,
-source-set import boundaries, type-resolved coroutine analysis, Souz Detekt
-extensions, and versioned quality reports; it is not a product module.
+source-set package and reference boundaries, type-resolved coroutine analysis,
+Souz Detekt extensions, and versioned quality reports; it is not a product
+module.
 
 See [Quality gates](../docs/quality-gates.md) for tasks, check contracts, report
 locations, CI authority, and remediation guidance.

--- a/build-logic/README.md
+++ b/build-logic/README.md
@@ -2,8 +2,8 @@
 
 This included Gradle build contains the `souz.quality` plugin used by the root
 project. It owns repository-contract checks, production module-boundary checks,
-type-resolved coroutine analysis, the Souz coroutine Detekt extension, and
-versioned quality reports; it is not a product module.
+source-set import boundaries, type-resolved coroutine analysis, Souz Detekt
+extensions, and versioned quality reports; it is not a product module.
 
 See [Quality gates](../docs/quality-gates.md) for tasks, check contracts, report
 locations, CI authority, and remediation guidance.

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
 
 group = "ru.souz.build"
 
+val kotlinGradlePluginVersion = "2.4.10"
+
 val functionalTestKotlinPluginClasspath by configurations.creating {
     isCanBeConsumed = false
     isCanBeResolved = true
@@ -21,12 +23,13 @@ dependencies {
     implementation("org.commonmark:commonmark:0.30.0")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.21.3")
     implementation("dev.detekt:detekt-gradle-plugin:2.0.0-alpha.6")
+    compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin-api:$kotlinGradlePluginVersion")
 
     testImplementation(gradleTestKit())
     testImplementation("org.junit.jupiter:junit-jupiter:6.0.2")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:6.0.2")
 
-    functionalTestKotlinPluginClasspath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.4.10")
+    functionalTestKotlinPluginClasspath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinGradlePluginVersion")
 }
 
 gradlePlugin {

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -5,6 +5,11 @@ plugins {
 
 group = "ru.souz.build"
 
+val functionalTestKotlinPluginClasspath by configurations.creating {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+}
+
 java {
     toolchain {
         languageVersion.set(JavaLanguageVersion.of(21))
@@ -12,6 +17,7 @@ java {
 }
 
 dependencies {
+    implementation(project(":detekt-rules"))
     implementation("org.commonmark:commonmark:0.30.0")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.21.3")
     implementation("dev.detekt:detekt-gradle-plugin:2.0.0-alpha.6")
@@ -19,6 +25,8 @@ dependencies {
     testImplementation(gradleTestKit())
     testImplementation("org.junit.jupiter:junit-jupiter:6.0.2")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:6.0.2")
+
+    functionalTestKotlinPluginClasspath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.4.10")
 }
 
 gradlePlugin {
@@ -32,6 +40,10 @@ gradlePlugin {
 
 tasks.test {
     useJUnitPlatform()
+    inputs.files(functionalTestKotlinPluginClasspath)
+    doFirst {
+        systemProperty("souz.test.kotlin-plugin-classpath", functionalTestKotlinPluginClasspath.asPath)
+    }
 }
 
 tasks.named("check") {

--- a/build-logic/detekt-rules/src/main/kotlin/ru/souz/build/quality/detekt/SourceSetBoundaries.kt
+++ b/build-logic/detekt-rules/src/main/kotlin/ru/souz/build/quality/detekt/SourceSetBoundaries.kt
@@ -1,0 +1,202 @@
+package ru.souz.build.quality.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.api.Entity
+import dev.detekt.api.Finding
+import dev.detekt.api.Rule
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtImportDirective
+
+/** Keeps portable, core, backend, and shared UI production sources behind their host boundaries. */
+class SourceSetBoundaries private constructor(
+    config: Config,
+    private val sourcePath: (KtFile) -> String,
+) : Rule(
+    config,
+    "Production imports must respect Souz source-set and host boundaries.",
+) {
+    constructor(config: Config) : this(config, { file -> file.virtualFilePath })
+
+    internal constructor(config: Config, sourcePath: String) : this(config, { sourcePath })
+
+    override fun visitImportDirective(importDirective: KtImportDirective) {
+        val importPath = importDirective.importPath?.pathStr?.removeSuffix(".*")
+        if (importPath != null) {
+            sourceSetBoundaryViolation(
+                sourcePath = sourcePath(importDirective.containingKtFile),
+                importPath = importPath,
+                isAllUnder = importDirective.isAllUnder,
+            )?.let { message -> report(Finding(Entity.from(importDirective), message)) }
+        }
+        super.visitImportDirective(importDirective)
+    }
+}
+
+private data class SourceLocation(
+    val module: String,
+    val sourceSet: String,
+) {
+    val isProduction: Boolean = sourceSet == "main" || sourceSet.endsWith("Main")
+}
+
+private fun sourceSetBoundaryViolation(
+    sourcePath: String,
+    importPath: String,
+    isAllUnder: Boolean,
+): String? {
+    val source = sourceLocation(sourcePath) ?: return null
+    if (!source.isProduction) return null
+    val renderedImport = importPath + if (isAllUnder) ".*" else ""
+
+    if (source.sourceSet == "commonMain" && importPath.isPortableHostImport(isAllUnder)) {
+        return "Import '$renderedImport' is host-specific; commonMain must remain portable. " +
+            "Move the implementation to a platform source set."
+    }
+    if (
+        source.module == "sharedUI" && source.sourceSet == "commonJvmMain" &&
+        importPath.isSharedUiHostImport(isAllUnder)
+    ) {
+        return "Import '$renderedImport' is not allowed in :sharedUI commonJvmMain. " +
+            "Move desktop or native integration to jvmMain and expose a host port."
+    }
+    if (source.module in CORE_MODULES && importPath.matchesAny(CORE_FORBIDDEN_PREFIXES)) {
+        return "Import '$renderedImport' is not allowed in :${source.module} ${source.sourceSet}. " +
+            "Core production code must not depend on Compose or host/backend implementations."
+    }
+    if (source.module == "backend" && importPath.matchesAny(BACKEND_FORBIDDEN_PREFIXES)) {
+        return "Import '$renderedImport' is not allowed in :backend ${source.sourceSet}. " +
+            "Backend production code must not depend on UI or desktop integrations."
+    }
+    return null
+}
+
+private fun sourceLocation(path: String): SourceLocation? {
+    val normalized = path.replace('\\', '/')
+    val match = SOURCE_LAYOUT.findAll(normalized).lastOrNull() ?: return null
+    return SourceLocation(module = match.groupValues[1], sourceSet = match.groupValues[2])
+}
+
+private fun String.isPortableHostImport(isAllUnder: Boolean): Boolean =
+    matchesAny(PORTABLE_HOST_PREFIXES) ||
+        isDesktopWindowImport(isAllUnder) ||
+        matchesAny(HOST_IMPLEMENTATION_PREFIXES) ||
+        this in HOST_IMPLEMENTATION_TYPES
+
+private fun String.isSharedUiHostImport(isAllUnder: Boolean): Boolean =
+    matchesAny(SHARED_UI_HOST_PREFIXES) ||
+        isDesktopWindowImport(isAllUnder) ||
+        matchesAny(HOST_IMPLEMENTATION_PREFIXES) ||
+        this in HOST_IMPLEMENTATION_TYPES
+
+private fun String.isDesktopWindowImport(isAllUnder: Boolean): Boolean =
+    (isAllUnder && this == COMPOSE_WINDOW_PACKAGE) ||
+        DESKTOP_WINDOW_TYPES.any { type -> this == type || startsWith("$type.") }
+
+private fun String.matchesAny(prefixes: List<String>): Boolean =
+    prefixes.any { prefix -> this == prefix.removeSuffix(".") || startsWith(prefix) }
+
+private val SOURCE_LAYOUT = Regex("(?:^|/)([^/]+)/src/([^/]+)/")
+
+private val CORE_MODULES = setOf("graph-engine", "llms", "agent", "skill-oauth-api")
+
+private const val COMPOSE_WINDOW_PACKAGE = "androidx.compose.ui.window"
+
+private val DESKTOP_WINDOW_TYPES = setOf(
+    "$COMPOSE_WINDOW_PACKAGE.ApplicationScope",
+    "$COMPOSE_WINDOW_PACKAGE.DialogWindow",
+    "$COMPOSE_WINDOW_PACKAGE.DialogWindowScope",
+    "$COMPOSE_WINDOW_PACKAGE.FrameWindowScope",
+    "$COMPOSE_WINDOW_PACKAGE.MenuBar",
+    "$COMPOSE_WINDOW_PACKAGE.Notification",
+    "$COMPOSE_WINDOW_PACKAGE.Tray",
+    "$COMPOSE_WINDOW_PACKAGE.TrayState",
+    "$COMPOSE_WINDOW_PACKAGE.Window",
+    "$COMPOSE_WINDOW_PACKAGE.WindowPlacement",
+    "$COMPOSE_WINDOW_PACKAGE.WindowPosition",
+    "$COMPOSE_WINDOW_PACKAGE.WindowScope",
+    "$COMPOSE_WINDOW_PACKAGE.WindowState",
+    "$COMPOSE_WINDOW_PACKAGE.application",
+    "$COMPOSE_WINDOW_PACKAGE.awaitApplication",
+    "$COMPOSE_WINDOW_PACKAGE.exitApplication",
+    "$COMPOSE_WINDOW_PACKAGE.rememberDialogState",
+    "$COMPOSE_WINDOW_PACKAGE.rememberTrayState",
+    "$COMPOSE_WINDOW_PACKAGE.rememberWindowState",
+    "$COMPOSE_WINDOW_PACKAGE.singleWindowApplication",
+)
+
+private val PORTABLE_HOST_PREFIXES = listOf(
+    "android.",
+    "androidx.compose.foundation.window.",
+    "androidx.compose.ui.awt.",
+    "com.sun.jna.",
+    "java.",
+    "javax.",
+    "kotlinx.cinterop.",
+    "org.jetbrains.skiko.",
+    "platform.",
+)
+
+private val DESKTOP_SERVICE_PREFIXES = listOf(
+    "ru.souz.service.audio.",
+    "ru.souz.service.image.",
+    "ru.souz.service.keys.",
+    "ru.souz.service.permissions.",
+    "ru.souz.service.speech.",
+    "ru.souz.service.telegram.",
+)
+
+private val DESKTOP_TOOL_PREFIXES = listOf(
+    "ru.souz.tool.application.",
+    "ru.souz.tool.browser.",
+    "ru.souz.tool.calendar.",
+    "ru.souz.tool.config.",
+    "ru.souz.tool.desktop.",
+    "ru.souz.tool.mail.",
+    "ru.souz.tool.notes.",
+    "ru.souz.tool.telegram.",
+    "ru.souz.tool.textReplace.",
+)
+
+private val HOST_IMPLEMENTATION_PREFIXES = listOf(
+    "ru.souz.backend.",
+    "ru.souz.llms.local.",
+    "ru.souz.ui.macos.",
+) + DESKTOP_SERVICE_PREFIXES + DESKTOP_TOOL_PREFIXES
+
+private val HOST_IMPLEMENTATION_TYPES = setOf(
+    "ru.souz.App",
+    "ru.souz.WindowLocals",
+    "ru.souz.di.SharedUiDiModule",
+)
+
+private val SHARED_UI_HOST_PREFIXES = listOf(
+    "androidx.compose.foundation.window.",
+    "androidx.compose.ui.awt.",
+    "com.sun.jna.",
+    "java.awt.",
+    "javax.swing.",
+    "org.jetbrains.skiko.",
+)
+
+private val CORE_FORBIDDEN_PREFIXES = listOf(
+    "androidx.compose.",
+    "com.sun.jna.",
+    "java.awt.",
+    "javax.swing.",
+    "org.jetbrains.skiko.",
+    "ru.souz.backend.",
+    "ru.souz.di.",
+    "ru.souz.llms.local.",
+    "ru.souz.service.",
+    "ru.souz.ui.",
+) + DESKTOP_TOOL_PREFIXES
+
+private val BACKEND_FORBIDDEN_PREFIXES = listOf(
+    "androidx.compose.",
+    "com.sun.jna.",
+    "java.awt.",
+    "javax.swing.",
+    "org.jetbrains.skiko.",
+    "ru.souz.di.",
+    "ru.souz.ui.",
+) + DESKTOP_SERVICE_PREFIXES + DESKTOP_TOOL_PREFIXES

--- a/build-logic/detekt-rules/src/main/kotlin/ru/souz/build/quality/detekt/SourceSetBoundaries.kt
+++ b/build-logic/detekt-rules/src/main/kotlin/ru/souz/build/quality/detekt/SourceSetBoundaries.kt
@@ -81,13 +81,13 @@ private fun String.isPortableHostImport(isAllUnder: Boolean): Boolean =
         isUnreviewedAndroidXImport() ||
         isDesktopWindowImport(isAllUnder) ||
         matchesAny(HOST_IMPLEMENTATION_PREFIXES) ||
-        this in HOST_IMPLEMENTATION_TYPES
+        matchesAnySymbol(HOST_IMPLEMENTATION_SYMBOLS, isAllUnder)
 
 private fun String.isSharedUiHostImport(isAllUnder: Boolean): Boolean =
     matchesAny(SHARED_UI_HOST_PREFIXES) ||
         isDesktopWindowImport(isAllUnder) ||
         matchesAny(HOST_IMPLEMENTATION_PREFIXES) ||
-        this in HOST_IMPLEMENTATION_TYPES
+        matchesAnySymbol(HOST_IMPLEMENTATION_SYMBOLS, isAllUnder)
 
 private fun String.isDesktopWindowImport(isAllUnder: Boolean): Boolean =
     when {
@@ -102,6 +102,10 @@ private fun String.isUnreviewedAndroidXImport(): Boolean =
 
 private fun String.matchesAny(prefixes: List<String>): Boolean =
     prefixes.any { prefix -> this == prefix.removeSuffix(".") || startsWith(prefix) }
+
+private fun String.matchesAnySymbol(symbols: Set<String>, isAllUnder: Boolean): Boolean =
+    this in symbols ||
+        isAllUnder && symbols.any { symbol -> symbol.substringBeforeLast('.') == this }
 
 private val SOURCE_LAYOUT = Regex("(?:^|/)([^/]+)/src/([^/]+)/")
 
@@ -160,10 +164,11 @@ private val HOST_IMPLEMENTATION_PREFIXES = listOf(
     "ru.souz.ui.macos.",
 ) + DESKTOP_ONLY_SERVICE_PREFIXES + DESKTOP_TOOL_PREFIXES
 
-private val HOST_IMPLEMENTATION_TYPES = setOf(
+private val HOST_IMPLEMENTATION_SYMBOLS = setOf(
     "ru.souz.App",
-    "ru.souz.WindowLocals",
-    "ru.souz.di.SharedUiDiModule",
+    "ru.souz.LocalWindowScope",
+    "ru.souz.di.sharedUiDesktopDiModule",
+    "ru.souz.di.sharedUiDiModule",
 )
 
 private val SHARED_UI_HOST_PREFIXES = listOf(

--- a/build-logic/detekt-rules/src/main/kotlin/ru/souz/build/quality/detekt/SourceSetBoundaries.kt
+++ b/build-logic/detekt-rules/src/main/kotlin/ru/souz/build/quality/detekt/SourceSetBoundaries.kt
@@ -90,8 +90,11 @@ private fun String.isSharedUiHostImport(isAllUnder: Boolean): Boolean =
         this in HOST_IMPLEMENTATION_TYPES
 
 private fun String.isDesktopWindowImport(isAllUnder: Boolean): Boolean =
-    (isAllUnder && this == COMPOSE_WINDOW_PACKAGE) ||
-        DESKTOP_WINDOW_TYPES.any { type -> this == type || startsWith("$type.") }
+    when {
+        this == COMPOSE_WINDOW_PACKAGE -> isAllUnder
+        !startsWith("$COMPOSE_WINDOW_PACKAGE.") -> false
+        else -> !PORTABLE_WINDOW_TYPES.any { type -> this == type || startsWith("$type.") }
+    }
 
 private fun String.isUnreviewedAndroidXImport(): Boolean =
     matchesAny(COMMON_MAIN_FORBIDDEN_ANDROIDX_PREFIXES) ||
@@ -110,27 +113,11 @@ private val COMMON_MAIN_ALLOWED_ANDROIDX_PREFIXES = listOf("androidx.compose.")
 
 private val COMMON_MAIN_FORBIDDEN_ANDROIDX_PREFIXES = listOf("androidx.compose.desktop.")
 
-private val DESKTOP_WINDOW_TYPES = setOf(
-    "$COMPOSE_WINDOW_PACKAGE.ApplicationScope",
-    "$COMPOSE_WINDOW_PACKAGE.DialogWindow",
-    "$COMPOSE_WINDOW_PACKAGE.DialogWindowScope",
-    "$COMPOSE_WINDOW_PACKAGE.FrameWindowScope",
-    "$COMPOSE_WINDOW_PACKAGE.MenuBar",
-    "$COMPOSE_WINDOW_PACKAGE.Notification",
-    "$COMPOSE_WINDOW_PACKAGE.Tray",
-    "$COMPOSE_WINDOW_PACKAGE.TrayState",
-    "$COMPOSE_WINDOW_PACKAGE.Window",
-    "$COMPOSE_WINDOW_PACKAGE.WindowPlacement",
-    "$COMPOSE_WINDOW_PACKAGE.WindowPosition",
-    "$COMPOSE_WINDOW_PACKAGE.WindowScope",
-    "$COMPOSE_WINDOW_PACKAGE.WindowState",
-    "$COMPOSE_WINDOW_PACKAGE.application",
-    "$COMPOSE_WINDOW_PACKAGE.awaitApplication",
-    "$COMPOSE_WINDOW_PACKAGE.exitApplication",
-    "$COMPOSE_WINDOW_PACKAGE.rememberDialogState",
-    "$COMPOSE_WINDOW_PACKAGE.rememberTrayState",
-    "$COMPOSE_WINDOW_PACKAGE.rememberWindowState",
-    "$COMPOSE_WINDOW_PACKAGE.singleWindowApplication",
+private val PORTABLE_WINDOW_TYPES = setOf(
+    "$COMPOSE_WINDOW_PACKAGE.Dialog",
+    "$COMPOSE_WINDOW_PACKAGE.DialogProperties",
+    "$COMPOSE_WINDOW_PACKAGE.Popup",
+    "$COMPOSE_WINDOW_PACKAGE.PopupProperties",
 )
 
 private val PORTABLE_HOST_PREFIXES = listOf(

--- a/build-logic/detekt-rules/src/main/kotlin/ru/souz/build/quality/detekt/SourceSetBoundaries.kt
+++ b/build-logic/detekt-rules/src/main/kotlin/ru/souz/build/quality/detekt/SourceSetBoundaries.kt
@@ -109,7 +109,10 @@ private val CORE_MODULES = setOf("graph-engine", "llms", "agent", "skill-oauth-a
 
 private const val COMPOSE_WINDOW_PACKAGE = "androidx.compose.ui.window"
 
-private val COMMON_MAIN_ALLOWED_ANDROIDX_PREFIXES = listOf("androidx.compose.")
+private val COMMON_MAIN_ALLOWED_ANDROIDX_PREFIXES = listOf(
+    "androidx.compose.",
+    "androidx.lifecycle.",
+)
 
 private val COMMON_MAIN_FORBIDDEN_ANDROIDX_PREFIXES = listOf("androidx.compose.desktop.")
 

--- a/build-logic/detekt-rules/src/main/kotlin/ru/souz/build/quality/detekt/SourceSetBoundaries.kt
+++ b/build-logic/detekt-rules/src/main/kotlin/ru/souz/build/quality/detekt/SourceSetBoundaries.kt
@@ -1,115 +1,345 @@
 package ru.souz.build.quality.detekt
 
+import com.intellij.psi.PsiElement
 import dev.detekt.api.Config
 import dev.detekt.api.Entity
 import dev.detekt.api.Finding
+import dev.detekt.api.RequiresAnalysisApi
 import dev.detekt.api.Rule
+import org.jetbrains.kotlin.analysis.api.KaExperimentalApi
+import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.analysis.api.symbols.KaCallableSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KaClassLikeSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KaPackageSymbol
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtImportDirective
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
+import org.jetbrains.kotlin.psi.KtPackageDirective
+import org.jetbrains.kotlin.psi.KtParenthesizedExpression
+import org.jetbrains.kotlin.psi.KtQualifiedExpression
+import org.jetbrains.kotlin.psi.KtSafeQualifiedExpression
+import org.jetbrains.kotlin.psi.KtUserType
 
-/** Keeps portable, core, backend, and shared UI production sources behind their host boundaries. */
+/** Keeps production package declarations and references behind their source-set and host boundaries. */
 class SourceSetBoundaries private constructor(
     config: Config,
     private val sourcePath: (KtFile) -> String,
+    private val sourceRoots: List<SourceRoot>,
 ) : Rule(
     config,
-    "Production imports must respect Souz source-set and host boundaries.",
-) {
-    constructor(config: Config) : this(config, { file -> file.virtualFilePath })
+    "Production package declarations and references must respect Souz source-set and host boundaries.",
+), RequiresAnalysisApi {
+    constructor(config: Config) : this(
+        config,
+        { file -> file.virtualFilePath },
+        config.valueOrDefault("sourceRoots", emptyList<String>()).map(::sourceRoot),
+    )
 
-    internal constructor(config: Config, sourcePath: String) : this(config, { sourcePath })
+    internal constructor(
+        config: Config,
+        sourcePath: String,
+        sourceRoots: List<String> = emptyList(),
+    ) : this(config, { sourcePath }, sourceRoots.map(::sourceRoot))
 
     override fun visitImportDirective(importDirective: KtImportDirective) {
         val importPath = importDirective.importPath?.pathStr?.removeSuffix(".*")
         if (importPath != null) {
-            sourceSetBoundaryViolation(
-                sourcePath = sourcePath(importDirective.containingKtFile),
-                importPath = importPath,
+            reportBoundaryViolation(
+                element = importDirective,
+                referencePath = importPath,
                 isAllUnder = importDirective.isAllUnder,
-            )?.let { message -> report(Finding(Entity.from(importDirective), message)) }
+                subject = "Import",
+            )
         }
         super.visitImportDirective(importDirective)
+    }
+
+    override fun visitPackageDirective(directive: KtPackageDirective) {
+        directive.fqName.asString().takeIf(String::isNotEmpty)?.let { packagePath ->
+            reportBoundaryViolation(
+                element = directive,
+                referencePath = packagePath,
+                subject = "Package",
+            )
+        }
+        super.visitPackageDirective(directive)
+    }
+
+    override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
+        visitQualifiedBoundaryReference(expression)
+        super.visitDotQualifiedExpression(expression)
+    }
+
+    override fun visitSafeQualifiedExpression(expression: KtSafeQualifiedExpression) {
+        visitQualifiedBoundaryReference(expression)
+        super.visitSafeQualifiedExpression(expression)
+    }
+
+    private fun visitQualifiedBoundaryReference(expression: KtQualifiedExpression) {
+        if (!expression.isNestedQualifiedReceiver() && !expression.isInsideDirective()) {
+            expression.referencePath()?.let { referencePath ->
+                reportBoundaryViolation(expression, referencePath, subject = "Reference")
+            }
+        }
+    }
+
+    override fun visitUserType(type: KtUserType) {
+        if (type.parent !is KtUserType) {
+            type.referencePath()?.let { referencePath ->
+                reportBoundaryViolation(type, referencePath, subject = "Reference")
+            }
+        }
+        super.visitUserType(type)
+    }
+
+    private fun reportBoundaryViolation(
+        element: PsiElement,
+        referencePath: String,
+        isAllUnder: Boolean = false,
+        subject: String,
+    ) {
+        val file = element.containingFile as? KtFile ?: return
+        val message = sourceSetBoundaryViolation(
+            sourcePath = sourcePath(file),
+            sourceRoots = sourceRoots,
+            referencePath = referencePath,
+            isAllUnder = isAllUnder,
+            subject = subject,
+        ) ?: return
+        if (
+            (element is KtQualifiedExpression || element is KtUserType) &&
+            element.rootReference()?.isQualifiedPackageReference(referencePath) != true
+        ) {
+            return
+        }
+        report(Finding(Entity.from(element), message))
     }
 }
 
 private data class SourceLocation(
     val module: String,
     val sourceSet: String,
-) {
-    val isProduction: Boolean = sourceSet == "main" || sourceSet.endsWith("Main")
-}
+    val isProduction: Boolean,
+    val isHostMain: Boolean,
+)
+
+private data class SourceRoot(
+    val path: String,
+    val source: SourceLocation,
+)
 
 private fun sourceSetBoundaryViolation(
     sourcePath: String,
-    importPath: String,
+    sourceRoots: List<SourceRoot>,
+    referencePath: String,
     isAllUnder: Boolean,
+    subject: String,
 ): String? {
-    val source = sourceLocation(sourcePath) ?: return null
+    val source = sourceLocation(sourcePath, sourceRoots) ?: return null
     if (!source.isProduction) return null
-    val renderedImport = importPath + if (isAllUnder) ".*" else ""
+    val renderedReference = referencePath + if (isAllUnder) ".*" else ""
 
-    if (source.sourceSet == "commonMain" && importPath.isPortableHostImport(isAllUnder)) {
-        return "Import '$renderedImport' is host-specific; commonMain must remain portable. " +
+    if (source.sourceSet == "commonMain" && referencePath.isPortableHostReference(isAllUnder)) {
+        return "$subject '$renderedReference' is host-specific; commonMain must remain portable. " +
             "Move the implementation to a platform source set."
     }
     if (
-        source.module == "sharedUI" && source.sourceSet == "commonJvmMain" &&
-        importPath.isSharedUiHostImport(isAllUnder)
+        source.module == "sharedUI" && !source.isHostMain &&
+        referencePath.isSharedUiHostReference(isAllUnder)
     ) {
-        return "Import '$renderedImport' is not allowed in :sharedUI commonJvmMain. " +
-            "Move desktop or native integration to jvmMain and expose a host port."
+        return "$subject '$renderedReference' is not allowed in :sharedUI ${source.sourceSet}. " +
+            "Move desktop or native integration to a host target main source set and expose a host port."
     }
-    if (source.module in CORE_MODULES && importPath.matchesAny(CORE_FORBIDDEN_PREFIXES)) {
-        return "Import '$renderedImport' is not allowed in :${source.module} ${source.sourceSet}. " +
+    if (
+        source.module in CORE_MODULES &&
+        referencePath.isCoreForbiddenReference(isAllUnder)
+    ) {
+        return "$subject '$renderedReference' is not allowed in :${source.module} ${source.sourceSet}. " +
             "Core production code must not depend on Compose or host/backend implementations."
     }
-    if (source.module == "backend" && importPath.matchesAny(BACKEND_FORBIDDEN_PREFIXES)) {
-        return "Import '$renderedImport' is not allowed in :backend ${source.sourceSet}. " +
+    if (
+        source.module == "backend" &&
+        referencePath.isBackendForbiddenReference(isAllUnder)
+    ) {
+        return "$subject '$renderedReference' is not allowed in :backend ${source.sourceSet}. " +
             "Backend production code must not depend on UI or desktop integrations."
     }
     return null
 }
 
-private fun sourceLocation(path: String): SourceLocation? {
+private fun sourceLocation(path: String, roots: List<SourceRoot>): SourceLocation? {
     val normalized = path.replace('\\', '/')
+    if (roots.isNotEmpty()) {
+        val matchingRoots = roots
+            .asSequence()
+            .filter { root -> normalized == root.path || normalized.startsWith("${root.path}/") }
+            .toList()
+        val configuredSource = matchingRoots
+            .filter { root -> root.source.isProduction }
+            .ifEmpty { matchingRoots }
+            .maxByOrNull { root -> root.path.length }
+            ?.source
+        if (configuredSource != null) return configuredSource
+    }
     val match = SOURCE_LAYOUT.findAll(normalized).lastOrNull() ?: return null
-    return SourceLocation(module = match.groupValues[1], sourceSet = match.groupValues[2])
+    val sourceSet = match.groupValues[2]
+    return SourceLocation(
+        module = match.groupValues[1],
+        sourceSet = sourceSet,
+        isProduction = sourceSet == "main" || sourceSet.endsWith("Main"),
+        isHostMain = sourceSet == "main" || sourceSet == "jvmMain",
+    )
 }
 
-private fun String.isPortableHostImport(isAllUnder: Boolean): Boolean =
+private fun sourceRoot(encoded: String): SourceRoot {
+    val parts = encoded.split(SOURCE_ROOT_SEPARATOR)
+    require(parts.size == SOURCE_ROOT_PARTS) { "Invalid SourceSetBoundaries source root '$encoded'." }
+    return SourceRoot(
+        path = parts[0].replace('\\', '/').trimEnd('/'),
+        source = SourceLocation(
+            module = parts[1],
+            sourceSet = parts[2],
+            isProduction = parts[3].toBooleanStrict(),
+            isHostMain = parts[4].toBooleanStrict(),
+        ),
+    )
+}
+
+private fun String.isPortableHostReference(isAllUnder: Boolean): Boolean =
     matchesAny(PORTABLE_HOST_PREFIXES) ||
-        isUnreviewedAndroidXImport(isAllUnder) ||
-        isDesktopWindowImport(isAllUnder) ||
+        matchesAny(JVM_ONLY_IMPLEMENTATION_PREFIXES) ||
+        isUnreviewedAndroidXReference(isAllUnder) ||
+        isDesktopWindowReference(isAllUnder) ||
         matchesAny(HOST_IMPLEMENTATION_PREFIXES) ||
-        matchesAnySymbol(HOST_IMPLEMENTATION_SYMBOLS, isAllUnder)
+        matchesAnySymbol(HOST_IMPLEMENTATION_SYMBOLS, isAllUnder) ||
+        matchesAnySymbol(JVM_ONLY_IMPLEMENTATION_SYMBOLS, isAllUnder)
 
-private fun String.isSharedUiHostImport(isAllUnder: Boolean): Boolean =
+private fun String.isSharedUiHostReference(isAllUnder: Boolean): Boolean =
     matchesAny(SHARED_UI_HOST_PREFIXES) ||
-        isDesktopWindowImport(isAllUnder) ||
+        matchesAny(JVM_ONLY_IMPLEMENTATION_PREFIXES) ||
+        isDesktopWindowReference(isAllUnder) ||
         matchesAny(HOST_IMPLEMENTATION_PREFIXES) ||
-        matchesAnySymbol(HOST_IMPLEMENTATION_SYMBOLS, isAllUnder)
+        matchesAnySymbol(HOST_IMPLEMENTATION_SYMBOLS, isAllUnder) ||
+        matchesAnySymbol(JVM_ONLY_IMPLEMENTATION_SYMBOLS, isAllUnder)
 
-private fun String.isDesktopWindowImport(isAllUnder: Boolean): Boolean =
+private fun String.isDesktopWindowReference(isAllUnder: Boolean): Boolean =
     when {
-        this == COMPOSE_WINDOW_PACKAGE -> isAllUnder
+        this == COMPOSE_WINDOW_PACKAGE -> true
         !startsWith("$COMPOSE_WINDOW_PACKAGE.") -> false
         else -> !PORTABLE_WINDOW_TYPES.any { type -> this == type || startsWith("$type.") }
     }
 
-private fun String.isUnreviewedAndroidXImport(isAllUnder: Boolean): Boolean =
+private fun String.isUnreviewedAndroidXReference(isAllUnder: Boolean): Boolean =
     (this == "androidx" || startsWith("androidx.")) &&
-        (isAllUnder || this !in COMMON_MAIN_ALLOWED_ANDROIDX_IMPORTS)
+        (isAllUnder || COMMON_MAIN_ALLOWED_ANDROIDX_REFERENCES.none { symbol ->
+            this == symbol || startsWith("$symbol.")
+        })
 
 private fun String.matchesAny(prefixes: List<String>): Boolean =
     prefixes.any { prefix -> this == prefix.removeSuffix(".") || startsWith(prefix) }
 
 private fun String.matchesAnySymbol(symbols: Set<String>, isAllUnder: Boolean): Boolean =
-    this in symbols ||
-        isAllUnder && symbols.any { symbol -> symbol.substringBeforeLast('.') == this }
+    symbols.any { symbol ->
+        this == symbol || startsWith("$symbol.") ||
+            isAllUnder && symbol.substringBeforeLast('.') == this
+    }
 
+private fun String.isCoreForbiddenReference(isAllUnder: Boolean): Boolean =
+    matchesAny(CORE_FORBIDDEN_PREFIXES) ||
+        matchesAny(JVM_ONLY_IMPLEMENTATION_PREFIXES) ||
+        matchesAnySymbol(HOST_IMPLEMENTATION_SYMBOLS, isAllUnder) ||
+        matchesAnySymbol(JVM_ONLY_IMPLEMENTATION_SYMBOLS, isAllUnder)
+
+private fun String.isBackendForbiddenReference(isAllUnder: Boolean): Boolean =
+    matchesAny(BACKEND_FORBIDDEN_PREFIXES) || matchesAnySymbol(HOST_IMPLEMENTATION_SYMBOLS, isAllUnder)
+
+private fun KtQualifiedExpression.referencePath(): String? = referenceSegments()?.joinToString(".")
+
+private fun KtExpression.referenceSegments(): List<String>? = when (this) {
+    is KtNameReferenceExpression -> listOf(getReferencedName())
+    is KtQualifiedExpression -> {
+        val receiver = receiverExpression.referenceSegments() ?: return null
+        val selector = selectorExpression?.referenceSegments() ?: return null
+        receiver + selector
+    }
+    is KtCallExpression -> calleeExpression?.referenceSegments()
+    is KtParenthesizedExpression -> expression?.referenceSegments()
+    else -> null
+}
+
+private fun KtUserType.referencePath(): String? =
+    generateSequence(this) { type -> type.qualifier }
+        .toList()
+        .asReversed()
+        .mapNotNull { type -> type.referencedName }
+        .takeIf { segments -> segments.size > 1 }
+        ?.joinToString(".")
+
+private fun PsiElement.rootReference(): KtNameReferenceExpression? = when (this) {
+    is KtQualifiedExpression -> receiverExpression.rootReference()
+    is KtCallExpression -> calleeExpression?.rootReference()
+    is KtParenthesizedExpression -> expression?.rootReference()
+    is KtUserType ->
+        generateSequence(this) { type -> type.qualifier }.last().referenceExpression as? KtNameReferenceExpression
+    is KtNameReferenceExpression -> this
+    else -> null
+}
+
+@OptIn(KaExperimentalApi::class)
+private fun KtNameReferenceExpression.isQualifiedPackageReference(referencePath: String): Boolean {
+    val symbol = analyze(this) { resolveSymbol() }
+    if (symbol == null) return referencePath.substringBefore('.') in BOUNDARY_PACKAGE_ROOTS
+    if (symbol is KaPackageSymbol) return true
+    val resolvedPath = when (symbol) {
+        is KaCallableSymbol -> symbol.callableId?.asSingleFqName()?.asString()
+        is KaClassLikeSymbol -> symbol.classId?.asSingleFqName()?.asString()
+        else -> null
+    } ?: return false
+    return referencePath == resolvedPath || referencePath.startsWith("$resolvedPath.")
+}
+
+private fun KtQualifiedExpression.isNestedQualifiedReceiver(): Boolean {
+    var child: PsiElement = this
+    var ancestor = child.parent
+    while (
+        ancestor is KtCallExpression && ancestor.calleeExpression == child ||
+        ancestor is KtParenthesizedExpression && ancestor.expression == child
+    ) {
+        child = ancestor
+        ancestor = ancestor.parent
+    }
+    return ancestor is KtQualifiedExpression && ancestor.receiverExpression == child
+}
+
+private fun PsiElement.isInsideDirective(): Boolean {
+    var ancestor = parent
+    while (ancestor != null && ancestor !is KtFile) {
+        if (ancestor is KtImportDirective || ancestor is KtPackageDirective) return true
+        ancestor = ancestor.parent
+    }
+    return false
+}
+
+private const val SOURCE_ROOT_SEPARATOR = '|'
+private const val SOURCE_ROOT_PARTS = 5
 private val SOURCE_LAYOUT = Regex("(?:^|/)([^/]+)/src/([^/]+)/")
 
 private val CORE_MODULES = setOf("graph-engine", "llms", "agent", "skill-oauth-api")
+
+private val BOUNDARY_PACKAGE_ROOTS = setOf(
+    "android",
+    "androidx",
+    "com",
+    "java",
+    "javax",
+    "kotlinx",
+    "org",
+    "platform",
+    "ru",
+)
 
 private const val COMPOSE_WINDOW_PACKAGE = "androidx.compose.ui.window"
 
@@ -121,7 +351,7 @@ private val PORTABLE_WINDOW_TYPES = setOf(
 )
 
 // AndroidX packages mix common and platform declarations, so portable imports are reviewed by symbol.
-private val COMMON_MAIN_ALLOWED_ANDROIDX_IMPORTS = setOf(
+private val COMMON_MAIN_ALLOWED_ANDROIDX_REFERENCES = setOf(
     "androidx.compose.animation.animateColorAsState",
     "androidx.compose.animation.core.FastOutSlowInEasing",
     "androidx.compose.animation.core.animateFloatAsState",
@@ -247,11 +477,141 @@ private val HOST_IMPLEMENTATION_PREFIXES = listOf(
     "ru.souz.ui.macos.",
 ) + DESKTOP_ONLY_SERVICE_PREFIXES + DESKTOP_TOOL_PREFIXES
 
+private val JVM_ONLY_IMPLEMENTATION_PREFIXES = listOf(
+    "ru.souz.llms.tunnel.",
+    "ru.souz.runtime.di.",
+    "ru.souz.runtime.sandbox.docker.",
+    "ru.souz.runtime.sandbox.local.",
+    "ru.souz.service.mcp.",
+    "ru.souz.service.speech.",
+    "ru.souz.service.telegram.",
+    "ru.souz.tool.dataAnalytics.",
+    "ru.souz.ui.approval.",
+    "ru.souz.ui.graphlog.",
+)
+
 private val HOST_IMPLEMENTATION_SYMBOLS = setOf(
     "ru.souz.App",
     "ru.souz.LocalWindowScope",
+    "ru.souz.ambient.LocalChatAmbientLocalLlm",
+    "ru.souz.ambient.selectAmbientLocalModel",
+    "ru.souz.db.DesktopDataExtractor",
+    "ru.souz.db.DesktopInfoRepository",
+    "ru.souz.db.asString",
+    "ru.souz.di.mainDiModule",
     "ru.souz.di.sharedUiDesktopDiModule",
     "ru.souz.di.sharedUiDiModule",
+    "ru.souz.main",
+    "ru.souz.memory.ConfigStoreMemoryMaintenanceSettingsStore",
+    "ru.souz.memory.DesktopConversationMemoryRuntime",
+    "ru.souz.memory.DesktopMemoryContextProvider",
+    "ru.souz.memory.DesktopMemoryMaintenanceBackgroundRunner",
+    "ru.souz.memory.DesktopMemoryMaintenanceController",
+    "ru.souz.memory.DesktopMemoryOwnerProvider",
+    "ru.souz.memory.DesktopMemoryProjectContextProvider",
+    "ru.souz.memory.MemoryMaintenanceSettingsStore",
+    "ru.souz.memory.MemoryMaintenanceWorker",
+    "ru.souz.memory.NoopDesktopMemoryProjectContextProvider",
+    "ru.souz.memory.SqliteMemoryRepository",
+    "ru.souz.service.speech.MacOsSpeechBridge",
+    "ru.souz.service.speech.MacOsSpeechBridgeLoader",
+    "ru.souz.service.telegram.PreferencesTelegramBotConfigProvider",
+    "ru.souz.service.telegram.TelegramBotApi",
+    "ru.souz.service.telegram.TelegramBotConfigProvider",
+    "ru.souz.service.telegram.TelegramBotController",
+    "ru.souz.service.telegram.TelegramBotFile",
+    "ru.souz.service.telegram.TelegramBotFileResponse",
+    "ru.souz.service.telegram.TelegramChat",
+    "ru.souz.service.telegram.TelegramDocument",
+    "ru.souz.service.telegram.TelegramMessage",
+    "ru.souz.service.telegram.TelegramPlatformSupport",
+    "ru.souz.service.telegram.TelegramService",
+    "ru.souz.service.telegram.TelegramUpdate",
+    "ru.souz.service.telegram.TelegramUpdatesResponse",
+    "ru.souz.service.telegram.TelegramUser",
+    "ru.souz.service.telegram.TelegramVoice",
+    "ru.souz.tool.DesktopToolAvailabilityPolicy",
+    "ru.souz.tool.ShellException",
+    "ru.souz.tool.ToolRunBashCommand",
+    "ru.souz.tool.ToolsFactory",
+    "ru.souz.tool.files.ToolRequestSelection",
+    "ru.souz.tool.main",
+    "ru.souz.ui.DockWindowController",
+    "ru.souz.ui.rememberDockWindowController",
+    "ru.souz.ui.common.DesktopExternalLinkOpener",
+    "ru.souz.ui.common.DraggableWindowArea",
+    "ru.souz.ui.common.FinderService",
+    "ru.souz.ui.common.LocalModelUiCoordinator",
+    "ru.souz.ui.common.MAIN_WINDOW_MIN_HEIGHT_PX",
+    "ru.souz.ui.common.MAIN_WINDOW_MIN_WIDTH_PX",
+    "ru.souz.ui.common.applyMinWindowSize",
+    "ru.souz.ui.common.openProviderLink",
+    "ru.souz.ui.common.toUi",
+    "ru.souz.ui.host.DesktopChatCommandInputSource",
+    "ru.souz.ui.host.DesktopLocalModelUiHost",
+    "ru.souz.ui.host.DesktopPathOpener",
+    "ru.souz.ui.host.DesktopPrivacyPolicyOpener",
+    "ru.souz.ui.host.DesktopSettingsHostPreferences",
+    "ru.souz.ui.host.DesktopSupportLogService",
+    "ru.souz.ui.host.DesktopTelegramSettingsHost",
+    "ru.souz.ui.host.TelegramControlBot",
+    "ru.souz.ui.host.TelegramControlIncomingMessage",
+    "ru.souz.ui.host.TelegramUiService",
+    "ru.souz.ui.main.ChatModeContent",
+    "ru.souz.ui.main.MainScreen",
+    "ru.souz.ui.main.MainScreenContent",
+    "ru.souz.ui.main.PreviewChatMode",
+    "ru.souz.ui.main.PreviewChatModeEmpty",
+    "ru.souz.ui.main.PreviewSmartFocusGlass",
+    "ru.souz.ui.main.usecases.DesktopAttachmentMetadataProvider",
+    "ru.souz.ui.main.usecases.DesktopDroppedFilePathExtractor",
+    "ru.souz.ui.main.usecases.DesktopPathPicker",
+    "ru.souz.ui.main.usecases.VoiceInputUseCase",
+    "ru.souz.ui.memory.MemoryScreen",
+    "ru.souz.ui.settings.AgentDropdown",
+    "ru.souz.ui.settings.CalendarDropdown",
+    "ru.souz.ui.settings.EmbeddingsModelDropdown",
+    "ru.souz.ui.settings.FoldersManagementScreen",
+    "ru.souz.ui.settings.FunctionsSettingsContent",
+    "ru.souz.ui.settings.GeneralSettingsContent",
+    "ru.souz.ui.settings.KeysSettingsContent",
+    "ru.souz.ui.settings.LogsView",
+    "ru.souz.ui.settings.ModelDropdown",
+    "ru.souz.ui.settings.ModelsSettingsContent",
+    "ru.souz.ui.settings.SecuritySettingsContent",
+    "ru.souz.ui.settings.SettingsRow",
+    "ru.souz.ui.settings.SettingsScreen",
+    "ru.souz.ui.settings.SettingsScreenMain",
+    "ru.souz.ui.settings.SettingsScreenPreview",
+    "ru.souz.ui.settings.SupportLogSender",
+    "ru.souz.ui.settings.SupportSettingsContent",
+    "ru.souz.ui.settings.TelegramLoginContent",
+    "ru.souz.ui.settings.TelegramSettingsScreen",
+    "ru.souz.ui.settings.TokensBalanceSection",
+    "ru.souz.ui.settings.VoiceRecognitionModelDropdown",
+    "ru.souz.ui.setup.SetupScreen",
+    "ru.souz.ui.setup.SetupScreenContent",
+    "ru.souz.ui.tools.ToolDetailsScreen",
+    "ru.souz.ui.tools.ToolsScreen",
+)
+
+private val JVM_ONLY_IMPLEMENTATION_SYMBOLS = setOf(
+    "ru.souz.ambient.DefaultAmbientTranscriptionService",
+    "ru.souz.db.AesGcmSecretCodec",
+    "ru.souz.db.ConfigStore",
+    "ru.souz.db.SettingsProviderImpl",
+    "ru.souz.db.VectorDB",
+    "ru.souz.llms.openai.MissingOpenAiVoiceKeyException",
+    "ru.souz.llms.openai.OpenAIVoiceAPI",
+    "ru.souz.runtime.files.createDefaultFilesToolUtil",
+    "ru.souz.runtime.sandbox.DefaultRuntimeSandboxFactory",
+    "ru.souz.runtime.sandbox.RuntimeSandboxModeResolver",
+    "ru.souz.tool.RuntimeToolsFactory",
+    "ru.souz.tool.files.ToolExtractText",
+    "ru.souz.tool.files.ToolReadPdfPages",
+    "ru.souz.tool.runtimeToolsDiModule",
+    "ru.souz.tool.web.ToolWebImageSearch",
+    "ru.souz.tool.web.internal.WebImageDownloader",
 )
 
 private val SHARED_UI_HOST_PREFIXES = listOf(

--- a/build-logic/detekt-rules/src/main/kotlin/ru/souz/build/quality/detekt/SourceSetBoundaries.kt
+++ b/build-logic/detekt-rules/src/main/kotlin/ru/souz/build/quality/detekt/SourceSetBoundaries.kt
@@ -94,7 +94,8 @@ private fun String.isDesktopWindowImport(isAllUnder: Boolean): Boolean =
         DESKTOP_WINDOW_TYPES.any { type -> this == type || startsWith("$type.") }
 
 private fun String.isUnreviewedAndroidXImport(): Boolean =
-    startsWith("androidx.") && !matchesAny(COMMON_MAIN_ALLOWED_ANDROIDX_PREFIXES)
+    matchesAny(COMMON_MAIN_FORBIDDEN_ANDROIDX_PREFIXES) ||
+        startsWith("androidx.") && !matchesAny(COMMON_MAIN_ALLOWED_ANDROIDX_PREFIXES)
 
 private fun String.matchesAny(prefixes: List<String>): Boolean =
     prefixes.any { prefix -> this == prefix.removeSuffix(".") || startsWith(prefix) }
@@ -106,6 +107,8 @@ private val CORE_MODULES = setOf("graph-engine", "llms", "agent", "skill-oauth-a
 private const val COMPOSE_WINDOW_PACKAGE = "androidx.compose.ui.window"
 
 private val COMMON_MAIN_ALLOWED_ANDROIDX_PREFIXES = listOf("androidx.compose.")
+
+private val COMMON_MAIN_FORBIDDEN_ANDROIDX_PREFIXES = listOf("androidx.compose.desktop.")
 
 private val DESKTOP_WINDOW_TYPES = setOf(
     "$COMPOSE_WINDOW_PACKAGE.ApplicationScope",

--- a/build-logic/detekt-rules/src/main/kotlin/ru/souz/build/quality/detekt/SourceSetBoundaries.kt
+++ b/build-logic/detekt-rules/src/main/kotlin/ru/souz/build/quality/detekt/SourceSetBoundaries.kt
@@ -78,6 +78,7 @@ private fun sourceLocation(path: String): SourceLocation? {
 
 private fun String.isPortableHostImport(isAllUnder: Boolean): Boolean =
     matchesAny(PORTABLE_HOST_PREFIXES) ||
+        isUnreviewedAndroidXImport() ||
         isDesktopWindowImport(isAllUnder) ||
         matchesAny(HOST_IMPLEMENTATION_PREFIXES) ||
         this in HOST_IMPLEMENTATION_TYPES
@@ -92,6 +93,9 @@ private fun String.isDesktopWindowImport(isAllUnder: Boolean): Boolean =
     (isAllUnder && this == COMPOSE_WINDOW_PACKAGE) ||
         DESKTOP_WINDOW_TYPES.any { type -> this == type || startsWith("$type.") }
 
+private fun String.isUnreviewedAndroidXImport(): Boolean =
+    startsWith("androidx.") && !matchesAny(COMMON_MAIN_ALLOWED_ANDROIDX_PREFIXES)
+
 private fun String.matchesAny(prefixes: List<String>): Boolean =
     prefixes.any { prefix -> this == prefix.removeSuffix(".") || startsWith(prefix) }
 
@@ -100,6 +104,8 @@ private val SOURCE_LAYOUT = Regex("(?:^|/)([^/]+)/src/([^/]+)/")
 private val CORE_MODULES = setOf("graph-engine", "llms", "agent", "skill-oauth-api")
 
 private const val COMPOSE_WINDOW_PACKAGE = "androidx.compose.ui.window"
+
+private val COMMON_MAIN_ALLOWED_ANDROIDX_PREFIXES = listOf("androidx.compose.")
 
 private val DESKTOP_WINDOW_TYPES = setOf(
     "$COMPOSE_WINDOW_PACKAGE.ApplicationScope",

--- a/build-logic/detekt-rules/src/main/kotlin/ru/souz/build/quality/detekt/SourceSetBoundaries.kt
+++ b/build-logic/detekt-rules/src/main/kotlin/ru/souz/build/quality/detekt/SourceSetBoundaries.kt
@@ -136,13 +136,11 @@ private val PORTABLE_HOST_PREFIXES = listOf(
     "platform.",
 )
 
-private val DESKTOP_SERVICE_PREFIXES = listOf(
+private val DESKTOP_ONLY_SERVICE_PREFIXES = listOf(
     "ru.souz.service.audio.",
     "ru.souz.service.image.",
     "ru.souz.service.keys.",
     "ru.souz.service.permissions.",
-    "ru.souz.service.speech.",
-    "ru.souz.service.telegram.",
 )
 
 private val DESKTOP_TOOL_PREFIXES = listOf(
@@ -161,7 +159,7 @@ private val HOST_IMPLEMENTATION_PREFIXES = listOf(
     "ru.souz.backend.",
     "ru.souz.llms.local.",
     "ru.souz.ui.macos.",
-) + DESKTOP_SERVICE_PREFIXES + DESKTOP_TOOL_PREFIXES
+) + DESKTOP_ONLY_SERVICE_PREFIXES + DESKTOP_TOOL_PREFIXES
 
 private val HOST_IMPLEMENTATION_TYPES = setOf(
     "ru.souz.App",
@@ -199,4 +197,4 @@ private val BACKEND_FORBIDDEN_PREFIXES = listOf(
     "org.jetbrains.skiko.",
     "ru.souz.di.",
     "ru.souz.ui.",
-) + DESKTOP_SERVICE_PREFIXES + DESKTOP_TOOL_PREFIXES
+) + DESKTOP_ONLY_SERVICE_PREFIXES + DESKTOP_TOOL_PREFIXES

--- a/build-logic/detekt-rules/src/main/kotlin/ru/souz/build/quality/detekt/SourceSetBoundaries.kt
+++ b/build-logic/detekt-rules/src/main/kotlin/ru/souz/build/quality/detekt/SourceSetBoundaries.kt
@@ -78,7 +78,7 @@ private fun sourceLocation(path: String): SourceLocation? {
 
 private fun String.isPortableHostImport(isAllUnder: Boolean): Boolean =
     matchesAny(PORTABLE_HOST_PREFIXES) ||
-        isUnreviewedAndroidXImport() ||
+        isUnreviewedAndroidXImport(isAllUnder) ||
         isDesktopWindowImport(isAllUnder) ||
         matchesAny(HOST_IMPLEMENTATION_PREFIXES) ||
         matchesAnySymbol(HOST_IMPLEMENTATION_SYMBOLS, isAllUnder)
@@ -96,9 +96,9 @@ private fun String.isDesktopWindowImport(isAllUnder: Boolean): Boolean =
         else -> !PORTABLE_WINDOW_TYPES.any { type -> this == type || startsWith("$type.") }
     }
 
-private fun String.isUnreviewedAndroidXImport(): Boolean =
-    matchesAny(COMMON_MAIN_FORBIDDEN_ANDROIDX_PREFIXES) ||
-        startsWith("androidx.") && !matchesAny(COMMON_MAIN_ALLOWED_ANDROIDX_PREFIXES)
+private fun String.isUnreviewedAndroidXImport(isAllUnder: Boolean): Boolean =
+    (this == "androidx" || startsWith("androidx.")) &&
+        (isAllUnder || this !in COMMON_MAIN_ALLOWED_ANDROIDX_IMPORTS)
 
 private fun String.matchesAny(prefixes: List<String>): Boolean =
     prefixes.any { prefix -> this == prefix.removeSuffix(".") || startsWith(prefix) }
@@ -113,19 +113,102 @@ private val CORE_MODULES = setOf("graph-engine", "llms", "agent", "skill-oauth-a
 
 private const val COMPOSE_WINDOW_PACKAGE = "androidx.compose.ui.window"
 
-private val COMMON_MAIN_ALLOWED_ANDROIDX_PREFIXES = listOf(
-    "androidx.compose.",
-    "androidx.lifecycle.",
-)
-
-private val COMMON_MAIN_FORBIDDEN_ANDROIDX_PREFIXES = listOf("androidx.compose.desktop.")
-
 private val PORTABLE_WINDOW_TYPES = setOf(
     "$COMPOSE_WINDOW_PACKAGE.Dialog",
     "$COMPOSE_WINDOW_PACKAGE.DialogProperties",
     "$COMPOSE_WINDOW_PACKAGE.Popup",
     "$COMPOSE_WINDOW_PACKAGE.PopupProperties",
 )
+
+// AndroidX packages mix common and platform declarations, so portable imports are reviewed by symbol.
+private val COMMON_MAIN_ALLOWED_ANDROIDX_IMPORTS = setOf(
+    "androidx.compose.animation.animateColorAsState",
+    "androidx.compose.animation.core.FastOutSlowInEasing",
+    "androidx.compose.animation.core.animateFloatAsState",
+    "androidx.compose.animation.core.tween",
+    "androidx.compose.foundation.BorderStroke",
+    "androidx.compose.foundation.background",
+    "androidx.compose.foundation.border",
+    "androidx.compose.foundation.clickable",
+    "androidx.compose.foundation.interaction.MutableInteractionSource",
+    "androidx.compose.foundation.interaction.collectIsHoveredAsState",
+    "androidx.compose.foundation.interaction.collectIsPressedAsState",
+    "androidx.compose.foundation.layout.Arrangement",
+    "androidx.compose.foundation.layout.Box",
+    "androidx.compose.foundation.layout.BoxWithConstraints",
+    "androidx.compose.foundation.layout.Column",
+    "androidx.compose.foundation.layout.ColumnScope",
+    "androidx.compose.foundation.layout.PaddingValues",
+    "androidx.compose.foundation.layout.Row",
+    "androidx.compose.foundation.layout.Spacer",
+    "androidx.compose.foundation.layout.fillMaxSize",
+    "androidx.compose.foundation.layout.fillMaxWidth",
+    "androidx.compose.foundation.layout.height",
+    "androidx.compose.foundation.layout.heightIn",
+    "androidx.compose.foundation.layout.padding",
+    "androidx.compose.foundation.layout.size",
+    "androidx.compose.foundation.layout.width",
+    "androidx.compose.foundation.layout.widthIn",
+    "androidx.compose.foundation.rememberScrollState",
+    "androidx.compose.foundation.shape.CircleShape",
+    "androidx.compose.foundation.shape.RoundedCornerShape",
+    "androidx.compose.foundation.text.BasicTextField",
+    "androidx.compose.foundation.text.selection.DisableSelection",
+    "androidx.compose.foundation.verticalScroll",
+    "androidx.compose.material.icons.Icons",
+    "androidx.compose.material.icons.filled.ArrowDropDown",
+    "androidx.compose.material.icons.filled.Visibility",
+    "androidx.compose.material.icons.filled.VisibilityOff",
+    "androidx.compose.material.icons.outlined.Info",
+    "androidx.compose.material.icons.outlined.Warning",
+    "androidx.compose.material.icons.rounded.Check",
+    "androidx.compose.material.icons.rounded.ContentCopy",
+    "androidx.compose.material3.Button",
+    "androidx.compose.material3.ButtonDefaults",
+    "androidx.compose.material3.CircularProgressIndicator",
+    "androidx.compose.material3.DropdownMenu",
+    "androidx.compose.material3.DropdownMenuItem",
+    "androidx.compose.material3.HorizontalDivider",
+    "androidx.compose.material3.Icon",
+    "androidx.compose.material3.IconButton",
+    "androidx.compose.material3.MaterialTheme",
+    "androidx.compose.material3.OutlinedButton",
+    "androidx.compose.material3.Surface",
+    "androidx.compose.material3.Text",
+    "androidx.compose.material3.TextButton",
+    "androidx.compose.runtime.Composable",
+    "androidx.compose.runtime.Immutable",
+    "androidx.compose.runtime.LaunchedEffect",
+    "androidx.compose.runtime.getValue",
+    "androidx.compose.runtime.mutableStateOf",
+    "androidx.compose.runtime.remember",
+    "androidx.compose.runtime.setValue",
+    "androidx.compose.runtime.staticCompositionLocalOf",
+    "androidx.compose.ui.Alignment",
+    "androidx.compose.ui.Modifier",
+    "androidx.compose.ui.draw.clip",
+    "androidx.compose.ui.draw.scale",
+    "androidx.compose.ui.focus.onFocusChanged",
+    "androidx.compose.ui.graphics.Color",
+    "androidx.compose.ui.graphics.SolidColor",
+    "androidx.compose.ui.graphics.graphicsLayer",
+    "androidx.compose.ui.graphics.vector.ImageVector",
+    "androidx.compose.ui.platform.LocalClipboardManager",
+    "androidx.compose.ui.text.AnnotatedString",
+    "androidx.compose.ui.text.TextStyle",
+    "androidx.compose.ui.text.font.FontFamily",
+    "androidx.compose.ui.text.font.FontWeight",
+    "androidx.compose.ui.text.input.PasswordVisualTransformation",
+    "androidx.compose.ui.text.input.VisualTransformation",
+    "androidx.compose.ui.text.style.TextAlign",
+    "androidx.compose.ui.text.style.TextOverflow",
+    "androidx.compose.ui.unit.Dp",
+    "androidx.compose.ui.unit.dp",
+    "androidx.compose.ui.unit.sp",
+    "androidx.compose.ui.zIndex",
+    "androidx.lifecycle.ViewModel",
+    "androidx.lifecycle.viewModelScope",
+) + PORTABLE_WINDOW_TYPES
 
 private val PORTABLE_HOST_PREFIXES = listOf(
     "android.",

--- a/build-logic/detekt-rules/src/main/kotlin/ru/souz/build/quality/detekt/SouzArchitectureRuleSetProvider.kt
+++ b/build-logic/detekt-rules/src/main/kotlin/ru/souz/build/quality/detekt/SouzArchitectureRuleSetProvider.kt
@@ -1,0 +1,15 @@
+package ru.souz.build.quality.detekt
+
+import dev.detekt.api.RuleSet
+import dev.detekt.api.RuleSetId
+import dev.detekt.api.RuleSetProvider
+
+/** Registers Souz's source-architecture rules with Detekt. */
+class SouzArchitectureRuleSetProvider : RuleSetProvider {
+    override val ruleSetId = RuleSetId("souz-architecture")
+
+    override fun instance(): RuleSet = RuleSet(
+        ruleSetId,
+        listOf { config -> SourceSetBoundaries(config) },
+    )
+}

--- a/build-logic/detekt-rules/src/main/kotlin/ru/souz/build/quality/detekt/SouzDetektRulesClasspathMarker.kt
+++ b/build-logic/detekt-rules/src/main/kotlin/ru/souz/build/quality/detekt/SouzDetektRulesClasspathMarker.kt
@@ -1,0 +1,4 @@
+package ru.souz.build.quality.detekt
+
+/** Locates the custom-rule classes on the quality plugin's runtime classpath. */
+object SouzDetektRulesClasspathMarker

--- a/build-logic/detekt-rules/src/main/resources/META-INF/services/dev.detekt.api.RuleSetProvider
+++ b/build-logic/detekt-rules/src/main/resources/META-INF/services/dev.detekt.api.RuleSetProvider
@@ -1,1 +1,2 @@
 ru.souz.build.quality.detekt.SouzCoroutineRuleSetProvider
+ru.souz.build.quality.detekt.SouzArchitectureRuleSetProvider

--- a/build-logic/detekt-rules/src/test/kotlin/ru/souz/build/quality/detekt/SourceSetBoundariesTest.kt
+++ b/build-logic/detekt-rules/src/test/kotlin/ru/souz/build/quality/detekt/SourceSetBoundariesTest.kt
@@ -63,12 +63,14 @@ class SourceSetBoundariesTest {
             "sharedUI/src/commonMain/kotlin/PortableUi.kt",
             """
             import androidx.appcompat.app.AppCompatActivity
+            import androidx.compose.desktop.ui.tooling.preview.Preview
             import androidx.compose.material3.Text
             """,
         )
 
-        assertEquals(1, findings.size)
-        assertTrue(findings.single().message.contains("androidx.appcompat.app.AppCompatActivity"))
+        assertEquals(2, findings.size)
+        assertTrue(findings.any { it.message.contains("androidx.appcompat.app.AppCompatActivity") })
+        assertTrue(findings.any { it.message.contains("androidx.compose.desktop.ui.tooling.preview.Preview") })
     }
 
     @Test

--- a/build-logic/detekt-rules/src/test/kotlin/ru/souz/build/quality/detekt/SourceSetBoundariesTest.kt
+++ b/build-logic/detekt-rules/src/test/kotlin/ru/souz/build/quality/detekt/SourceSetBoundariesTest.kt
@@ -61,13 +61,14 @@ class SourceSetBoundariesTest {
     }
 
     @Test
-    fun `rejects Android-only AndroidX and allows reviewed Compose in portable common sources`() {
+    fun `rejects Android-only AndroidX and allows reviewed multiplatform APIs in portable common sources`() {
         val findings = lint(
             "sharedUI/src/commonMain/kotlin/PortableUi.kt",
             """
             import androidx.appcompat.app.AppCompatActivity
             import androidx.compose.desktop.ui.tooling.preview.Preview
             import androidx.compose.material3.Text
+            import androidx.lifecycle.ViewModel
             """,
         )
 

--- a/build-logic/detekt-rules/src/test/kotlin/ru/souz/build/quality/detekt/SourceSetBoundariesTest.kt
+++ b/build-logic/detekt-rules/src/test/kotlin/ru/souz/build/quality/detekt/SourceSetBoundariesTest.kt
@@ -67,20 +67,35 @@ class SourceSetBoundariesTest {
     }
 
     @Test
-    fun `rejects Android-only AndroidX and allows reviewed multiplatform APIs in portable common sources`() {
+    fun `rejects unreviewed AndroidX siblings and wildcards in portable common sources`() {
         val findings = lint(
             "sharedUI/src/commonMain/kotlin/PortableUi.kt",
             """
             import androidx.appcompat.app.AppCompatActivity
             import androidx.compose.desktop.ui.tooling.preview.Preview
+            import androidx.compose.foundation.AndroidExternalSurface
+            import androidx.compose.material3.*
             import androidx.compose.material3.Text
+            import androidx.compose.ui.platform.*
+            import androidx.compose.ui.platform.LocalClipboardManager
+            import androidx.compose.ui.platform.LocalContext
+            import androidx.compose.ui.window.Dialog
+            import androidx.lifecycle.*
+            import androidx.lifecycle.LifecycleService
             import androidx.lifecycle.ViewModel
+            import androidx.lifecycle.viewModelScope
             """,
         )
 
-        assertEquals(2, findings.size)
+        assertEquals(8, findings.size)
         assertTrue(findings.any { it.message.contains("androidx.appcompat.app.AppCompatActivity") })
         assertTrue(findings.any { it.message.contains("androidx.compose.desktop.ui.tooling.preview.Preview") })
+        assertTrue(findings.any { it.message.contains("androidx.compose.foundation.AndroidExternalSurface") })
+        assertTrue(findings.any { it.message.contains("androidx.compose.material3.*") })
+        assertTrue(findings.any { it.message.contains("androidx.compose.ui.platform.*") })
+        assertTrue(findings.any { it.message.contains("androidx.compose.ui.platform.LocalContext") })
+        assertTrue(findings.any { it.message.contains("androidx.lifecycle.*") })
+        assertTrue(findings.any { it.message.contains("androidx.lifecycle.LifecycleService") })
     }
 
     @Test

--- a/build-logic/detekt-rules/src/test/kotlin/ru/souz/build/quality/detekt/SourceSetBoundariesTest.kt
+++ b/build-logic/detekt-rules/src/test/kotlin/ru/souz/build/quality/detekt/SourceSetBoundariesTest.kt
@@ -1,0 +1,112 @@
+package ru.souz.build.quality.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.test.lint
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SourceSetBoundariesTest {
+    @Test
+    fun `reports desktop and native imports from shared UI common JVM sources`() {
+        val findings = lint(
+            "sharedUI/src/commonJvmMain/kotlin/SharedUi.kt",
+            """
+            import java.awt.Desktop
+            import javax.swing.JButton
+            import androidx.compose.foundation.window.WindowDraggableArea
+            import androidx.compose.ui.awt.ComposeWindow
+            import androidx.compose.ui.window.Window
+            import ru.souz.llms.local.LocalChatAPI
+            import ru.souz.tool.desktop.ToolGetCurrentWindow
+            """,
+        )
+
+        assertEquals(7, findings.size)
+        assertTrue(findings.all { it.message.contains(":sharedUI commonJvmMain") })
+    }
+
+    @Test
+    fun `allows portable Compose windows and ordinary JVM APIs in shared UI common JVM sources`() {
+        val findings = lint(
+            "sharedUI/src/commonJvmMain/kotlin/SharedUi.kt",
+            """
+            import androidx.compose.material3.Text
+            import androidx.compose.ui.window.Dialog
+            import androidx.compose.ui.window.Popup
+            import java.time.Clock
+            """,
+        )
+
+        assertEquals(0, findings.size)
+    }
+
+    @Test
+    fun `reports host imports from portable common sources`() {
+        val findings = lint(
+            "/repo/sharedUI/src/commonMain/kotlin/PortableUi.kt",
+            """
+            import java.time.Clock
+            import platform.AppKit.NSWindow
+            import ru.souz.service.speech.MacOsSpeechBridge
+            import androidx.compose.ui.window.*
+            """,
+        )
+
+        assertEquals(4, findings.size)
+        assertTrue(findings.all { it.message.contains("commonMain must remain portable") })
+    }
+
+    @Test
+    fun `reports UI and host implementation imports from core production modules`() {
+        val findings = lint(
+            "agent/src/main/kotlin/AgentRuntime.kt",
+            """
+            import androidx.compose.runtime.Composable
+            import ru.souz.backend.client.PublicClientService
+            import ru.souz.di.SharedUiDiModule
+            import ru.souz.service.speech.MacOsSpeechBridge
+            """,
+        )
+
+        assertEquals(4, findings.size)
+        assertTrue(findings.all { it.message.contains(":agent main") })
+    }
+
+    @Test
+    fun `reports UI and desktop tool imports from backend production sources`() {
+        val findings = lint(
+            "backend/src/main/kotlin/BackendRuntime.kt",
+            """
+            import ru.souz.ui.main.MainViewModel
+            import ru.souz.tool.calendar.ToolGetCalendarEvents
+            import ru.souz.llms.local.LocalChatAPI
+            import ru.souz.tool.skills.ToolInvokeSkill
+            """,
+        )
+
+        assertEquals(2, findings.size)
+        assertTrue(findings.all { it.message.contains(":backend main") })
+    }
+
+    @Test
+    fun `ignores test sources and unknown layouts`() {
+        val import = "import java.awt.Desktop"
+
+        assertEquals(0, lint("sharedUI/src/jvmTest/kotlin/SharedUiTest.kt", import).size)
+        assertEquals(0, lint("scratch/SharedUi.kt", import).size)
+    }
+
+    @Test
+    fun `normalizes Windows source paths`() {
+        val findings = lint(
+            "C:\\repo\\sharedUI\\src\\commonJvmMain\\kotlin\\SharedUi.kt",
+            "import java.awt.Desktop",
+        )
+
+        assertEquals(1, findings.size)
+    }
+
+    private fun lint(path: String, code: String) =
+        SourceSetBoundaries(Config.empty, path).lint(code.trimIndent())
+}

--- a/build-logic/detekt-rules/src/test/kotlin/ru/souz/build/quality/detekt/SourceSetBoundariesTest.kt
+++ b/build-logic/detekt-rules/src/test/kotlin/ru/souz/build/quality/detekt/SourceSetBoundariesTest.kt
@@ -17,12 +17,13 @@ class SourceSetBoundariesTest {
             import androidx.compose.foundation.window.WindowDraggableArea
             import androidx.compose.ui.awt.ComposeWindow
             import androidx.compose.ui.window.Window
+            import androidx.compose.ui.window.FutureDesktopWindowApi
             import ru.souz.llms.local.LocalChatAPI
             import ru.souz.tool.desktop.ToolGetCurrentWindow
             """,
         )
 
-        assertEquals(7, findings.size)
+        assertEquals(8, findings.size)
         assertTrue(findings.all { it.message.contains(":sharedUI commonJvmMain") })
     }
 
@@ -33,7 +34,9 @@ class SourceSetBoundariesTest {
             """
             import androidx.compose.material3.Text
             import androidx.compose.ui.window.Dialog
+            import androidx.compose.ui.window.DialogProperties
             import androidx.compose.ui.window.Popup
+            import androidx.compose.ui.window.PopupProperties
             import java.time.Clock
             """,
         )

--- a/build-logic/detekt-rules/src/test/kotlin/ru/souz/build/quality/detekt/SourceSetBoundariesTest.kt
+++ b/build-logic/detekt-rules/src/test/kotlin/ru/souz/build/quality/detekt/SourceSetBoundariesTest.kt
@@ -20,10 +20,16 @@ class SourceSetBoundariesTest {
             import androidx.compose.ui.window.FutureDesktopWindowApi
             import ru.souz.llms.local.LocalChatAPI
             import ru.souz.tool.desktop.ToolGetCurrentWindow
+            import ru.souz.App
+            import ru.souz.LocalWindowScope
+            import ru.souz.di.sharedUiDesktopDiModule
+            import ru.souz.di.sharedUiDiModule
+            import ru.souz.*
+            import ru.souz.di.*
             """,
         )
 
-        assertEquals(8, findings.size)
+        assertEquals(14, findings.size)
         assertTrue(findings.all { it.message.contains(":sharedUI commonJvmMain") })
     }
 
@@ -84,7 +90,7 @@ class SourceSetBoundariesTest {
             """
             import androidx.compose.runtime.Composable
             import ru.souz.backend.client.PublicClientService
-            import ru.souz.di.SharedUiDiModule
+            import ru.souz.di.sharedUiDesktopDiModule
             import ru.souz.service.speech.MacOsSpeechBridge
             """,
         )

--- a/build-logic/detekt-rules/src/test/kotlin/ru/souz/build/quality/detekt/SourceSetBoundariesTest.kt
+++ b/build-logic/detekt-rules/src/test/kotlin/ru/souz/build/quality/detekt/SourceSetBoundariesTest.kt
@@ -58,6 +58,20 @@ class SourceSetBoundariesTest {
     }
 
     @Test
+    fun `rejects Android-only AndroidX and allows reviewed Compose in portable common sources`() {
+        val findings = lint(
+            "sharedUI/src/commonMain/kotlin/PortableUi.kt",
+            """
+            import androidx.appcompat.app.AppCompatActivity
+            import androidx.compose.material3.Text
+            """,
+        )
+
+        assertEquals(1, findings.size)
+        assertTrue(findings.single().message.contains("androidx.appcompat.app.AppCompatActivity"))
+    }
+
+    @Test
     fun `reports UI and host implementation imports from core production modules`() {
         val findings = lint(
             "agent/src/main/kotlin/AgentRuntime.kt",

--- a/build-logic/detekt-rules/src/test/kotlin/ru/souz/build/quality/detekt/SourceSetBoundariesTest.kt
+++ b/build-logic/detekt-rules/src/test/kotlin/ru/souz/build/quality/detekt/SourceSetBoundariesTest.kt
@@ -1,12 +1,17 @@
 package ru.souz.build.quality.detekt
 
 import dev.detekt.api.Config
-import dev.detekt.test.lint
+import dev.detekt.test.junit.KotlinCoreEnvironmentTest
+import dev.detekt.test.lintWithContext
+import dev.detekt.test.utils.KotlinEnvironmentContainer
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
-class SourceSetBoundariesTest {
+@KotlinCoreEnvironmentTest
+class SourceSetBoundariesTest(
+    private val environment: KotlinEnvironmentContainer,
+) {
     @Test
     fun `reports desktop and native imports from shared UI common JVM sources`() {
         val findings = lint(
@@ -24,12 +29,20 @@ class SourceSetBoundariesTest {
             import ru.souz.LocalWindowScope
             import ru.souz.di.sharedUiDesktopDiModule
             import ru.souz.di.sharedUiDiModule
+            import ru.souz.di.mainDiModule
+            import ru.souz.tool.ToolRunBashCommand
+            import ru.souz.tool.files.ToolRequestSelection
+            import ru.souz.ui.common.DesktopExternalLinkOpener
+            import ru.souz.ui.host.DesktopPathOpener
+            import ru.souz.ui.main.usecases.DesktopPathPicker
+            import ru.souz.db.ConfigStore
+            import ru.souz.service.mcp.McpClientManager
             import ru.souz.*
             import ru.souz.di.*
             """,
         )
 
-        assertEquals(14, findings.size)
+        assertEquals(22, findings.size)
         assertTrue(findings.all { it.message.contains(":sharedUI commonJvmMain") })
     }
 
@@ -58,12 +71,111 @@ class SourceSetBoundariesTest {
             import java.time.Clock
             import platform.AppKit.NSWindow
             import ru.souz.service.audio.AudioRecorder
+            import ru.souz.tool.ToolRunBashCommand
+            import ru.souz.ambient.DefaultAmbientTranscriptionService
+            import ru.souz.db.ConfigStore
+            import ru.souz.runtime.files.createDefaultFilesToolUtil
+            import ru.souz.service.mcp.McpClientManager
             import androidx.compose.ui.window.*
             """,
         )
 
-        assertEquals(4, findings.size)
+        assertEquals(9, findings.size)
         assertTrue(findings.all { it.message.contains("commonMain must remain portable") })
+    }
+
+    @Test
+    fun `reports fully qualified host references from shared sources`() {
+        val sharedUiFindings = lint(
+            "sharedUI/src/commonJvmMain/kotlin/SharedUi.kt",
+            """
+            val desktop = java.awt.Desktop.getDesktop()
+            val window: androidx.compose.ui.awt.ComposeWindow? = null
+            val clock = java.time.Clock.systemUTC()
+            val opener: ru.souz.ui.host.DesktopPathOpener? = null
+            """,
+        )
+        val commonFindings = lint(
+            "sharedUI/src/commonMain/kotlin/PortableUi.kt",
+            """
+            val clock = java.time.Clock.systemUTC()
+            val context = androidx.compose.ui.platform.LocalContext.current
+            val viewModel: androidx.lifecycle.ViewModel? = null
+            val ambient: ru.souz.ambient.DefaultAmbientTranscriptionService? = null
+
+            @androidx.compose.runtime.Composable
+            fun Content() {
+                androidx.compose.material3.Text("Portable")
+            }
+            """,
+        )
+
+        assertEquals(3, sharedUiFindings.size, sharedUiFindings.joinToString { it.message })
+        assertTrue(sharedUiFindings.any { it.message.contains("java.awt.Desktop.getDesktop") })
+        assertTrue(sharedUiFindings.any { it.message.contains("androidx.compose.ui.awt.ComposeWindow") })
+        assertEquals(3, commonFindings.size, commonFindings.joinToString { it.message })
+        assertTrue(commonFindings.any { it.message.contains("java.time.Clock.systemUTC") })
+        assertTrue(commonFindings.any { it.message.contains("androidx.compose.ui.platform.LocalContext.current") })
+    }
+
+    @Test
+    fun `reports fully qualified host references from core and backend sources`() {
+        val coreFindings = lint(
+            "agent/src/main/kotlin/AgentRuntime.kt",
+            "val service: ru.souz.backend.client.PublicClientService? = null",
+        )
+        val backendFindings = lint(
+            "backend/src/main/kotlin/BackendRuntime.kt",
+            "val viewModel: ru.souz.ui.main.MainViewModel? = null",
+        )
+
+        assertEquals(1, coreFindings.size)
+        assertEquals(1, backendFindings.size)
+    }
+
+    @Test
+    fun `reports package declarations that expose forbidden APIs without imports`() {
+        val javaFindings = lint(
+            "sharedUI/src/commonJvmMain/kotlin/DesktopPackage.kt",
+            """
+            package java.awt
+
+            val desktop = Desktop.getDesktop()
+            """,
+        )
+        val composeFindings = lint(
+            "sharedUI/src/commonJvmMain/kotlin/WindowPackage.kt",
+            """
+            package androidx.compose.ui.window
+
+            val window: Window? = null
+            """,
+        )
+
+        assertEquals(1, javaFindings.size)
+        assertTrue(javaFindings.single().message.contains("Package 'java.awt'"))
+        assertEquals(1, composeFindings.size)
+        assertTrue(composeFindings.single().message.contains("Package 'androidx.compose.ui.window'"))
+    }
+
+    @Test
+    fun `ignores qualified member chains rooted in local values`() {
+        val findings = lint(
+            "sharedUI/src/commonJvmMain/kotlin/SharedUi.kt",
+            """
+            class DesktopApi {
+                fun getDesktop() = Unit
+            }
+            class AwtNamespace(val Desktop: DesktopApi)
+            class JavaNamespace(val awt: AwtNamespace)
+
+            fun use(java: JavaNamespace) {
+                java.awt.Desktop.getDesktop()
+            }
+            """,
+        )
+
+        assertEquals(0, findings.size)
     }
 
     @Test
@@ -107,10 +219,12 @@ class SourceSetBoundariesTest {
             import ru.souz.backend.client.PublicClientService
             import ru.souz.di.sharedUiDesktopDiModule
             import ru.souz.service.speech.MacOsSpeechBridge
+            import ru.souz.tool.ToolRunBashCommand
+            import ru.souz.tool.files.ToolRequestSelection
             """,
         )
 
-        assertEquals(4, findings.size)
+        assertEquals(6, findings.size)
         assertTrue(findings.all { it.message.contains(":agent main") })
     }
 
@@ -124,10 +238,13 @@ class SourceSetBoundariesTest {
             import ru.souz.tool.telegram.ToolTelegramSend
             import ru.souz.llms.local.LocalChatAPI
             import ru.souz.tool.skills.ToolInvokeSkill
+            import ru.souz.di.mainDiModule
+            import ru.souz.tool.ToolRunBashCommand
+            import ru.souz.tool.files.ToolRequestSelection
             """,
         )
 
-        assertEquals(3, findings.size)
+        assertEquals(6, findings.size)
         assertTrue(findings.all { it.message.contains(":backend main") })
     }
 
@@ -138,6 +255,9 @@ class SourceSetBoundariesTest {
             """
             import ru.souz.service.speech.SpeechRecognitionProvider
             import ru.souz.service.telegram.TelegramAuthStep
+            import ru.souz.db.ConfigStore
+            import ru.souz.runtime.files.createDefaultFilesToolUtil
+            import ru.souz.service.mcp.McpClientManager
             """,
         )
 
@@ -162,6 +282,19 @@ class SourceSetBoundariesTest {
         assertEquals(1, findings.size)
     }
 
-    private fun lint(path: String, code: String) =
-        SourceSetBoundaries(Config.empty, path).lint(code.trimIndent())
+    @Test
+    fun `configured source roots fail closed for overlap and unmapped conventional paths`() {
+        val roots = listOf(
+            "/repo/sharedUI/portable|sharedUI|commonJvmMain|true|false",
+            "/repo/sharedUI/portable/tests|sharedUI|jvmTest|false|false",
+        )
+        val import = "import java.awt.Desktop"
+
+        assertEquals(1, lint("/repo/sharedUI/portable/SharedUi.kt", import, roots).size)
+        assertEquals(1, lint("/repo/sharedUI/portable/tests/SharedUiTest.kt", import, roots).size)
+        assertEquals(1, lint("/repo/sharedUI/src/commonJvmMain/Unmapped.kt", import, roots).size)
+    }
+
+    private fun lint(path: String, code: String, sourceRoots: List<String> = emptyList()) =
+        SourceSetBoundaries(Config.empty, path, sourceRoots).lintWithContext(environment, code.trimIndent())
 }

--- a/build-logic/detekt-rules/src/test/kotlin/ru/souz/build/quality/detekt/SourceSetBoundariesTest.kt
+++ b/build-logic/detekt-rules/src/test/kotlin/ru/souz/build/quality/detekt/SourceSetBoundariesTest.kt
@@ -48,7 +48,7 @@ class SourceSetBoundariesTest {
             """
             import java.time.Clock
             import platform.AppKit.NSWindow
-            import ru.souz.service.speech.MacOsSpeechBridge
+            import ru.souz.service.audio.AudioRecorder
             import androidx.compose.ui.window.*
             """,
         )
@@ -74,19 +74,33 @@ class SourceSetBoundariesTest {
     }
 
     @Test
-    fun `reports UI and desktop tool imports from backend production sources`() {
+    fun `reports UI and desktop-only imports from backend production sources`() {
         val findings = lint(
             "backend/src/main/kotlin/BackendRuntime.kt",
             """
             import ru.souz.ui.main.MainViewModel
-            import ru.souz.tool.calendar.ToolGetCalendarEvents
+            import ru.souz.service.audio.AudioRecorder
+            import ru.souz.tool.telegram.ToolTelegramSend
             import ru.souz.llms.local.LocalChatAPI
             import ru.souz.tool.skills.ToolInvokeSkill
             """,
         )
 
-        assertEquals(2, findings.size)
+        assertEquals(3, findings.size)
         assertTrue(findings.all { it.message.contains(":backend main") })
+    }
+
+    @Test
+    fun `allows shared speech and telegram contracts in backend production sources`() {
+        val findings = lint(
+            "backend/src/main/kotlin/BackendRuntime.kt",
+            """
+            import ru.souz.service.speech.SpeechRecognitionProvider
+            import ru.souz.service.telegram.TelegramAuthStep
+            """,
+        )
+
+        assertEquals(0, findings.size)
     }
 
     @Test

--- a/build-logic/src/main/kotlin/ru/souz/build/quality/DetektReports.kt
+++ b/build-logic/src/main/kotlin/ru/souz/build/quality/DetektReports.kt
@@ -68,5 +68,6 @@ internal fun parseSecureXml(file: File): Document {
 
 // link to classes
 internal val CANCELLATION_RULES = setOf("SuspendFunSwallowedCancellation")
+internal val SOURCE_SET_BOUNDARY_RULES = setOf("SourceSetBoundaries")
 internal val THREAD_LOCAL_RULES = setOf("ThreadLocalInCoroutineCode")
 internal val MONITOR_RULES = setOf("MonitorInsideSuspendContext")

--- a/build-logic/src/main/kotlin/ru/souz/build/quality/QualityModel.kt
+++ b/build-logic/src/main/kotlin/ru/souz/build/quality/QualityModel.kt
@@ -72,7 +72,7 @@ internal object SouzQualityChecks {
     val sourceSetBoundaries = QualityCheckDefinition(
         id = "source-set-boundaries",
         implementationVersion = 1,
-        description = "Production imports stay within portable, core, backend, and shared UI host boundaries.",
+        description = "Production package declarations and references stay within source-set and host boundaries.",
         policy = "AGENTS.md",
     )
 

--- a/build-logic/src/main/kotlin/ru/souz/build/quality/QualityModel.kt
+++ b/build-logic/src/main/kotlin/ru/souz/build/quality/QualityModel.kt
@@ -69,6 +69,13 @@ internal object SouzQualityChecks {
         policy = "AGENTS.md",
     )
 
+    val sourceSetBoundaries = QualityCheckDefinition(
+        id = "source-set-boundaries",
+        implementationVersion = 1,
+        description = "Production imports stay within portable, core, backend, and shared UI host boundaries.",
+        policy = "AGENTS.md",
+    )
+
     val cancellationPropagation = QualityCheckDefinition(
         id = "cancellation-propagation",
         implementationVersion = 2,
@@ -97,6 +104,7 @@ internal object SouzQualityChecks {
         gitMetadata,
         repositoryContracts,
         moduleBoundaries,
+        sourceSetBoundaries,
         cancellationPropagation,
         coroutineThreadLocal,
         coroutineMonitorUse,

--- a/build-logic/src/main/kotlin/ru/souz/build/quality/SourceSetBoundaryConfigTask.kt
+++ b/build-logic/src/main/kotlin/ru/souz/build/quality/SourceSetBoundaryConfigTask.kt
@@ -1,0 +1,87 @@
+package ru.souz.build.quality
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+@CacheableTask
+abstract class SourceSetBoundaryConfigTask : DefaultTask() {
+    @get:Input
+    abstract val sourceRoots: ListProperty<String>
+
+    @get:OutputFile
+    abstract val outputFile: RegularFileProperty
+
+    @TaskAction
+    fun writeConfig() {
+        val mappings = sourceRoots.get().distinct().sorted()
+        val entries = mappings.map(::parseSourceRoot)
+        val conflictingRoots = entries.flatMapIndexed { index, left ->
+            entries.drop(index + 1).mapNotNull { right ->
+                (left to right).takeIf {
+                    left.owner != right.owner && (left.contains(right) || right.contains(left))
+                }
+            }
+        }
+        check(conflictingRoots.isEmpty()) {
+            conflictingRoots.joinToString(
+                prefix = "Overlapping source roots belong to different Kotlin source sets: ",
+                separator = "; ",
+            ) { (left, right) ->
+                "${left.root} (${left.renderedOwner}) and ${right.root} (${right.renderedOwner})"
+            }
+        }
+
+        val output = outputFile.get().asFile
+        output.parentFile.mkdirs()
+        output.writeText(
+            buildString {
+                appendLine("souz-architecture:")
+                appendLine("  SourceSetBoundaries:")
+                if (mappings.isEmpty()) {
+                    appendLine("    sourceRoots: []")
+                } else {
+                    appendLine("    sourceRoots:")
+                    mappings.forEach { mapping ->
+                        append("      - '")
+                        append(mapping.replace("'", "''"))
+                        appendLine("'")
+                    }
+                }
+            }
+        )
+    }
+}
+
+private data class SourceRoot(
+    val root: String,
+    val module: String,
+    val sourceSet: String,
+    val production: Boolean,
+    val hostMain: Boolean,
+) {
+    val owner: Pair<String, String> = module to sourceSet
+    val renderedOwner: String = "$module:$sourceSet"
+
+    fun contains(other: SourceRoot): Boolean =
+        other.root == root || other.root.startsWith("${root.trimEnd('/')}/")
+}
+
+private fun parseSourceRoot(encoded: String): SourceRoot {
+    val parts = encoded.split('|')
+    require(parts.size == 5 && parts.none(String::isEmpty)) {
+        "Invalid source-root mapping '$encoded'. " +
+            "Expected absoluteRoot|moduleName|sourceSetName|production|hostMain."
+    }
+    return SourceRoot(
+        root = parts[0],
+        module = parts[1],
+        sourceSet = parts[2],
+        production = parts[3].toBooleanStrict(),
+        hostMain = parts[4].toBooleanStrict(),
+    )
+}

--- a/build-logic/src/main/kotlin/ru/souz/build/quality/SouzGateFastTask.kt
+++ b/build-logic/src/main/kotlin/ru/souz/build/quality/SouzGateFastTask.kt
@@ -87,6 +87,9 @@ abstract class SouzGateFastTask : DefaultTask() {
                     edges = edges,
                 )
             },
+            runCheck(SouzQualityChecks.sourceSetBoundaries) {
+                detektDiagnostics { it in SOURCE_SET_BOUNDARY_RULES }
+            },
             runCheck(SouzQualityChecks.cancellationPropagation) {
                 detektDiagnostics { it in CANCELLATION_RULES }
             },

--- a/build-logic/src/main/kotlin/ru/souz/build/quality/SouzQualityPlugin.kt
+++ b/build-logic/src/main/kotlin/ru/souz/build/quality/SouzQualityPlugin.kt
@@ -6,6 +6,8 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.file.ConfigurableFileCollection
+import ru.souz.build.quality.detekt.SouzDetektRulesClasspathMarker
+import java.io.File
 
 class SouzQualityPlugin : Plugin<Project> {
     override fun apply(project: Project) {
@@ -58,7 +60,7 @@ class SouzQualityPlugin : Plugin<Project> {
         }
         val gate = project.tasks.register("souzGateFast") {
             group = "verification"
-            description = "Runs exact, local-safe Souz repository, module, and coroutine checks."
+            description = "Runs exact, local-safe Souz repository, module, source-set, and coroutine checks."
             finalizedBy(report)
         }
 
@@ -72,18 +74,15 @@ class SouzQualityPlugin : Plugin<Project> {
         reportFiles: ConfigurableFileCollection,
     ) {
         val configFile = project.layout.projectDirectory.file("quality/detekt.yml")
-        val rulesJar = project.layout.projectDirectory.file(
-            "build-logic/detekt-rules/build/libs/souz-detekt-rules.jar"
-        )
+        val rulesClasspath = detektRulesClasspath(project)
 
         project.subprojects.forEach { subproject ->
             var configured = false
             val configure = {
                 if (!configured) {
                     configured = true
-                    val rulesJarTask = project.gradle.includedBuild("build-logic").task(":detekt-rules:jar")
                     subproject.pluginManager.apply("dev.detekt")
-                    subproject.dependencies.add("detektPlugins", subproject.files(rulesJar))
+                    subproject.dependencies.add("detektPlugins", subproject.files(rulesClasspath))
                     subproject.extensions.configure(DetektExtension::class.java) {
                         toolVersion.set("2.0.0-alpha.6")
                         config.setFrom(configFile)
@@ -98,7 +97,6 @@ class SouzQualityPlugin : Plugin<Project> {
                     val analysisTasks = subproject.tasks.withType(Detekt::class.java)
                         .matching { task -> task.name != "detekt" && !task.name.endsWith("SourceSet") }
                     analysisTasks.configureEach {
-                        dependsOn(rulesJarTask)
                         exclude("**/generated/resources/**")
                         reports.checkstyle.required.set(true)
                         reports.html.required.set(false)
@@ -118,6 +116,11 @@ class SouzQualityPlugin : Plugin<Project> {
             subproject.pluginManager.withPlugin("org.jetbrains.kotlin.jvm") { configure() }
             subproject.pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform") { configure() }
         }
+    }
+
+    private fun detektRulesClasspath(project: Project): ConfigurableFileCollection {
+        val markerClass = SouzDetektRulesClasspathMarker::class.java
+        return project.files(File(markerClass.protectionDomain.codeSource.location.toURI()))
     }
 
     private fun dependencyEdges(sourceProject: Project, repository: java.io.File): List<DependencyEdge> {

--- a/build-logic/src/main/kotlin/ru/souz/build/quality/SouzQualityPlugin.kt
+++ b/build-logic/src/main/kotlin/ru/souz/build/quality/SouzQualityPlugin.kt
@@ -6,6 +6,12 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.tasks.TaskProvider
+import org.jetbrains.kotlin.gradle.dsl.KotlinBaseExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmExtension
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
+import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
+import org.jetbrains.kotlin.gradle.plugin.KotlinTargetsContainer
 import ru.souz.build.quality.detekt.SouzDetektRulesClasspathMarker
 import java.io.File
 
@@ -22,7 +28,18 @@ class SouzQualityPlugin : Plugin<Project> {
             )
         }.sortedBy(ProjectDescriptor::path)
         val edgeInputs = project.objects.listProperty(String::class.java).convention(emptyList())
+        val sourceRootInputs = project.objects.listProperty(String::class.java).convention(emptyList())
         val detektReportFiles = project.objects.fileCollection()
+
+        val sourceSetBoundaryConfig = project.tasks.register(
+            "generateSourceSetBoundaryConfig",
+            SourceSetBoundaryConfigTask::class.java,
+        ) {
+            sourceRoots.set(sourceRootInputs)
+            outputFile.set(
+                project.layout.buildDirectory.file("generated/souz-quality/detekt/source-set-boundaries.yml")
+            )
+        }
 
         project.gradle.projectsEvaluated {
             edgeInputs.set(
@@ -32,6 +49,16 @@ class SouzQualityPlugin : Plugin<Project> {
                     .sorted()
             )
             edgeInputs.finalizeValue()
+            sourceRootInputs.set(
+                project.subprojects
+                    .filter { subproject ->
+                        subproject.pluginManager.hasPlugin("org.jetbrains.kotlin.jvm") ||
+                            subproject.pluginManager.hasPlugin("org.jetbrains.kotlin.multiplatform")
+                    }
+                    .flatMap(::sourceRootMappings)
+                    .sorted()
+            )
+            sourceRootInputs.finalizeValue()
         }
 
         val policyFiles = project.fileTree(repository) {
@@ -64,7 +91,7 @@ class SouzQualityPlugin : Plugin<Project> {
             finalizedBy(report)
         }
 
-        configureDetekt(project, gate, report, detektReportFiles)
+        configureDetekt(project, gate, report, detektReportFiles, sourceSetBoundaryConfig)
     }
 
     private fun configureDetekt(
@@ -72,6 +99,7 @@ class SouzQualityPlugin : Plugin<Project> {
         gate: org.gradle.api.tasks.TaskProvider<org.gradle.api.Task>,
         report: org.gradle.api.tasks.TaskProvider<SouzGateFastTask>,
         reportFiles: ConfigurableFileCollection,
+        sourceSetBoundaryConfig: TaskProvider<SourceSetBoundaryConfigTask>,
     ) {
         val configFile = project.layout.projectDirectory.file("quality/detekt.yml")
         val rulesClasspath = detektRulesClasspath(project)
@@ -97,6 +125,7 @@ class SouzQualityPlugin : Plugin<Project> {
                     val analysisTasks = subproject.tasks.withType(Detekt::class.java)
                         .matching { task -> task.name != "detekt" && !task.name.endsWith("SourceSet") }
                     analysisTasks.configureEach {
+                        config.from(sourceSetBoundaryConfig.flatMap { task -> task.outputFile })
                         exclude("**/generated/resources/**")
                         reports.checkstyle.required.set(true)
                         reports.html.required.set(false)
@@ -121,6 +150,32 @@ class SouzQualityPlugin : Plugin<Project> {
     private fun detektRulesClasspath(project: Project): ConfigurableFileCollection {
         val markerClass = SouzDetektRulesClasspathMarker::class.java
         return project.files(File(markerClass.protectionDomain.codeSource.location.toURI()))
+    }
+
+    private fun sourceRootMappings(sourceProject: Project): List<String> {
+        val kotlin = sourceProject.extensions.findByType(KotlinBaseExtension::class.java) ?: return emptyList()
+        val targets: Collection<KotlinTarget> = when (kotlin) {
+            is KotlinJvmExtension -> listOf(kotlin.target)
+            is KotlinTargetsContainer -> kotlin.targets.toList()
+            else -> emptyList()
+        }
+        val mainCompilations = targets.mapNotNull { target ->
+            target.compilations.findByName(KotlinCompilation.MAIN_COMPILATION_NAME)
+        }
+        val productionSourceSets = mainCompilations
+            .flatMap { compilation -> compilation.allKotlinSourceSets }
+            .mapTo(mutableSetOf()) { sourceSet -> sourceSet.name }
+        val hostMainSourceSets = mainCompilations
+            .mapTo(mutableSetOf()) { compilation -> compilation.defaultSourceSet.name }
+        return kotlin.sourceSets.flatMap { sourceSet ->
+            sourceSet.kotlin.sourceDirectories.files.map { root ->
+                val normalizedRoot = root.toPath().toAbsolutePath().normalize().toString()
+                    .replace(File.separatorChar, '/')
+                require('|' !in normalizedRoot) { "Kotlin source root cannot contain '|': $normalizedRoot" }
+                "$normalizedRoot|${sourceProject.name}|${sourceSet.name}|" +
+                    "${sourceSet.name in productionSourceSets}|${sourceSet.name in hostMainSourceSets}"
+            }
+        }
     }
 
     private fun dependencyEdges(sourceProject: Project, repository: java.io.File): List<DependencyEdge> {

--- a/build-logic/src/test/kotlin/ru/souz/build/quality/FixtureProject.kt
+++ b/build-logic/src/test/kotlin/ru/souz/build/quality/FixtureProject.kt
@@ -2,11 +2,14 @@ package ru.souz.build.quality
 
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
+import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.Properties
 
 internal class FixtureProject(private val root: Path) {
     private val modules = listOf(":graph-engine", ":llms", ":agent", ":sharedUI")
+    private var needsKotlinPluginClasspath = false
 
     fun create() {
         write(
@@ -61,6 +64,65 @@ internal class FixtureProject(private val root: Path) {
         )
     }
 
+    fun addSharedUiKmpBoundaryViolation() {
+        needsKotlinPluginClasspath = true
+        write(
+            "build.gradle.kts",
+            """
+            plugins {
+                id("souz.quality")
+                id("org.jetbrains.kotlin.multiplatform") apply false
+            }
+            """.trimIndent() + "\n",
+        )
+        write(
+            "sharedUI/build.gradle.kts",
+            """
+            plugins { id("org.jetbrains.kotlin.multiplatform") }
+
+            repositories { mavenCentral() }
+
+            kotlin {
+                jvm()
+                sourceSets {
+                    val commonMain by getting
+                    val commonJvmMain by creating {
+                        dependsOn(commonMain)
+                    }
+                    val jvmMain by getting {
+                        dependsOn(commonJvmMain)
+                    }
+                }
+            }
+            """.trimIndent() + "\n",
+        )
+        write(
+            "quality/detekt.yml",
+            """
+            config:
+              validation: false
+
+            souz-coroutines:
+              active: false
+
+            souz-architecture:
+              active: true
+              SourceSetBoundaries:
+                active: true
+            """.trimIndent() + "\n",
+        )
+        write(
+            "sharedUI/src/commonJvmMain/kotlin/fixture/SharedUiState.kt",
+            """
+            package fixture
+
+            import java.awt.Desktop
+
+            class SharedUiState
+            """.trimIndent() + "\n",
+        )
+    }
+
     fun append(path: String, content: String) {
         Files.writeString(root.resolve(path), content, java.nio.file.StandardOpenOption.APPEND)
     }
@@ -108,10 +170,35 @@ internal class FixtureProject(private val root: Path) {
 
     fun reportPath(): Path = root.resolve("build/reports/souz-quality/fast/gate-summary-v1.json")
 
-    private fun runner(arguments: List<String>): GradleRunner = GradleRunner.create()
-        .withProjectDir(root.toFile())
-        .withPluginClasspath()
-        .withArguments(arguments + listOf("--console=plain", "--stacktrace"))
+    private fun runner(arguments: List<String>): GradleRunner {
+        val runner = GradleRunner.create()
+            .withProjectDir(root.toFile())
+            .withArguments(arguments + listOf("--console=plain", "--stacktrace"))
+        return if (needsKotlinPluginClasspath) {
+            runner.withPluginClasspath(pluginUnderTestClasspath() + kotlinPluginClasspath())
+        } else {
+            runner.withPluginClasspath()
+        }
+    }
+
+    private fun pluginUnderTestClasspath(): List<File> {
+        val properties = Properties().apply {
+            val metadata = checkNotNull(
+                FixtureProject::class.java.classLoader.getResourceAsStream(PLUGIN_METADATA)
+            ) {
+                "Missing $PLUGIN_METADATA on the test runtime classpath."
+            }
+            metadata.use { load(it) }
+        }
+        return properties.getProperty("implementation-classpath")
+            .split(File.pathSeparator)
+            .map(::File)
+    }
+
+    private fun kotlinPluginClasspath(): List<File> =
+        checkNotNull(System.getProperty("souz.test.kotlin-plugin-classpath")) {
+            "Missing Kotlin plugin classpath for the KMP functional fixture."
+        }.split(File.pathSeparator).map(::File)
 
     private fun git(vararg arguments: String) {
         val process = ProcessBuilder(listOf("git", "-C", root.toString()) + arguments)
@@ -121,3 +208,5 @@ internal class FixtureProject(private val root: Path) {
         check(process.waitFor() == 0) { "git ${arguments.joinToString(" ")} failed: $output" }
     }
 }
+
+private const val PLUGIN_METADATA = "plugin-under-test-metadata.properties"

--- a/build-logic/src/test/kotlin/ru/souz/build/quality/FixtureProject.kt
+++ b/build-logic/src/test/kotlin/ru/souz/build/quality/FixtureProject.kt
@@ -64,7 +64,10 @@ internal class FixtureProject(private val root: Path) {
         )
     }
 
-    fun addSharedUiKmpBoundaryViolation() {
+    fun addSharedUiKmpBoundaryViolation(
+        sourceDirectory: String = "src/commonJvmMain/kotlin",
+        sourceSetName: String = "commonJvmMain",
+    ) {
         needsKotlinPluginClasspath = true
         write(
             "build.gradle.kts",
@@ -86,11 +89,12 @@ internal class FixtureProject(private val root: Path) {
                 jvm()
                 sourceSets {
                     val commonMain by getting
-                    val commonJvmMain by creating {
+                    val boundarySource = maybeCreate("$sourceSetName").apply {
                         dependsOn(commonMain)
+                        kotlin.srcDir("$sourceDirectory")
                     }
                     val jvmMain by getting {
-                        dependsOn(commonJvmMain)
+                        dependsOn(boundarySource)
                     }
                 }
             }
@@ -112,7 +116,7 @@ internal class FixtureProject(private val root: Path) {
             """.trimIndent() + "\n",
         )
         write(
-            "sharedUI/src/commonJvmMain/kotlin/fixture/SharedUiState.kt",
+            "sharedUI/$sourceDirectory/fixture/SharedUiState.kt",
             """
             package fixture
 

--- a/build-logic/src/test/kotlin/ru/souz/build/quality/SouzQualityPluginFunctionalTest.kt
+++ b/build-logic/src/test/kotlin/ru/souz/build/quality/SouzQualityPluginFunctionalTest.kt
@@ -192,6 +192,30 @@ class SouzQualityPluginFunctionalTest {
     }
 
     @Test
+    fun `KMP common JVM source is analyzed once with path and line diagnostics`(@TempDir root: Path) {
+        val fixture = FixtureProject(root).apply {
+            create()
+            addSharedUiKmpBoundaryViolation()
+            commit()
+        }
+
+        val result = fixture.buildAndFail("souzGateFast")
+        assertTrue(Files.isRegularFile(fixture.reportPath()), result.output)
+        val boundaryResult = check(report(fixture), "source-set-boundaries")
+        val diagnostics = boundaryResult.path("diagnostics")
+
+        assertTrue(result.output.contains(":sharedUI:detektMainJvm"))
+        assertFalse(result.output.contains("detektCommonJvmMainSourceSet"))
+        assertEquals("fail", boundaryResult.path("status").asText())
+        assertEquals(1, diagnostics.size())
+        assertEquals(
+            "sharedUI/src/commonJvmMain/kotlin/fixture/SharedUiState.kt",
+            diagnostics.single().path("path").asText(),
+        )
+        assertEquals(3, diagnostics.single().path("line").asInt())
+    }
+
+    @Test
     fun `invalid policy encoding is an internal error without hiding the other check`(@TempDir root: Path) {
         val fixture = FixtureProject(root).apply {
             create()
@@ -223,6 +247,7 @@ class SouzQualityPluginFunctionalTest {
         val report = report(fixture)
 
         assertEquals("error", report.path("status").asText())
+        assertEquals("error", check(report, "source-set-boundaries").path("status").asText())
         assertEquals("error", check(report, "cancellation-propagation").path("status").asText())
         assertEquals("error", check(report, "coroutine-thread-local").path("status").asText())
         assertEquals("error", check(report, "coroutine-monitor-use").path("status").asText())

--- a/build-logic/src/test/kotlin/ru/souz/build/quality/SouzQualityPluginFunctionalTest.kt
+++ b/build-logic/src/test/kotlin/ru/souz/build/quality/SouzQualityPluginFunctionalTest.kt
@@ -216,6 +216,58 @@ class SouzQualityPluginFunctionalTest {
     }
 
     @Test
+    fun `custom KMP production source set and root preserve classification and configuration cache`(
+        @TempDir root: Path,
+    ) {
+        val fixture = FixtureProject(root).apply {
+            create()
+            addSharedUiKmpBoundaryViolation("portable-ui", "portable")
+            commit()
+        }
+        val arguments = arrayOf(
+            "souzGateFast",
+            "--configuration-cache",
+            "--configuration-cache-problems=fail",
+        )
+
+        val first = fixture.buildAndFail(*arguments)
+        val second = fixture.buildAndFail(*arguments)
+        val diagnostics = check(report(fixture), "source-set-boundaries").path("diagnostics")
+
+        assertTrue(first.output.contains("Configuration cache entry stored."), first.output)
+        assertTrue(second.output.contains("Configuration cache entry reused."), second.output)
+        assertEquals(1, diagnostics.size())
+        assertEquals(
+            "sharedUI/portable-ui/fixture/SharedUiState.kt",
+            diagnostics.single().path("path").asText(),
+        )
+    }
+
+    @Test
+    fun `overlapping source roots owned by different source sets are rejected`(@TempDir root: Path) {
+        val fixture = FixtureProject(root).apply {
+            create()
+            addSharedUiKmpBoundaryViolation("portable-ui")
+            append(
+                "sharedUI/build.gradle.kts",
+                """
+
+                kotlin.sourceSets.named("jvmTest") {
+                    kotlin.srcDir("portable-ui/tests")
+                }
+                """.trimIndent() + "\n",
+            )
+            commit()
+        }
+
+        val result = fixture.buildAndFail("generateSourceSetBoundaryConfig")
+
+        assertTrue(result.output.contains("Overlapping source roots belong to different Kotlin source sets"), result.output)
+        assertTrue(result.output.contains("sharedUI:commonJvmMain"), result.output)
+        assertTrue(result.output.contains("sharedUI:jvmTest"), result.output)
+    }
+
+    @Test
     fun `invalid policy encoding is an internal error without hiding the other check`(@TempDir root: Path) {
         val fixture = FixtureProject(root).apply {
             create()

--- a/desktopApp/src/main/kotlin/ru/souz/tool/application/ToolOpen.kt
+++ b/desktopApp/src/main/kotlin/ru/souz/tool/application/ToolOpen.kt
@@ -8,6 +8,7 @@ import ru.souz.db.SettingsProviderImpl
 import ru.souz.tool.*
 import ru.souz.tool.desktop.ToolOpenFolder
 import ru.souz.runtime.files.FilesToolUtil
+import ru.souz.runtime.files.createDefaultFilesToolUtil
 import java.awt.Desktop
 import java.io.File
 import java.net.URI
@@ -118,7 +119,7 @@ class ToolOpen(
 }
 
 fun main() {
-    val filesToolUtil = FilesToolUtil(SettingsProviderImpl(ConfigStore))
+    val filesToolUtil = createDefaultFilesToolUtil(SettingsProviderImpl(ConfigStore))
     val result = ToolOpen(ToolRunBashCommand, filesToolUtil).invoke(
         ToolOpen.Input("ru.keepcoder.Telegram"),
         ToolInvocationMeta.localDefault(),

--- a/desktopApp/src/main/kotlin/ru/souz/tool/desktop/ToolOpenFolder.kt
+++ b/desktopApp/src/main/kotlin/ru/souz/tool/desktop/ToolOpenFolder.kt
@@ -4,6 +4,7 @@ import ru.souz.llms.ToolInvocationMeta
 
 import ru.souz.tool.*
 import ru.souz.runtime.files.FilesToolUtil
+import ru.souz.runtime.files.createDefaultFilesToolUtil
 import ru.souz.tool.files.ToolListFiles
 import org.slf4j.LoggerFactory
 import ru.souz.db.ConfigStore
@@ -124,7 +125,7 @@ class ToolOpenFolder(
 }
 
 fun main() {
-    val filesToolUtil = FilesToolUtil(SettingsProviderImpl(ConfigStore))
+    val filesToolUtil = createDefaultFilesToolUtil(SettingsProviderImpl(ConfigStore))
     val v = ToolOpenFolder(ToolRunBashCommand, filesToolUtil)
         .invoke(ToolOpenFolder.Input("семья"), ToolInvocationMeta.localDefault())
     println(v)

--- a/desktopApp/src/test/kotlin/agent/AgentScenarioTestSupport.kt
+++ b/desktopApp/src/test/kotlin/agent/AgentScenarioTestSupport.kt
@@ -52,6 +52,7 @@ import ru.souz.tool.RuntimePassThroughToolsFilter
 import ru.souz.tool.ToolCategory
 import ru.souz.tool.ToolsFactory
 import ru.souz.runtime.files.FilesToolUtil
+import ru.souz.runtime.files.createDefaultFilesToolUtil
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
@@ -60,7 +61,7 @@ class AgentScenarioTestSupport(
     private val selectedModel: LLMModel,
 ) {
     private val agentType: AgentId = parseScenarioAgentId(readEnvironment(SOUZ_AGENT_INTEGRATION_TEST_AGENT))
-    val filesUtil: FilesToolUtil by lazy { FilesToolUtil(spySettings) }
+    val filesUtil: FilesToolUtil by lazy { createDefaultFilesToolUtil(spySettings) }
     private var fewShotExamplesEnabled: Boolean = true
 
     private val spySettings: SettingsProviderImpl by lazy {

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -8,9 +8,9 @@ the fast gate from the repository root:
 ```
 
 The fast lane is local-safe: its results remain meaningful in a dirty
-checkout. Repository and module contracts are blocking locally and in
-pull-request CI. Coroutine analysis is advisory. CI publishes the quality
-summary and report artifacts even when a blocking check fails.
+checkout. Repository, module, and source-set contracts are blocking locally
+and in pull-request CI. Coroutine analysis is advisory. CI publishes the
+quality summary and report artifacts even when a blocking check fails.
 
 ## Checks
 
@@ -19,6 +19,7 @@ summary and report artifacts even when a blocking check fails.
 | `git-metadata` | The gate can identify the tested commit and worktree state. | Run the gate from the repository checkout and remove Git routing overrides that point outside it. |
 | `repository-contracts` | The Gradle project set, root Module Map, module policies, pain-point indexes, local policy links, and registered check policy paths agree. | Repair the reported repository-relative policy path or update the owning policy with the reviewed module change. |
 | `module-boundaries` | Direct production `ProjectDependency` edges match the explicit module and KMP source-set allowlist. Test dependencies are excluded. | Remove the edge or update the owning module policy and allowlist together when the architecture change is intentional. |
+| `source-set-boundaries` | Production imports keep portable, core, backend, and shared UI source sets behind their reviewed host boundaries. Test source sets are excluded. | Move host-specific code to the owning platform or composition-root source set and expose a contract or host port where the inward module needs one. |
 | `cancellation-propagation` | Suspend paths do not swallow `CancellationException`, including through `runCatching`. | Catch the expected exception type or rethrow cancellation immediately. |
 | `coroutine-thread-local` | Every JVM `ThreadLocal` state declaration is reviewed explicitly. | Move the state into coroutine context, or suppress the reviewed declaration and propagate coroutine access with `asContextElement`. |
 | `coroutine-monitor-use` | `synchronized`, `@Synchronized`, and `Collections.synchronized*` use inside suspend execution is reported for review. | Prefer `Mutex` inside suspend execution or keep monitor coordination behind an explicit non-suspending JVM boundary. |
@@ -34,12 +35,35 @@ gate can exclude them explicitly.
 Local-link checks validate filesystem targets. Markdown fragment identifiers
 are not part of the version 1 repository contract.
 
+## Source-set analysis
+
+The custom `SourceSetBoundaries` rule inspects production import directives and
+enforces these boundaries:
+
+- `commonMain` rejects JVM, Android, native-platform, Skiko/JNA, desktop-window,
+  and Souz host-implementation imports.
+- `sharedUI/commonJvmMain` rejects AWT/Swing, Skiko/JNA, desktop-only Compose
+  window APIs, native model implementations, backend code, and desktop service
+  or tool implementations. Portable `Dialog` and `Popup` APIs and ordinary JVM
+  APIs remain allowed.
+- `:graph-engine`, `:llms`, `:agent`, and `:skill-oauth-api` production code
+  rejects Compose, UI, backend, native-model, host-DI, and host-service imports.
+- `:backend` production code rejects Compose, UI, host-DI, AWT/Swing, Skiko/JNA,
+  and desktop service or tool imports. Its reviewed `:native` dependency remains
+  available.
+
+The rule reports the forbidden import's repository-relative path and line.
+Gradle project-dependency checks remain the primary module authority; this rule
+adds source-level diagnostics and protects boundaries inside allowed dependency
+graphs.
+
 ## Coroutine analysis
 
 Detekt runs one type-resolved analysis task for every JVM production and test
-compilation. Non-coroutine rule sets are disabled in
-[`quality/detekt.yml`](../quality/detekt.yml). Advisory analysis has no baseline,
-so every finding remains visible.
+compilation. General built-in rule sets are disabled in
+[`quality/detekt.yml`](../quality/detekt.yml); the Souz architecture and
+coroutine rule sets are enabled. Detekt analysis has no baseline, so every
+blocking or advisory finding remains visible.
 
 The enabled built-in rule is `SuspendFunSwallowedCancellation`.
 

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -41,7 +41,8 @@ The custom `SourceSetBoundaries` rule inspects production import directives and
 enforces these boundaries:
 
 - `commonMain` rejects JVM, Android, native-platform, Skiko/JNA, desktop-window,
-  and Souz host-implementation imports.
+  and Souz host-implementation imports. AndroidX imports fail closed: portable
+  symbols are reviewed individually, and wildcard imports are rejected.
 - `sharedUI/commonJvmMain` rejects AWT/Swing, Skiko/JNA, desktop-only Compose
   window APIs, native model implementations, backend code, and desktop service
   or tool implementations. Portable `Dialog` and `Popup` APIs and ordinary JVM

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -19,7 +19,7 @@ quality summary and report artifacts even when a blocking check fails.
 | `git-metadata` | The gate can identify the tested commit and worktree state. | Run the gate from the repository checkout and remove Git routing overrides that point outside it. |
 | `repository-contracts` | The Gradle project set, root Module Map, module policies, pain-point indexes, local policy links, and registered check policy paths agree. | Repair the reported repository-relative policy path or update the owning policy with the reviewed module change. |
 | `module-boundaries` | Direct production `ProjectDependency` edges match the explicit module and KMP source-set allowlist. Test dependencies are excluded. | Remove the edge or update the owning module policy and allowlist together when the architecture change is intentional. |
-| `source-set-boundaries` | Production imports keep portable, core, backend, and shared UI source sets behind their reviewed host boundaries. Test source sets are excluded. | Move host-specific code to the owning platform or composition-root source set and expose a contract or host port where the inward module needs one. |
+| `source-set-boundaries` | Production package declarations and references keep portable, core, backend, and shared UI source sets behind their reviewed host boundaries. Test source sets are excluded. | Move host-specific code to the owning platform or composition-root source set and expose a contract or host port where the inward module needs one. |
 | `cancellation-propagation` | Suspend paths do not swallow `CancellationException`, including through `runCatching`. | Catch the expected exception type or rethrow cancellation immediately. |
 | `coroutine-thread-local` | Every JVM `ThreadLocal` state declaration is reviewed explicitly. | Move the state into coroutine context, or suppress the reviewed declaration and propagate coroutine access with `asContextElement`. |
 | `coroutine-monitor-use` | `synchronized`, `@Synchronized`, and `Collections.synchronized*` use inside suspend execution is reported for review. | Prefer `Mutex` inside suspend execution or keep monitor coordination behind an explicit non-suspending JVM boundary. |
@@ -37,23 +37,32 @@ are not part of the version 1 repository contract.
 
 ## Source-set analysis
 
-The custom `SourceSetBoundaries` rule inspects production import directives and
-enforces these boundaries:
+The custom `SourceSetBoundaries` rule inspects production package declarations,
+imports, and fully qualified references and enforces these boundaries:
+
+Gradle supplies the rule with each configured Kotlin source root, source-set
+owner, and main-compilation membership. Custom source-set names and directories
+are classified by the build model; roots with overlapping ownership are rejected
+as ambiguous.
 
 - `commonMain` rejects JVM, Android, native-platform, Skiko/JNA, desktop-window,
-  and Souz host-implementation imports. AndroidX imports fail closed: portable
-  symbols are reviewed individually, and wildcard imports are rejected.
-- `sharedUI/commonJvmMain` rejects AWT/Swing, Skiko/JNA, desktop-only Compose
-  window APIs, native model implementations, backend code, and desktop service
-  or tool implementations. Portable `Dialog` and `Popup` APIs and ordinary JVM
-  APIs remain allowed.
+  and Souz host-implementation references. AndroidX references fail closed:
+  portable symbols are reviewed individually, and wildcard imports are rejected.
+- Shared `:sharedUI` production source sets, including `commonJvmMain`, reject
+  AWT/Swing, Skiko/JNA, desktop-only Compose window APIs, native model
+  implementations, backend code, and desktop service or tool implementations.
+  Portable `Dialog` and `Popup` APIs and ordinary JVM APIs remain allowed.
 - `:graph-engine`, `:llms`, `:agent`, and `:skill-oauth-api` production code
-  rejects Compose, UI, backend, native-model, host-DI, and host-service imports.
+  rejects Compose, UI, backend, native-model, host-DI, and host-service references.
 - `:backend` production code rejects Compose, UI, host-DI, AWT/Swing, Skiko/JNA,
-  and desktop service or tool imports. Its reviewed `:native` dependency remains
+  and desktop service or tool references. Its reviewed `:native` dependency remains
   available.
 
-The rule reports the forbidden import's repository-relative path and line.
+JVM-only packages are denied from portable source sets. JVM and desktop
+implementations in packages shared with portable contracts are reviewed as exact
+symbols, so the shared contracts remain available without exposing host code.
+
+The rule reports each forbidden reference's repository-relative path and line.
 Gradle project-dependency checks remain the primary module authority; this rule
 adds source-level diagnostics and protects boundaries inside allowed dependency
 graphs.

--- a/quality/detekt.yml
+++ b/quality/detekt.yml
@@ -46,3 +46,8 @@ souz-coroutines:
     active: true
   ThreadLocalInCoroutineCode:
     active: true
+
+souz-architecture:
+  active: true
+  SourceSetBoundaries:
+    active: true

--- a/sharedLogic/src/jvmMain/kotlin/ru/souz/runtime/files/FilesToolUtilJvmDefaults.kt
+++ b/sharedLogic/src/jvmMain/kotlin/ru/souz/runtime/files/FilesToolUtilJvmDefaults.kt
@@ -5,8 +5,7 @@ import ru.souz.runtime.sandbox.DefaultRuntimeSandboxFactory
 import ru.souz.runtime.sandbox.SandboxScope
 import ru.souz.runtime.sandbox.ToolInvocationSandboxScopeResolver
 
-@Suppress("FunctionName")
-fun FilesToolUtil(settingsProvider: SettingsProvider): FilesToolUtil =
+fun createDefaultFilesToolUtil(settingsProvider: SettingsProvider): FilesToolUtil =
     FilesToolUtil(
         sandboxFactory = DefaultRuntimeSandboxFactory(settingsProvider = settingsProvider),
         scopeResolver = ToolInvocationSandboxScopeResolver {

--- a/sharedLogic/src/jvmMain/kotlin/ru/souz/tool/dataAnalytics/ToolCreatePlotFromCsv.kt
+++ b/sharedLogic/src/jvmMain/kotlin/ru/souz/tool/dataAnalytics/ToolCreatePlotFromCsv.kt
@@ -18,6 +18,7 @@ import ru.souz.runtime.sandbox.SandboxMode
 import ru.souz.tool.*
 import ru.souz.runtime.files.FilesToolUtil
 import ru.souz.runtime.files.ForbiddenFolder
+import ru.souz.runtime.files.createDefaultFilesToolUtil
 import ru.souz.db.ConfigStore
 import ru.souz.db.SettingsProviderImpl
 import java.awt.Desktop
@@ -269,7 +270,7 @@ class ToolCreatePlotFromCsv(private val filesToolUtil: FilesToolUtil) : ToolSetu
 }
 
 fun main() {
-    val tool = ToolCreatePlotFromCsv(FilesToolUtil(SettingsProviderImpl(ConfigStore)))
+    val tool = ToolCreatePlotFromCsv(createDefaultFilesToolUtil(SettingsProviderImpl(ConfigStore)))
     println(
         tool.invoke(
             ToolCreatePlotFromCsv.Input(

--- a/sharedUI/src/jvmTest/kotlin/ru/souz/ui/main/MainViewModelTest.kt
+++ b/sharedUI/src/jvmTest/kotlin/ru/souz/ui/main/MainViewModelTest.kt
@@ -96,6 +96,7 @@ import ru.souz.tool.skills.ToolGetSkillsByCategory
 import ru.souz.tool.skills.ToolInvokeSkill
 import ru.souz.tool.files.DeferredToolModifyPermissionBroker
 import ru.souz.runtime.files.FilesToolUtil
+import ru.souz.runtime.files.createDefaultFilesToolUtil
 import ru.souz.tool.files.ToolModifyFile
 import ru.souz.ui.BaseViewModel
 import ru.souz.di.sharedUiMainViewModelUseCasesDiModule
@@ -1904,7 +1905,8 @@ class MainViewModelTest {
         }
 
         val toolPermissionBroker: ToolPermissionBroker = ImmediateToolPermissionBroker(settingsProvider)
-        val deferredToolModifyPermissionBroker = DeferredToolModifyPermissionBroker(settingsProvider, FilesToolUtil(settingsProvider))
+        val deferredToolModifyPermissionBroker =
+            DeferredToolModifyPermissionBroker(settingsProvider, createDefaultFilesToolUtil(settingsProvider))
 
         val telegramBotController = mockk<TelegramControlBot>(relaxed = true)
         val incomingMessages = MutableSharedFlow<TelegramControlIncomingMessage>()
@@ -1952,7 +1954,7 @@ class MainViewModelTest {
             bindSingleton { deferredToolModifyPermissionBroker }
             bindSingleton<TelegramControlBot> { telegramBotController }
             bindSingleton<UiAudioRecorder> { audioRecorder }
-            bindSingleton { FilesToolUtil(instance<SettingsProvider>()) }
+            bindSingleton { createDefaultFilesToolUtil(instance<SettingsProvider>()) }
             bindSingleton { FinderPathExtractor(instance()) }
             bindSingleton<PathPicker> { DesktopPathPicker() }
             bindSingleton<DroppedFilePathExtractor> { DesktopDroppedFilePathExtractor() }


### PR DESCRIPTION
## Summary

- add a blocking custom Detekt rule for portable, shared UI, core, and backend production import boundaries
- integrate source-set diagnostics into `souzGateFast` and load the rule classpath without repository-path assumptions
- cover rule behavior and actual KMP task wiring, including one repository-relative path and line diagnostic
- document the enforced source boundaries and remediation guidance

## Verification

- `./gradlew :build-logic:check`
- `./gradlew souzGateFast --configuration-cache --configuration-cache-problems=fail`
- repeated the fast gate to verify configuration-cache reuse
- `git diff --check`

The new blocking `source-set-boundaries` check passes with zero diagnostics. The aggregate fast-gate status remains `warning` because the existing cancellation-propagation check is advisory.