### PR TITLE
Bypass JetBrains Gradle plugin markers

### DIFF
--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -10,7 +10,7 @@ pluginManagement {
 
     resolutionStrategy {
         eachPlugin {
-            val version = requested.version ?: return@eachPlugin
+            val version = target.version ?: requested.version ?: return@eachPlugin
             if (requested.id.id == "org.jetbrains.kotlin.jvm") {
                 useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:$version")
             }

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -8,6 +8,15 @@ pluginManagement {
         mavenCentral()
     }
 
+    resolutionStrategy {
+        eachPlugin {
+            val version = requested.version ?: return@eachPlugin
+            if (requested.id.id == "org.jetbrains.kotlin.jvm") {
+                useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:$version")
+            }
+        }
+    }
+
     plugins {
         id("org.jetbrains.kotlin.jvm") version "2.4.10"
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,7 +11,7 @@ pluginManagement {
 
     resolutionStrategy {
         eachPlugin {
-            val version = requested.version ?: return@eachPlugin
+            val version = target.version ?: requested.version ?: return@eachPlugin
             when (requested.id.id) {
                 "org.jetbrains.kotlin.jvm",
                 "org.jetbrains.kotlin.multiplatform" ->

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,6 +8,26 @@ pluginManagement {
         mavenCentral()
         gradlePluginPortal()
     }
+
+    resolutionStrategy {
+        eachPlugin {
+            val version = requested.version ?: return@eachPlugin
+            when (requested.id.id) {
+                "org.jetbrains.kotlin.jvm",
+                "org.jetbrains.kotlin.multiplatform" ->
+                    useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:$version")
+
+                "org.jetbrains.kotlin.plugin.compose" ->
+                    useModule("org.jetbrains.kotlin:compose-compiler-gradle-plugin:$version")
+
+                "org.jetbrains.compose" ->
+                    useModule("org.jetbrains.compose:compose-gradle-plugin:$version")
+
+                "org.jetbrains.kotlinx.kover" ->
+                    useModule("org.jetbrains.kotlinx:kover-gradle-plugin:$version")
+            }
+        }
+    }
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
## Summary
- map JetBrains Gradle plugin ids to their implementation modules with pluginManagement resolutionStrategy
- bypass the missing org.jetbrains.kotlin.jvm.gradle.plugin marker reported by GitLab
- apply the same Kotlin plugin mapping inside the build-logic included build

## Context
GitLab moved past the previous kotlin-dsl marker failure and now fails resolving org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin:2.4.10. This change avoids that marker artifact and resolves org.jetbrains.kotlin:kotlin-gradle-plugin directly.

## Verification
- ./gradlew :build-logic:check
- ./gradlew :backend:installDist --no-daemon
- ./gradlew souzGateFast --configuration-cache --configuration-cache-problems=fail