### PR TITLE
perf(backend): hoist lease refresh delay conversion

### DIFF
--- a/backend/src/main/kotlin/ru/souz/backend/execution/service/AgentExecutionLauncher.kt
+++ b/backend/src/main/kotlin/ru/souz/backend/execution/service/AgentExecutionLauncher.kt
@@ -85,10 +85,11 @@ internal class AgentExecutionLauncher(
         val registry = clientThreadRegistry ?: return null
         if (!registry.contains(execution.id)) return null
         val owner = registry.runtimeOwner
+        val refreshDelayMillis = leaseRefreshInterval.toMillis()
         return owningScope.launch {
             var leaseExpiresAt = execution.runtimeLeaseUntil ?: ClientThreadRuntimeRegistry.leaseUntil()
             while (isActive) {
-                delay(leaseRefreshInterval.toMillis())
+                delay(refreshDelayMillis)
                 if (!Instant.now().isBefore(leaseExpiresAt)) {
                     activeJobs.cancel(
                         execution.id,


### PR DESCRIPTION
## Summary
- Hoist `leaseRefreshInterval.toMillis()` out of the client thread lease refresh loop.
- Preserve the existing terminal-state fallback read when lease refresh returns `null`.

## Validation
- `./gradlew :backend:test --tests 'ru.souz.backend.execution.service.AgentExecutionLauncherTest'`
- `./gradlew souzGateFast`
- `./gradlew :backend:test`
- `git diff --check`