### PR TITLE
Split backend agent model boundary

### DIFF
--- a/backend/src/main/kotlin/ru/souz/backend/agent/model/AgentConversationKey.kt
+++ b/backend/src/main/kotlin/ru/souz/backend/agent/model/AgentConversationKey.kt
@@ -1,0 +1,19 @@
+package ru.souz.backend.agent.model
+
+import java.util.UUID
+
+/** Stable backend conversation identifier composed from user and conversation ids. */
+data class AgentConversationKey(
+    val userId: String,
+    val conversationId: String,
+) {
+    companion object {
+        internal fun fromChat(userId: String, chatId: UUID): AgentConversationKey =
+            AgentConversationKey(
+                userId = userId,
+                conversationId = chatId.toString(),
+            )
+    }
+}
+
+internal fun AgentConversationKey.chatId(): UUID = UUID.fromString(conversationId)

--- a/backend/src/main/kotlin/ru/souz/backend/agent/model/BackendConversationTurnRequest.kt
+++ b/backend/src/main/kotlin/ru/souz/backend/agent/model/BackendConversationTurnRequest.kt
@@ -2,12 +2,6 @@ package ru.souz.backend.agent.model
 
 import ru.souz.llms.LLMModel
 
-/** Stable backend conversation identifier composed from user and conversation ids. */
-data class AgentConversationKey(
-    val userId: String,
-    val conversationId: String,
-)
-
 /** Internal request model for one chat-oriented backend agent turn. */
 internal data class BackendConversationTurnRequest(
     val prompt: String,

--- a/backend/src/main/kotlin/ru/souz/backend/agent/runtime/conversation/BackendConversationRuntimeFactory.kt
+++ b/backend/src/main/kotlin/ru/souz/backend/agent/runtime/conversation/BackendConversationRuntimeFactory.kt
@@ -1,7 +1,6 @@
 package ru.souz.backend.agent.runtime.conversation
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import java.util.UUID
 import kotlinx.coroutines.CoroutineScope
 import ru.souz.agent.AgentExecutionKernelFactory
 import ru.souz.agent.knowledge.ConversationKnowledgeStore
@@ -10,6 +9,7 @@ import ru.souz.agent.spi.AgentTelemetry
 import ru.souz.agent.spi.AgentToolCatalog
 import ru.souz.backend.agent.model.AgentConversationKey
 import ru.souz.backend.agent.model.BackendConversationTurnRequest
+import ru.souz.backend.agent.model.chatId
 import ru.souz.backend.agent.runtime.BackendAgentErrorMessages
 import ru.souz.backend.agent.runtime.BackendConversationSettingsProvider
 import ru.souz.backend.agent.runtime.BackendNoopAgentDesktopInfoRepository
@@ -94,7 +94,7 @@ internal class BackendConversationRuntimeFactory(
         } else {
             messageRepository.list(
                 userId = key.userId,
-                chatId = UUID.fromString(key.conversationId),
+                chatId = key.chatId(),
                 afterSeq = basedOnMessageSeq.takeIf { it > 0L },
                 limit = MessageRepository.MAX_LIMIT,
             )

--- a/backend/src/main/kotlin/ru/souz/backend/agent/session/AgentSessionRepository.kt
+++ b/backend/src/main/kotlin/ru/souz/backend/agent/session/AgentSessionRepository.kt
@@ -3,8 +3,8 @@ package ru.souz.backend.agent.session
 import java.time.Instant
 import java.time.ZoneId
 import java.util.Locale
-import java.util.UUID
 import ru.souz.backend.agent.model.AgentConversationKey
+import ru.souz.backend.agent.model.chatId
 import ru.souz.llms.LLMRequest
 
 /** Persisted backend conversation snapshot used to resume the next agent turn. */
@@ -46,8 +46,6 @@ class AgentStateBackedSessionRepository(
         )
     }
 }
-
-private fun AgentConversationKey.chatId(): UUID = UUID.fromString(conversationId)
 
 private fun AgentConversationState.toConversationSession(): AgentConversationSession =
     AgentConversationSession(

--- a/backend/src/main/kotlin/ru/souz/backend/execution/service/AgentExecutionRequestFactory.kt
+++ b/backend/src/main/kotlin/ru/souz/backend/execution/service/AgentExecutionRequestFactory.kt
@@ -100,7 +100,7 @@ internal class AgentExecutionRequestFactory(
             normalizedClientMessageId = normalizedClientMessageId,
             effectiveSettings = effectiveSettings,
             execution = execution,
-            conversationKey = conversationKey(userId, chatId),
+            conversationKey = AgentConversationKey.fromChat(userId, chatId),
             runtimeRequest = BackendConversationTurnRequest(
                 prompt = content,
                 model = effectiveSettings.defaultModel,
@@ -126,7 +126,7 @@ internal class AgentExecutionRequestFactory(
     ): PreparedContinuationTurn {
         val runtimeRequest = createContinuationTurnRequest(execution, option)
         return PreparedContinuationTurn(
-            conversationKey = conversationKey(execution.userId, execution.chatId),
+            conversationKey = AgentConversationKey.fromChat(execution.userId, execution.chatId),
             runtimeRequest = runtimeRequest,
             streamingMessagesEnabled = runtimeRequest.streamingMessages == true,
             toolEventsEnabled = executionMetadataBoolean(execution, METADATA_SHOW_TOOL_EVENTS) ?: false,
@@ -187,12 +187,6 @@ internal class AgentExecutionRequestFactory(
             assistantMessageId = execution.assistantMessageId,
             beforePublicEvent = { clientThreadRegistry?.awaitAcceptedInputAcks(execution.id) },
             publicClientThread = clientThreadRegistry?.contains(execution.id) == true,
-        )
-
-    private fun conversationKey(userId: String, chatId: UUID): AgentConversationKey =
-        AgentConversationKey(
-            userId = userId,
-            conversationId = chatId.toString(),
         )
 
     private fun userMessageMetadata(clientMessageId: String?): Map<String, String> =

--- a/backend/src/test/kotlin/ru/souz/backend/storage/postgres/PostgresRepositoriesTest.kt
+++ b/backend/src/test/kotlin/ru/souz/backend/storage/postgres/PostgresRepositoriesTest.kt
@@ -894,9 +894,9 @@ class PostgresRepositoriesTest {
                 ).copy(id = chatId)
             )
             val repository = AgentStateBackedSessionRepository(repositories.stateRepository)
-            val key = AgentConversationKey(
+            val key = AgentConversationKey.fromChat(
                 userId = "opaque/user:session",
-                conversationId = chatId.toString(),
+                chatId = chatId,
             )
             val session = AgentConversationSession(
                 history = listOf(


### PR DESCRIPTION
## Summary
- split the mixed backend agent model file into separate conversation key and turn request models
- centralize chat id conversion on AgentConversationKey
- update direct runtime/session/request factory callers and the Postgres session repository test

## Verification
- ./gradlew :backend:compileKotlin
- ./gradlew :backend:compileTestKotlin
- ./gradlew :backend:test --tests 'ru.souz.backend.app.BackendDiModuleTest'
- ./gradlew souzGateFast
- git diff --check