### PR TITLE
Refactor runtime tool catalog construction

### DIFF
--- a/sharedLogic/src/commonJvmMain/kotlin/ru/souz/tool/PortableRuntimeToolsModule.kt
+++ b/sharedLogic/src/commonJvmMain/kotlin/ru/souz/tool/PortableRuntimeToolsModule.kt
@@ -210,40 +210,23 @@ class PortableRuntimeToolsFactory(
 ) : AgentToolCatalog {
     override val toolsByCategory: Map<ToolCategory, Map<String, LLMToolSetup>> =
         immutableToolCatalogFromLists(
-            ToolCategory.entries.associateWith { category -> category.tools() }
+            mapOf(
+                ToolCategory.FILES to listOf(
+                    toolListFiles.toGiga(),
+                    toolFindInFiles.toGiga(),
+                    toolNewFile.toGiga(),
+                    toolDeleteFile.toGiga(),
+                    toolModifyFile.toGiga(),
+                    toolMoveFile.toGiga(),
+                    toolFindFilesByName.toGiga(),
+                    toolFindFolders.toGiga(),
+                ),
+                ToolCategory.WEB_SEARCH to listOf(toolWebPageText.toGiga()),
+                ToolCategory.CALCULATOR to listOf(toolCalculator.toGiga()),
+                ToolCategory.OAUTH to listOfNotNull(
+                    toolConnectOAuthProvider?.toGiga(),
+                    toolSafeApiCall?.toGiga(),
+                ),
+            )
         ).toolsByCategory
-
-    private fun ToolCategory.tools(): List<LLMToolSetup> = when (this) {
-        ToolCategory.FILES -> listOf(
-            toolListFiles.toGiga(),
-            toolFindInFiles.toGiga(),
-            toolNewFile.toGiga(),
-            toolDeleteFile.toGiga(),
-            toolModifyFile.toGiga(),
-            toolMoveFile.toGiga(),
-            toolFindFilesByName.toGiga(),
-            toolFindFolders.toGiga(),
-        )
-
-        ToolCategory.WEB_SEARCH -> listOf(toolWebPageText.toGiga())
-        ToolCategory.CALCULATOR -> listOf(toolCalculator.toGiga())
-
-        ToolCategory.OAUTH -> listOfNotNull(toolConnectOAuthProvider?.toGiga(), toolSafeApiCall?.toGiga())
-
-        ToolCategory.CONFIG,
-        ToolCategory.DATA_ANALYTICS,
-        ToolCategory.BROWSER,
-        ToolCategory.IMAGE,
-        ToolCategory.IMAGE_GENERATION,
-        ToolCategory.NOTES,
-        ToolCategory.APPLICATIONS,
-        ToolCategory.CALENDAR,
-        ToolCategory.MAIL,
-        ToolCategory.TEXT_REPLACE,
-        ToolCategory.CHAT,
-        ToolCategory.TELEGRAM,
-        ToolCategory.DESKTOP,
-        ToolCategory.HELP,
-        ToolCategory.CHANNEL_MESSAGING -> emptyList()
-    }
 }

--- a/sharedLogic/src/jvmMain/kotlin/ru/souz/tool/RuntimeToolsModule.kt
+++ b/sharedLogic/src/jvmMain/kotlin/ru/souz/tool/RuntimeToolsModule.kt
@@ -69,40 +69,19 @@ class RuntimeToolsFactory(
             listOf(
                 portableToolsFactory,
                 immutableToolCatalogFromLists(
-                    ToolCategory.entries.associateWith { category -> category.jvmTools() }
+                    mapOf(
+                        ToolCategory.FILES to listOf(
+                            toolExtractText.toGiga(),
+                            toolReadPdfPages.toGiga(),
+                        ),
+                        ToolCategory.WEB_SEARCH to listOfNotNull(toolWebImageSearch?.toGiga()),
+                        ToolCategory.DATA_ANALYTICS to listOf(
+                            toolCreatePlotFromCsv.toGiga(),
+                            excelRead.toGiga(),
+                            excelReport.toGiga(),
+                        ),
+                    )
                 ),
             )
         ).toolsByCategory
-
-    private fun ToolCategory.jvmTools(): List<LLMToolSetup> = when (this) {
-        ToolCategory.FILES -> listOf(
-            toolExtractText.toGiga(),
-            toolReadPdfPages.toGiga(),
-        )
-
-        ToolCategory.WEB_SEARCH -> listOfNotNull(toolWebImageSearch?.toGiga())
-
-        ToolCategory.DATA_ANALYTICS -> listOf(
-            toolCreatePlotFromCsv.toGiga(),
-            excelRead.toGiga(),
-            excelReport.toGiga(),
-        )
-
-        ToolCategory.BROWSER,
-        ToolCategory.CONFIG,
-        ToolCategory.IMAGE,
-        ToolCategory.IMAGE_GENERATION,
-        ToolCategory.NOTES,
-        ToolCategory.APPLICATIONS,
-        ToolCategory.CALENDAR,
-        ToolCategory.MAIL,
-        ToolCategory.TEXT_REPLACE,
-        ToolCategory.CHAT,
-        ToolCategory.TELEGRAM,
-        ToolCategory.DESKTOP,
-        ToolCategory.CALCULATOR,
-        ToolCategory.OAUTH,
-        ToolCategory.HELP,
-        ToolCategory.CHANNEL_MESSAGING -> emptyList()
-    }
 }


### PR DESCRIPTION
## Summary
- Replace explicit empty ToolCategory branches in portable and JVM runtime catalogs with sparse maps passed to immutableToolCatalogFromLists.
- Keep MarkdownSearchTraversal unchanged because the flagged match is Markdown AST traversal, not tool catalog construction.

## Validation
- ./gradlew :sharedLogic:jvmTest --tests 'ru.souz.tool.PortableRuntimeToolsFactoryTest' --tests 'ru.souz.tool.PortableRuntimeToolsModuleSafeModeTest' --tests 'ru.souz.tool.skills.SkillRuntimeToolsTest' --tests 'ru.souz.tool.ToolCatalogsTest'
- ./gradlew :backend:test --tests 'ru.souz.backend.app.BackendDiModuleTest'
- ./gradlew :desktopApp:test --tests 'agent.AgentScenarioTestSupportTest'
- ./gradlew :sharedUI:jvmTest --tests 'ru.souz.ui.main.search.ChatSearchProjectorTest'
- ./gradlew souzGateFast
- npm ci --prefix quality
- ./gradlew souzDuplicationCheck
- git diff --check