### PR TITLE
feat(quality): show duplication baseline deltas

### DIFF
--- a/build-logic/src/main/kotlin/ru/souz/build/quality/DuplicationRatchet.kt
+++ b/build-logic/src/main/kotlin/ru/souz/build/quality/DuplicationRatchet.kt
@@ -151,20 +151,22 @@ internal object DuplicationRatchet {
             }
 
             val comparison = measurement.duplicatedTokens.compareTo(baselineEntry.duplicatedTokens)
+            val delta = measurement.duplicatedTokens - baselineEntry.duplicatedTokens
             if (comparison != 0) {
                 failed = true
             }
-            val ratchet = when {
-                comparison > 0 -> "exceeds"
-                comparison < 0 -> "is below the stale"
-                else -> "matches"
+            val comparisonLabel = when {
+                comparison > 0 -> "exceeds baseline"
+                comparison < 0 -> "baseline is stale"
+                else -> "matches baseline"
             }
             diagnostics += diagnostic(
                 baselinePath,
-                "${scope.wireName}: ${measurement.duplicatedTokens} duplicated tokens in " +
-                    "${measurement.clones} clones (${formatPercentage(measurement.percentageTokens)}% of " +
-                    "${measurement.tokens} tokens across ${measurement.sources} files) $ratchet baseline " +
-                    "${baselineEntry.duplicatedTokens}; minimum ${threshold.minLines} lines/${threshold.minTokens} tokens.",
+                "${scope.wireName}: duplicated tokens ${baselineEntry.duplicatedTokens} baseline -> " +
+                    "${measurement.duplicatedTokens} current (delta ${formatDelta(delta)}; $comparisonLabel); " +
+                    "${measurement.clones} clones, ${formatPercentage(measurement.percentageTokens)}% of " +
+                    "${measurement.tokens} tokens across ${measurement.sources} files; " +
+                    "minimum ${threshold.minLines} lines/${threshold.minTokens} tokens.",
             )
         }
 
@@ -187,6 +189,8 @@ internal object DuplicationRatchet {
     )
 
     private fun formatPercentage(value: Double): String = String.format(Locale.ROOT, "%.3f", value)
+
+    private fun formatDelta(value: Long): String = if (value >= 0) "+$value" else value.toString()
 
     private fun JsonNode.requiredObject(name: String): JsonNode = required(name).also {
         require(it.isObject) { "'$name' must be a JSON object." }

--- a/build-logic/src/main/kotlin/ru/souz/build/quality/QualityModel.kt
+++ b/build-logic/src/main/kotlin/ru/souz/build/quality/QualityModel.kt
@@ -116,7 +116,7 @@ internal object SouzQualityChecks {
 
     val duplicateCode = QualityCheckDefinition(
         id = "duplicate-code",
-        implementationVersion = 1,
+        implementationVersion = 2,
         description = "Production and test duplicated-token totals match their reviewed baselines.",
         policy = "docs/quality-gates.md",
         lane = QualityLane.EXPENSIVE,

--- a/build-logic/src/test/kotlin/ru/souz/build/quality/DuplicationRatchetTest.kt
+++ b/build-logic/src/test/kotlin/ru/souz/build/quality/DuplicationRatchetTest.kt
@@ -23,10 +23,11 @@ class DuplicationRatchetTest {
         val stale = evaluate(baselineFile, measurements(production = 100, tests = 199))
 
         assertFalse(unchanged.failed)
+        assertTrue(unchanged.diagnostics.any { it.message.contains("100 baseline -> 100 current (delta +0") })
         assertTrue(growth.failed)
-        assertTrue(growth.diagnostics.any { it.message.contains("exceeds baseline 100") })
+        assertTrue(growth.diagnostics.any { it.message.contains("100 baseline -> 101 current (delta +1") })
         assertTrue(stale.failed)
-        assertTrue(stale.diagnostics.any { it.message.contains("below the stale") })
+        assertTrue(stale.diagnostics.any { it.message.contains("200 baseline -> 199 current (delta -1") })
     }
 
     @Test

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -86,6 +86,9 @@ reviewed baseline update:
 ./gradlew updateSouzDuplicationBaseline
 ```
 
+The expensive-lane summary shows the reviewed baseline, current duplicated-token
+total, and signed delta for production and tests.
+
 The local task compares the same inputs but reports `not_authoritative` for the
 exact-checkout preflight. Pull-request CI requires a clean checkout whose
 `HEAD` matches `GITHUB_SHA`. Local HTML reports are written to


### PR DESCRIPTION
## Summary

- show baseline, current duplicated-token total, and signed delta for production and tests
- keep duplicate-code ratchet behavior unchanged
- document the expensive-lane comparison

## Verification

- ./gradlew :build-logic:check souzDuplicationCheck souzGateFast --configuration-cache --configuration-cache-problems=fail
- git diff --check