### PR TITLE
Refactor agent core tool wiring

### DIFF
--- a/agent/src/main/kotlin/ru/souz/GraphBasedAgent.kt
+++ b/agent/src/main/kotlin/ru/souz/GraphBasedAgent.kt
@@ -6,6 +6,7 @@ import ru.souz.agent.AgentExecutionResult
 import ru.souz.agent.AgentStreamChunk
 import ru.souz.agent.GraphStepCallback
 import ru.souz.agent.TraceableAgent
+import ru.souz.agent.AgentCoreTools
 import ru.souz.agent.graph.Graph
 import ru.souz.agent.graph.Node
 import ru.souz.agent.graph.buildGraph
@@ -24,7 +25,6 @@ import ru.souz.agent.runtime.GraphExecutionDelegate
 import ru.souz.agent.state.AgentContext
 import ru.souz.agent.runtime.GraphExecutionDelegateImpl
 import ru.souz.llms.LLMResponse
-import ru.souz.llms.LLMToolSetup
 
 class GraphBasedAgent internal constructor(
     logObjectMapper: ObjectMapper,
@@ -37,11 +37,7 @@ class GraphBasedAgent internal constructor(
     private val nodesSkillInventory: NodesSkillInventory,
     private val nodesToolUseWithKnowledge: NodesToolUseWithKnowledge,
     private val nodesMemory: NodesMemory,
-    getSkillByNameTool: LLMToolSetup,
-    getKnowledgeTool: LLMToolSetup,
-    searchKnowledgeTool: LLMToolSetup,
-    searchMemoryTool: LLMToolSetup,
-    runtimeCommandTool: LLMToolSetup,
+    coreTools: AgentCoreTools,
     private val executionDelegate: GraphExecutionDelegate = GraphExecutionDelegateImpl(
         logObjectMapper = logObjectMapper,
         loggerClass = GraphBasedAgent::class.java,
@@ -49,8 +45,8 @@ class GraphBasedAgent internal constructor(
 ) : TraceableAgent {
 
     override val sideEffects: Flow<AgentStreamChunk> = nodesLLM.sideEffects
-    private val alwaysInlineResultTools = listOf(getSkillByNameTool, getKnowledgeTool, searchKnowledgeTool)
-    private val coreTools = alwaysInlineResultTools + searchMemoryTool + runtimeCommandTool
+    private val alwaysInlineResultTools = coreTools.graphAlwaysInlineResultTools
+    private val graphCoreTools = coreTools.graphCoreTools
 
     private val graph: Graph<String, String> = buildGraph(name = "Agent") {
         val chatSubgraph: Node<String, LLMResponse.Chat> = nodesLLM.chat("LLM")
@@ -62,7 +58,7 @@ class GraphBasedAgent internal constructor(
         val memoryRecall: Node<String, String> = nodesMemory.recall()
         val nodeClassify: Node<String, String> = nodesClassify.node(CLASSIFY_NODE_NAME)
         val nodeSkillInventory: Node<String, String> = nodesSkillInventory.node(
-            skillTools = coreTools,
+            skillTools = graphCoreTools,
             name = SKILL_INVENTORY_NODE_NAME,
         )
         val nodeMcp: Node<String, String> = nodesMCP.nodeProvideMcpTools("MCP Node")

--- a/agent/src/main/kotlin/ru/souz/SkillsGraphBasedAgent.kt
+++ b/agent/src/main/kotlin/ru/souz/SkillsGraphBasedAgent.kt
@@ -10,6 +10,7 @@ import ru.souz.agent.AgentExecutionResult
 import ru.souz.agent.AgentStreamChunk
 import ru.souz.agent.GraphStepCallback
 import ru.souz.agent.TraceableAgent
+import ru.souz.agent.AgentCoreTools
 import ru.souz.agent.graph.Graph
 import ru.souz.agent.graph.Node
 import ru.souz.agent.graph.buildGraph
@@ -27,7 +28,6 @@ import ru.souz.agent.runtime.GraphExecutionDelegate
 import ru.souz.agent.runtime.GraphExecutionDelegateImpl
 import ru.souz.agent.state.AgentContext
 import ru.souz.llms.LLMResponse
-import ru.souz.llms.LLMToolSetup
 
 /**
  * Agent graph whose model always sees only the core skill-discovery, Knowledge, and execution tools.
@@ -42,13 +42,7 @@ class SkillsGraphBasedAgent internal constructor(
     private val nodesMemory: NodesMemory,
     private val nodesSkillInventory: NodesSkillInventory,
     private val nodesToolUseWithKnowledge: NodesToolUseWithKnowledge,
-    getSkillByNameTool: LLMToolSetup,
-    getSkillsByCategoryTool: LLMToolSetup,
-    getSkillsNamesByCategoryTool: LLMToolSetup,
-    getKnowledgeTool: LLMToolSetup,
-    searchKnowledgeTool: LLMToolSetup,
-    searchMemoryTool: LLMToolSetup,
-    runtimeCommandTool: LLMToolSetup,
+    coreTools: AgentCoreTools,
     private val executionDelegate: GraphExecutionDelegate = GraphExecutionDelegateImpl(
         logObjectMapper = logObjectMapper,
         loggerClass = SkillsGraphBasedAgent::class.java,
@@ -56,14 +50,8 @@ class SkillsGraphBasedAgent internal constructor(
 ) : TraceableAgent {
     override val supportsActiveRunInput: Boolean = true
     override val sideEffects: Flow<AgentStreamChunk> = nodesLLM.sideEffects
-    private val alwaysInlineResultTools = listOf(
-        getSkillByNameTool,
-        getSkillsByCategoryTool,
-        getSkillsNamesByCategoryTool,
-        getKnowledgeTool,
-        searchKnowledgeTool,
-    )
-    private val coreTools = alwaysInlineResultTools + searchMemoryTool + runtimeCommandTool
+    private val alwaysInlineResultTools = coreTools.skillsAlwaysInlineResultTools
+    private val skillsCoreTools = coreTools.skillsCoreTools
     private val activeRun = MutableStateFlow<ActiveRunInputController?>(null)
 
     private fun graph(controller: ActiveRunInputController): Graph<String, String> = buildGraph(name = "Skills Agent") {
@@ -123,7 +111,7 @@ class SkillsGraphBasedAgent internal constructor(
         onStep: GraphStepCallback?,
     ): AgentExecutionResult {
         cancelActiveJob()
-        val restrictedContext = nodesSkillInventory.restrictToTools(ctx, coreTools)
+        val restrictedContext = nodesSkillInventory.restrictToTools(ctx, skillsCoreTools)
         val controller = ActiveRunInputController()
         val executionGraph = graph(controller)
         activeRun.value = controller

--- a/agent/src/main/kotlin/ru/souz/agent/AgentCoreTools.kt
+++ b/agent/src/main/kotlin/ru/souz/agent/AgentCoreTools.kt
@@ -1,0 +1,29 @@
+package ru.souz.agent
+
+import ru.souz.llms.LLMToolSetup
+
+internal class AgentCoreTools(
+    getSkillByName: LLMToolSetup,
+    getSkillsByCategory: LLMToolSetup,
+    getSkillsNamesByCategory: LLMToolSetup,
+    getKnowledge: LLMToolSetup,
+    searchKnowledge: LLMToolSetup,
+    searchMemory: LLMToolSetup,
+    runtimeCommand: LLMToolSetup,
+) {
+    val graphAlwaysInlineResultTools: List<LLMToolSetup> = listOf(
+        getSkillByName,
+        getKnowledge,
+        searchKnowledge,
+    )
+    val graphCoreTools: List<LLMToolSetup> = graphAlwaysInlineResultTools + searchMemory + runtimeCommand
+
+    val skillsAlwaysInlineResultTools: List<LLMToolSetup> = listOf(
+        getSkillByName,
+        getSkillsByCategory,
+        getSkillsNamesByCategory,
+        getKnowledge,
+        searchKnowledge,
+    )
+    val skillsCoreTools: List<LLMToolSetup> = skillsAlwaysInlineResultTools + searchMemory + runtimeCommand
+}

--- a/agent/src/main/kotlin/ru/souz/agent/AgentExecutionKernel.kt
+++ b/agent/src/main/kotlin/ru/souz/agent/AgentExecutionKernel.kt
@@ -76,6 +76,15 @@ class AgentExecutionKernelFactory(
         val nodesLLM = NodesLLM(llmApi = llmApi, settingsProvider = settingsProvider)
         val nodesErrorHandling = NodesErrorHandling(errorMessages)
         val nodesSummarization = NodesSummarization(llmApi = llmApi, nodesCommon = nodesCommon)
+        val coreTools = AgentCoreTools(
+            getSkillByName = getSkillByNameTool,
+            getSkillsByCategory = getSkillsByCategoryTool,
+            getSkillsNamesByCategory = getSkillsNamesByCategoryTool,
+            getKnowledge = getKnowledgeTool,
+            searchKnowledge = searchKnowledgeTool,
+            searchMemory = searchMemoryTool,
+            runtimeCommand = runtimeCommandTool,
+        )
         val availableAgents = listOf(AgentId.SKILLS_GRAPH)
         val contextFactory = AgentContextFactory(
             settingsProvider = settingsProvider,
@@ -92,13 +101,7 @@ class AgentExecutionKernelFactory(
             nodesMemory = nodesMemory,
             nodesSkillInventory = nodesSkillInventory,
             nodesToolUseWithKnowledge = nodesToolUseWithKnowledge,
-            getSkillByNameTool = getSkillByNameTool,
-            getSkillsByCategoryTool = getSkillsByCategoryTool,
-            getSkillsNamesByCategoryTool = getSkillsNamesByCategoryTool,
-            getKnowledgeTool = getKnowledgeTool,
-            searchKnowledgeTool = searchKnowledgeTool,
-            searchMemoryTool = searchMemoryTool,
-            runtimeCommandTool = runtimeCommandTool,
+            coreTools = coreTools,
         )
         val executor = AgentExecutor(
             agentProvider = { skillsGraphAgent },

--- a/agent/src/main/kotlin/ru/souz/agent/AgentModule.kt
+++ b/agent/src/main/kotlin/ru/souz/agent/AgentModule.kt
@@ -96,6 +96,17 @@ fun agentDiModule(
     }
     bindSingleton { SystemPromptResolver() }
     bindSingleton<AgentRuntimeEnvironment> { SystemAgentRuntimeEnvironment }
+    bindSingleton {
+        AgentCoreTools(
+            getSkillByName = instance(tag = SkillToolBindingTags.GET_SKILL_BY_NAME_TOOL),
+            getSkillsByCategory = instance(tag = SkillToolBindingTags.GET_SKILLS_BY_CATEGORY_TOOL),
+            getSkillsNamesByCategory = instance(tag = SkillToolBindingTags.GET_SKILLS_NAMES_BY_CATEGORY_TOOL),
+            getKnowledge = instance(tag = SkillToolBindingTags.GET_KNOWLEDGE_TOOL),
+            searchKnowledge = instance(tag = SkillToolBindingTags.SEARCH_KNOWLEDGE_TOOL),
+            searchMemory = instance(tag = SkillToolBindingTags.SEARCH_MEMORY_TOOL),
+            runtimeCommand = instance(tag = SkillToolBindingTags.RUNTIME_COMMAND_TOOL),
+        )
+    }
     bindSingleton { AgentContextFactory(instance(), instance(), instance()) }
     bindSingleton {
         GraphBasedAgent(
@@ -109,11 +120,7 @@ fun agentDiModule(
             nodesSkillInventory = instance(),
             nodesToolUseWithKnowledge = instance(),
             nodesMemory = instance(),
-            getSkillByNameTool = instance(tag = SkillToolBindingTags.GET_SKILL_BY_NAME_TOOL),
-            getKnowledgeTool = instance(tag = SkillToolBindingTags.GET_KNOWLEDGE_TOOL),
-            searchKnowledgeTool = instance(tag = SkillToolBindingTags.SEARCH_KNOWLEDGE_TOOL),
-            searchMemoryTool = instance(tag = SkillToolBindingTags.SEARCH_MEMORY_TOOL),
-            runtimeCommandTool = instance(tag = SkillToolBindingTags.RUNTIME_COMMAND_TOOL),
+            coreTools = instance(),
         )
     }
     bindSingleton {
@@ -126,13 +133,7 @@ fun agentDiModule(
             nodesMemory = instance(),
             nodesSkillInventory = instance(),
             nodesToolUseWithKnowledge = instance(),
-            getSkillByNameTool = instance(tag = SkillToolBindingTags.GET_SKILL_BY_NAME_TOOL),
-            getSkillsByCategoryTool = instance(tag = SkillToolBindingTags.GET_SKILLS_BY_CATEGORY_TOOL),
-            getSkillsNamesByCategoryTool = instance(tag = SkillToolBindingTags.GET_SKILLS_NAMES_BY_CATEGORY_TOOL),
-            getKnowledgeTool = instance(tag = SkillToolBindingTags.GET_KNOWLEDGE_TOOL),
-            searchKnowledgeTool = instance(tag = SkillToolBindingTags.SEARCH_KNOWLEDGE_TOOL),
-            searchMemoryTool = instance(tag = SkillToolBindingTags.SEARCH_MEMORY_TOOL),
-            runtimeCommandTool = instance(tag = SkillToolBindingTags.RUNTIME_COMMAND_TOOL),
+            coreTools = instance(),
         )
     }
     bindSingleton {

--- a/agent/src/test/kotlin/ru/souz/GraphBasedAgentTest.kt
+++ b/agent/src/test/kotlin/ru/souz/GraphBasedAgentTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.test.runTest
+import ru.souz.agent.AgentCoreTools
 import ru.souz.agent.nodes.CLASSIFY_NODE_NAME
 import ru.souz.agent.nodes.NodesClassification
 import ru.souz.agent.nodes.NodesCommon
@@ -49,6 +50,15 @@ class GraphBasedAgentTest {
         val searchKnowledgeTool = testTool("SearchKnowledge")
         val searchMemoryTool = testTool("SearchMemory")
         val runtimeCommandTool = testTool("RunSkillCommand")
+        val coreTools = AgentCoreTools(
+            getSkillByName = getSkillByNameTool,
+            getSkillsByCategory = testTool("GetSkillsByCategory"),
+            getSkillsNamesByCategory = testTool("GetSkillsNamesByCategory"),
+            getKnowledge = getKnowledgeTool,
+            searchKnowledge = searchKnowledgeTool,
+            searchMemory = searchMemoryTool,
+            runtimeCommand = runtimeCommandTool,
+        )
         val expectedCoreTools = listOf(
             getSkillByNameTool,
             getKnowledgeTool,
@@ -96,11 +106,7 @@ class GraphBasedAgentTest {
             nodesSkillInventory = nodesSkillInventory,
             nodesToolUseWithKnowledge = nodesToolUseWithKnowledge,
             nodesMemory = nodesMemory,
-            getSkillByNameTool = getSkillByNameTool,
-            getKnowledgeTool = getKnowledgeTool,
-            searchKnowledgeTool = searchKnowledgeTool,
-            searchMemoryTool = searchMemoryTool,
-            runtimeCommandTool = runtimeCommandTool,
+            coreTools = coreTools,
         )
         val expectedRun = listOf(
             "Input->History",

--- a/agent/src/test/kotlin/ru/souz/SkillsGraphBasedAgentMidRunInputTest.kt
+++ b/agent/src/test/kotlin/ru/souz/SkillsGraphBasedAgentMidRunInputTest.kt
@@ -26,7 +26,6 @@ import ru.souz.agent.state.AgentSettings
 import ru.souz.llms.LLMMessageRole
 import ru.souz.llms.LLMRequest
 import ru.souz.llms.LLMResponse
-import ru.souz.llms.LLMToolSetup
 import ru.souz.llms.restJsonMapper
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -370,13 +369,7 @@ private class Harness(
             nodesMemory = nodesMemory,
             nodesSkillInventory = nodesSkillInventory,
             nodesToolUseWithKnowledge = nodesToolUse,
-            getSkillByNameTool = tool("GetSkillByName"),
-            getSkillsByCategoryTool = tool("GetSkillsByCategory"),
-            getSkillsNamesByCategoryTool = tool("GetSkillsNamesByCategory"),
-            getKnowledgeTool = tool("GetKnowledge"),
-            searchKnowledgeTool = tool("SearchKnowledge"),
-            searchMemoryTool = tool("SearchMemory"),
-            runtimeCommandTool = tool("RunSkillCommand"),
+            coreTools = testCoreTools(),
         )
     }
 
@@ -433,14 +426,3 @@ private fun functionCall(): LLMResponse.FunctionCall =
 
 private fun responseContent(response: LLMResponse.Chat.Ok): String =
     response.choices.lastOrNull()?.message?.content.orEmpty()
-
-private fun tool(name: String): LLMToolSetup = object : LLMToolSetup {
-    override val fn = LLMRequest.Function(
-        name = name,
-        description = name,
-        parameters = LLMRequest.Parameters("object", emptyMap()),
-    )
-
-    override suspend fun invoke(functionCall: LLMResponse.FunctionCall): LLMRequest.Message =
-        LLMRequest.Message(LLMMessageRole.function, "{}", name = name)
-}

--- a/agent/src/test/kotlin/ru/souz/SkillsGraphBasedAgentTest.kt
+++ b/agent/src/test/kotlin/ru/souz/SkillsGraphBasedAgentTest.kt
@@ -5,6 +5,7 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.test.runTest
+import ru.souz.agent.AgentCoreTools
 import ru.souz.agent.graph.Node
 import ru.souz.agent.nodes.NodesSkillInventory
 import ru.souz.agent.nodes.NodesCommon
@@ -160,13 +161,7 @@ class SkillsGraphBasedAgentTest {
             nodesCommon = nodesCommon,
             knowledgeStore = null,
         ),
-        getSkillByNameTool = testTool("GetSkillByName"),
-        getSkillsByCategoryTool = testTool("GetSkillsByCategory"),
-        getSkillsNamesByCategoryTool = testTool("GetSkillsNamesByCategory"),
-        getKnowledgeTool = testTool("GetKnowledge"),
-        searchKnowledgeTool = testTool("SearchKnowledge"),
-        searchMemoryTool = testTool("SearchMemory"),
-        runtimeCommandTool = testTool("RunSkillCommand"),
+        coreTools = testCoreTools(),
     )
 
     private fun passthrough(name: String, executed: MutableList<String>) = Node<String, String>(name) { ctx ->
@@ -288,6 +283,16 @@ class SkillsGraphBasedAgentTest {
         """.trimIndent()
     }
 }
+
+internal fun testCoreTools(): AgentCoreTools = AgentCoreTools(
+    getSkillByName = testTool("GetSkillByName"),
+    getSkillsByCategory = testTool("GetSkillsByCategory"),
+    getSkillsNamesByCategory = testTool("GetSkillsNamesByCategory"),
+    getKnowledge = testTool("GetKnowledge"),
+    searchKnowledge = testTool("SearchKnowledge"),
+    searchMemory = testTool("SearchMemory"),
+    runtimeCommand = testTool("RunSkillCommand"),
+)
 
 internal fun testTool(name: String): LLMToolSetup = object : LLMToolSetup {
     override val fn = LLMRequest.Function(name, name, LLMRequest.Parameters("object", emptyMap()))

--- a/backend/src/test/kotlin/ru/souz/backend/e2e/BackendPublicWebSocketE2eTest.kt
+++ b/backend/src/test/kotlin/ru/souz/backend/e2e/BackendPublicWebSocketE2eTest.kt
@@ -291,7 +291,7 @@ class BackendPublicWebSocketE2eTest {
             val cancelStatus = readJson(session)
             val terminal = readJson(session)
             assertEquals("accepted", cancelAck["status"].asText())
-            assertEquals("cancelling", cancelStatus["status"].asText())
+            assertTrue(cancelStatus["status"].asText() in setOf("cancelling", "cancelled"))
             assertEquals("thread.cancelled", terminal["type"].asText())
 
             session.send(


### PR DESCRIPTION
## Summary
 add an internal AgentCoreTools helper for the ordered classic and skills graph core tool lists
 wire AgentModule and AgentExecutionKernelFactory through the helper
 update agent tests to reuse the shared core-tool setup
 allow cancellation status feedback to observe either cancelling or cancelled, matching the durable-status race

## Verification
```
 ./gradlew :backend:test
 20 repeated executions of the client-tool cancellation scenario
 ./gradlew test :sharedLogic:allTests :sharedUI:allTests :koverXmlReport :koverHtmlReport koverLog -Psouz.coverage --no-parallel
 ./gradlew souzGateFast
 npm ci --prefix quality
 ./gradlew souzDuplicationCheck
 git diff --check
```