### PR TITLE
Move local embedding mapping to profiles

### DIFF
--- a/native/src/main/kotlin/ru/souz/llms/local/LocalChatAPI.kt
+++ b/native/src/main/kotlin/ru/souz/llms/local/LocalChatAPI.kt
@@ -22,7 +22,7 @@ class LocalChatAPI(
         runtime.chatStream(body)
 
     override suspend fun embeddings(body: LLMRequest.Embeddings): LLMResponse.Embeddings = try {
-        runtime.embeddings(body)
+        LocalEmbeddingProfiles.embeddings(body, runtime.nativeEmbeddings(body))
     } catch (error: Exception) {
         LLMResponse.Embeddings.Error(-1, "Local provider error: ${error.message}")
     }

--- a/native/src/main/kotlin/ru/souz/llms/local/LocalLlamaRuntime.kt
+++ b/native/src/main/kotlin/ru/souz/llms/local/LocalLlamaRuntime.kt
@@ -21,7 +21,6 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
-import ru.souz.llms.EmbeddingInputKind
 import ru.souz.llms.LLMMessageRole
 import ru.souz.llms.LLMRequest
 import ru.souz.llms.LLMResponse
@@ -87,27 +86,14 @@ class LocalLlamaRuntime(
         emit(response)
     }
 
-    suspend fun embeddings(body: LLMRequest.Embeddings): LLMResponse.Embeddings {
-        val nativeResult = runCatching { embed(body) }
+    suspend fun embeddings(body: LLMRequest.Embeddings): LLMResponse.Embeddings =
+        LocalEmbeddingProfiles.embeddings(body, nativeEmbeddings(body))
+
+    internal suspend fun nativeEmbeddings(body: LLMRequest.Embeddings): NativeEmbeddingsResult =
+        runCatching { executeEmbeddings(body) }
             .getOrElse { error ->
                 NativeEmbeddingsResult.error("Local embeddings failed: ${error.message ?: error::class.simpleName.orEmpty()}")
             }
-        nativeResult.error?.let { message ->
-            return LLMResponse.Embeddings.Error(-1, message)
-        }
-        return LLMResponse.Embeddings.Ok(
-            data = nativeResult.embeddings.mapIndexed { index, embedding ->
-                LLMResponse.Embedding(
-                    embedding = embedding,
-                    index = index,
-                    objectType = "embedding",
-                )
-            },
-            model = LocalEmbeddingProfiles.forAlias(body.model)?.embeddingsModel?.alias
-                ?: LocalEmbeddingProfiles.default().embeddingsModel.alias,
-            objectType = "list",
-        )
-    }
 
     fun cancelActiveRequest() {
         runtimeHandle.get()?.let { runtime ->
@@ -152,7 +138,7 @@ class LocalLlamaRuntime(
         }
     }
 
-    private suspend fun embed(body: LLMRequest.Embeddings): NativeEmbeddingsResult {
+    private suspend fun executeEmbeddings(body: LLMRequest.Embeddings): NativeEmbeddingsResult {
         val availabilityStatus = availability.status()
         if (!availabilityStatus.available) {
             return NativeEmbeddingsResult.error(availabilityStatus.message)
@@ -162,24 +148,17 @@ class LocalLlamaRuntime(
             return NativeEmbeddingsResult.error("Local embeddings request is empty.")
         }
 
-        val profile = LocalEmbeddingProfiles.forAlias(body.model) ?: LocalEmbeddingProfiles.default()
+        val prepared = LocalEmbeddingProfiles.prepareRequest(body)
+        val profile = prepared.profile
         val runtime = ensureRuntime()
         val modelHandle = ensureEmbeddingModel(profile)
-        val inputKind = resolveEmbeddingInputKind(body)
-        val preparedInputs = body.input.map { text -> profile.format(text, inputKind) }
-        val requestJson = restJsonMapper.writeValueAsString(
-            LocalEmbeddingsRequest(
-                inputs = preparedInputs,
-                contextSize = profile.maxContextSize,
-                normalize = true,
-            )
-        )
+        val requestJson = restJsonMapper.writeValueAsString(prepared.request)
 
         l.debug(
             "Prepared local embeddings for model={} items={} inputKind={} contextSize={}",
             profile.id,
-            preparedInputs.size,
-            inputKind,
+            prepared.request.inputs.size,
+            prepared.inputKind,
             profile.maxContextSize,
         )
         val responseJson = withContext(Dispatchers.IO) {
@@ -461,12 +440,6 @@ class LocalLlamaRuntime(
             profile.maxContextSize.coerceAtMost(MAX_VISION_CONTEXT_SIZE)
         } else {
             profile.maxContextSize
-        }
-
-    internal fun resolveEmbeddingInputKind(body: LLMRequest.Embeddings): LocalEmbeddingInputKind =
-        when (body.inputKind) {
-            EmbeddingInputKind.QUERY -> LocalEmbeddingInputKind.QUERY
-            EmbeddingInputKind.DOCUMENT -> LocalEmbeddingInputKind.DOCUMENT
         }
 
     private fun nextContextBucket(tokens: Int): Int {

--- a/native/src/main/kotlin/ru/souz/llms/local/LocalModels.kt
+++ b/native/src/main/kotlin/ru/souz/llms/local/LocalModels.kt
@@ -4,8 +4,11 @@ import com.sun.management.OperatingSystemMXBean
 import java.lang.management.ManagementFactory
 import org.slf4j.LoggerFactory
 import ru.souz.llms.DEFAULT_MAX_TOKENS
+import ru.souz.llms.EmbeddingInputKind
 import ru.souz.llms.EmbeddingsModel
 import ru.souz.llms.LLMModel
+import ru.souz.llms.LLMRequest
+import ru.souz.llms.LLMResponse
 import ru.souz.llms.LocalModelAvailability
 
 data class LocalLicenseRequirements(
@@ -320,6 +323,54 @@ object LocalEmbeddingProfiles {
     }
 
     fun default(): LocalEmbeddingProfile = EMBEDDING_GEMMA_300M
+
+    internal fun forAliasOrDefault(alias: String): LocalEmbeddingProfile = forAlias(alias) ?: default()
+
+    internal fun prepareRequest(body: LLMRequest.Embeddings): PreparedEmbeddingsRequest {
+        val profile = forAliasOrDefault(body.model)
+        val inputKind = resolveInputKind(body)
+        return PreparedEmbeddingsRequest(
+            profile = profile,
+            inputKind = inputKind,
+            request = LocalLlamaRuntime.LocalEmbeddingsRequest(
+                inputs = body.input.map { text -> profile.format(text, inputKind) },
+                contextSize = profile.maxContextSize,
+                normalize = true,
+            ),
+        )
+    }
+
+    internal fun embeddings(
+        body: LLMRequest.Embeddings,
+        nativeResult: LocalLlamaRuntime.NativeEmbeddingsResult,
+    ): LLMResponse.Embeddings {
+        nativeResult.error?.let { message ->
+            return LLMResponse.Embeddings.Error(-1, message)
+        }
+        return LLMResponse.Embeddings.Ok(
+            data = nativeResult.embeddings.mapIndexed { index, embedding ->
+                LLMResponse.Embedding(
+                    embedding = embedding,
+                    index = index,
+                    objectType = "embedding",
+                )
+            },
+            model = forAliasOrDefault(body.model).embeddingsModel.alias,
+            objectType = "list",
+        )
+    }
+
+    internal fun resolveInputKind(body: LLMRequest.Embeddings): LocalEmbeddingInputKind =
+        when (body.inputKind) {
+            EmbeddingInputKind.QUERY -> LocalEmbeddingInputKind.QUERY
+            EmbeddingInputKind.DOCUMENT -> LocalEmbeddingInputKind.DOCUMENT
+        }
+
+    internal data class PreparedEmbeddingsRequest(
+        val profile: LocalEmbeddingProfile,
+        val inputKind: LocalEmbeddingInputKind,
+        val request: LocalLlamaRuntime.LocalEmbeddingsRequest,
+    )
 }
 
 fun LocalModelProfile.requiredDownloadProfiles(): List<LocalDownloadableProfile> =

--- a/native/src/test/kotlin/ru/souz/local/LocalInferenceSupportTest.kt
+++ b/native/src/test/kotlin/ru/souz/local/LocalInferenceSupportTest.kt
@@ -1687,7 +1687,7 @@ class LocalInferenceSupportTest {
         val queryRequest = restJsonMapper.readValue(requests[0], LocalLlamaRuntime.LocalEmbeddingsRequest::class.java)
         assertEquals(
             LocalEmbeddingInputKind.QUERY,
-            runtime.resolveEmbeddingInputKind(
+            LocalEmbeddingProfiles.resolveInputKind(
                 LLMRequest.Embeddings(input = listOf("hello"), inputKind = EmbeddingInputKind.QUERY)
             )
         )
@@ -1696,7 +1696,7 @@ class LocalInferenceSupportTest {
         val documentRequest = restJsonMapper.readValue(requests[1], LocalLlamaRuntime.LocalEmbeddingsRequest::class.java)
         assertEquals(
             LocalEmbeddingInputKind.DOCUMENT,
-            runtime.resolveEmbeddingInputKind(
+            LocalEmbeddingProfiles.resolveInputKind(
                 LLMRequest.Embeddings(input = listOf("doc one"), inputKind = EmbeddingInputKind.DOCUMENT)
             )
         )
@@ -1776,10 +1776,8 @@ class LocalInferenceSupportTest {
     @Test
     fun `local chat api supports embeddings and still rejects unsupported file features`() = runTest {
         val runtime = mockk<LocalLlamaRuntime>(relaxed = true)
-        coEvery { runtime.embeddings(any()) } returns LLMResponse.Embeddings.Ok(
-            data = listOf(LLMResponse.Embedding(listOf(0.1, 0.2), 0, "embedding")),
-            model = LocalEmbeddingProfiles.default().embeddingsModel.alias,
-            objectType = "list",
+        coEvery { runtime.nativeEmbeddings(any()) } returns LocalLlamaRuntime.NativeEmbeddingsResult(
+            embeddings = listOf(listOf(0.1, 0.2)),
         )
         val api = LocalChatAPI(runtime = runtime)
 


### PR DESCRIPTION
Summary:
- Moves embedding alias defaulting, request preparation, input-kind mapping, and response shaping onto LocalEmbeddingProfiles.
- Leaves LocalLlamaRuntime responsible for native execution and model loading.
- Updates LocalChatAPI and native tests for the new runtime/profile boundary.

Tests:
- ./gradlew :native:test souzGateFast