### PR TITLE
Revert Gradle plugin marker bypasses

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.jetbrains.kotlin.jvm")
+    `kotlin-dsl`
     `java-gradle-plugin`
 }
 

--- a/build-logic/detekt-rules/build.gradle.kts
+++ b/build-logic/detekt-rules/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.jetbrains.kotlin.jvm")
+    kotlin("jvm")
 }
 
 group = "ru.souz.build"

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -8,15 +8,6 @@ pluginManagement {
         mavenCentral()
     }
 
-    resolutionStrategy {
-        eachPlugin {
-            val version = target.version ?: requested.version ?: return@eachPlugin
-            if (requested.id.id == "org.jetbrains.kotlin.jvm") {
-                useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:$version")
-            }
-        }
-    }
-
     plugins {
         id("org.jetbrains.kotlin.jvm") version "2.4.10"
     }

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -7,10 +7,6 @@ pluginManagement {
         gradlePluginPortal()
         mavenCentral()
     }
-
-    plugins {
-        id("org.jetbrains.kotlin.jvm") version "2.4.10"
-    }
 }
 
 dependencyResolutionManagement {

--- a/build-logic/src/main/kotlin/ru/souz/build/quality/SouzDuplicationTask.kt
+++ b/build-logic/src/main/kotlin/ru/souz/build/quality/SouzDuplicationTask.kt
@@ -106,11 +106,11 @@ abstract class SouzDuplicationTask @Inject constructor(
                 "Pinned jscpd is not installed; run 'npm ci --prefix quality' from the repository root."
             }
             val threshold = DuplicationRatchet.thresholds.getValue(scope)
-            execOperations.exec { spec ->
-                spec.workingDir(repository)
-                spec.executable(binary)
-                spec.args(roots.map { it.relativeInvariantPath(repository) })
-                spec.args(
+            execOperations.exec {
+                workingDir(repository)
+                executable(binary)
+                args(roots.map { it.relativeInvariantPath(repository) })
+                args(
                     "--config", configFile.get().asFile.relativeInvariantPath(repository),
                     "--min-lines", threshold.minLines.toString(),
                     "--min-tokens", threshold.minTokens.toString(),

--- a/build-logic/src/main/kotlin/ru/souz/build/quality/SouzQualityPlugin.kt
+++ b/build-logic/src/main/kotlin/ru/souz/build/quality/SouzQualityPlugin.kt
@@ -3,13 +3,10 @@ package ru.souz.build.quality
 import dev.detekt.gradle.Detekt
 import dev.detekt.gradle.DetektCreateBaselineTask
 import dev.detekt.gradle.extensions.DetektExtension
-import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.tasks.TaskProvider
 
 class SouzQualityPlugin : Plugin<Project> {
     override fun apply(project: Project) {
@@ -36,7 +33,7 @@ class SouzQualityPlugin : Plugin<Project> {
             edgeInputs.finalizeValue()
         }
 
-        val policyFiles = project.fileTree(repository).apply {
+        val policyFiles = project.fileTree(repository) {
             include("**/AGENTS.md")
             include("docs/pain-points.md")
             include("**/docs/pain-points.md")
@@ -50,69 +47,54 @@ class SouzQualityPlugin : Plugin<Project> {
             exclude("native/third_party/**")
         }
 
-        val report = project.tasks.register(
-            "souzGateFastReport",
-            SouzGateFastTask::class.java,
-            Action { task ->
-                task.repositoryDirectory.set(project.layout.projectDirectory)
-                task.projectDescriptors.set(descriptors.map(ProjectDescriptor::encode))
-                task.dependencyEdges.set(edgeInputs)
-                task.policyFiles.from(policyFiles)
-                task.detektReports.from(detektReportFiles)
-                task.jsonReport.set(project.layout.buildDirectory.file("reports/souz-quality/fast/gate-summary-v1.json"))
-                task.markdownReport.set(project.layout.buildDirectory.file("reports/souz-quality/fast/gate-summary.md"))
-                task.doNotTrackState("The report records current Git identity and worktree state.")
-            },
-        )
-        val gate = project.tasks.register(
-            "souzGateFast",
-            Action { task ->
-                task.group = "verification"
-                task.description = "Runs exact, local-safe Souz repository, module, and coroutine checks."
-                task.finalizedBy(report)
-            },
-        )
+        val report = project.tasks.register("souzGateFastReport", SouzGateFastTask::class.java) {
+            repositoryDirectory.set(project.layout.projectDirectory)
+            projectDescriptors.set(descriptors.map(ProjectDescriptor::encode))
+            dependencyEdges.set(edgeInputs)
+            this.policyFiles.from(policyFiles)
+            detektReports.from(detektReportFiles)
+            jsonReport.set(project.layout.buildDirectory.file("reports/souz-quality/fast/gate-summary-v1.json"))
+            markdownReport.set(project.layout.buildDirectory.file("reports/souz-quality/fast/gate-summary.md"))
+            doNotTrackState("The report records current Git identity and worktree state.")
+        }
+        val gate = project.tasks.register("souzGateFast") {
+            group = "verification"
+            description = "Runs exact, local-safe Souz repository, module, and coroutine checks."
+            finalizedBy(report)
+        }
 
         configureDetekt(project, gate, report, detektReportFiles)
 
-        project.tasks.register(
-            "souzDuplicationCheck",
-            SouzDuplicationTask::class.java,
-            Action { task ->
-                task.group = "verification"
-                task.description = "Checks production and test Kotlin duplication against the jscpd baseline."
-                task.repositoryDirectory.set(project.layout.projectDirectory)
-                task.projectDescriptors.set(descriptors.map(ProjectDescriptor::encode))
-                task.configFile.set(project.layout.projectDirectory.file("quality/jscpd.json"))
-                task.packageFile.set(project.layout.projectDirectory.file("quality/package.json"))
-                task.baselineFile.set(project.layout.projectDirectory.file("quality/duplication-baseline.json"))
-                task.jsonReport.set(project.layout.buildDirectory.file("reports/souz-quality/expensive/gate-summary-v1.json"))
-                task.markdownReport.set(project.layout.buildDirectory.file("reports/souz-quality/expensive/gate-summary.md"))
-                task.updateBaseline.set(false)
-                task.doNotTrackState("The check records current Git identity and invokes the pinned jscpd binary.")
-            },
-        )
-        project.tasks.register(
-            "updateSouzDuplicationBaseline",
-            SouzDuplicationTask::class.java,
-            Action { task ->
-                task.group = "verification"
-                task.description = "Updates the reviewed production and test jscpd duplication baseline."
-                task.repositoryDirectory.set(project.layout.projectDirectory)
-                task.projectDescriptors.set(descriptors.map(ProjectDescriptor::encode))
-                task.configFile.set(project.layout.projectDirectory.file("quality/jscpd.json"))
-                task.packageFile.set(project.layout.projectDirectory.file("quality/package.json"))
-                task.baselineFile.set(project.layout.projectDirectory.file("quality/duplication-baseline.json"))
-                task.updateBaseline.set(true)
-                task.doNotTrackState("Baseline updates are explicit reviewed mutations.")
-            },
-        )
+        project.tasks.register("souzDuplicationCheck", SouzDuplicationTask::class.java) {
+            group = "verification"
+            description = "Checks production and test Kotlin duplication against the jscpd baseline."
+            repositoryDirectory.set(project.layout.projectDirectory)
+            projectDescriptors.set(descriptors.map(ProjectDescriptor::encode))
+            configFile.set(project.layout.projectDirectory.file("quality/jscpd.json"))
+            packageFile.set(project.layout.projectDirectory.file("quality/package.json"))
+            baselineFile.set(project.layout.projectDirectory.file("quality/duplication-baseline.json"))
+            jsonReport.set(project.layout.buildDirectory.file("reports/souz-quality/expensive/gate-summary-v1.json"))
+            markdownReport.set(project.layout.buildDirectory.file("reports/souz-quality/expensive/gate-summary.md"))
+            updateBaseline.set(false)
+            doNotTrackState("The check records current Git identity and invokes the pinned jscpd binary.")
+        }
+        project.tasks.register("updateSouzDuplicationBaseline", SouzDuplicationTask::class.java) {
+            group = "verification"
+            description = "Updates the reviewed production and test jscpd duplication baseline."
+            repositoryDirectory.set(project.layout.projectDirectory)
+            projectDescriptors.set(descriptors.map(ProjectDescriptor::encode))
+            configFile.set(project.layout.projectDirectory.file("quality/jscpd.json"))
+            packageFile.set(project.layout.projectDirectory.file("quality/package.json"))
+            baselineFile.set(project.layout.projectDirectory.file("quality/duplication-baseline.json"))
+            updateBaseline.set(true)
+            doNotTrackState("Baseline updates are explicit reviewed mutations.")
+        }
     }
 
     private fun configureDetekt(
         project: Project,
-        gate: TaskProvider<Task>,
-        report: TaskProvider<SouzGateFastTask>,
+        gate: org.gradle.api.tasks.TaskProvider<org.gradle.api.Task>,
+        report: org.gradle.api.tasks.TaskProvider<SouzGateFastTask>,
         reportFiles: ConfigurableFileCollection,
     ) {
         val configFile = project.layout.projectDirectory.file("quality/detekt.yml")
@@ -123,13 +105,12 @@ class SouzQualityPlugin : Plugin<Project> {
         val updateBaseline = project.tasks.register(
             "updateSouzCoroutineBaseline",
             UpdateSouzCoroutineBaselineTask::class.java,
-            Action { task ->
-                task.group = "verification"
-                task.description = "Updates the reviewed module- and analysis-scoped coroutine baselines."
-                task.repositoryDirectory.set(project.layout.projectDirectory)
-                task.baselines.set(baselineDirectory)
-            },
-        )
+        ) {
+            group = "verification"
+            description = "Updates the reviewed module- and analysis-scoped coroutine baselines."
+            repositoryDirectory.set(project.layout.projectDirectory)
+            baselines.set(baselineDirectory)
+        }
 
         project.subprojects.forEach { subproject ->
             var configured = false
@@ -139,57 +120,54 @@ class SouzQualityPlugin : Plugin<Project> {
                     val rulesJarTask = project.gradle.includedBuild("build-logic").task(":detekt-rules:jar")
                     subproject.pluginManager.apply("dev.detekt")
                     subproject.dependencies.add("detektPlugins", subproject.files(rulesJar))
-                    subproject.extensions.configure(
-                        DetektExtension::class.java,
-                        Action { extension ->
-                            extension.toolVersion.set("2.0.0-alpha.6")
-                            extension.config.setFrom(configFile)
-                            extension.basePath.set(project.layout.projectDirectory)
-                            extension.buildUponDefaultConfig.set(false)
-                            extension.allRules.set(false)
-                            extension.disableDefaultRuleSets.set(false)
-                            extension.ignoreFailures.set(true)
-                            extension.parallel.set(true)
-                        },
-                    )
+                    subproject.extensions.configure(DetektExtension::class.java) {
+                        toolVersion.set("2.0.0-alpha.6")
+                        config.setFrom(configFile)
+                        basePath.set(project.layout.projectDirectory)
+                        buildUponDefaultConfig.set(false)
+                        allRules.set(false)
+                        disableDefaultRuleSets.set(false)
+                        ignoreFailures.set(true)
+                        parallel.set(true)
+                    }
 
                     val analysisTasks = subproject.tasks.withType(Detekt::class.java)
                         .matching { task -> task.name != "detekt" && !task.name.endsWith("SourceSet") }
-                    analysisTasks.configureEach { task ->
-                        task.dependsOn(rulesJarTask)
-                        task.exclude("**/generated/resources/**")
+                    analysisTasks.configureEach {
+                        dependsOn(rulesJarTask)
+                        exclude("**/generated/resources/**")
                         val projectPath = subproject.projectDir.relativeInvariantPath(
                             project.layout.projectDirectory.asFile
                         )
-                        val analysis = task.name.removePrefix("detekt").replaceFirstChar(Char::lowercase)
-                        task.baseline.set(baselineDirectory.file("$projectPath/$analysis.xml"))
-                        task.reports.checkstyle.required.set(true)
-                        task.reports.html.required.set(false)
-                        task.reports.markdown.required.set(false)
-                        task.reports.sarif.required.set(false)
-                        val checkstyleReport = task.reports.checkstyle.outputLocation
+                        val analysis = name.removePrefix("detekt").replaceFirstChar(Char::lowercase)
+                        baseline.set(baselineDirectory.file("$projectPath/$analysis.xml"))
+                        reports.checkstyle.required.set(true)
+                        reports.html.required.set(false)
+                        reports.markdown.required.set(false)
+                        reports.sarif.required.set(false)
+                        val checkstyleReport = reports.checkstyle.outputLocation
                         reportFiles.from(
                             project.provider {
-                                if (task.source.isEmpty) emptyList() else listOf(checkstyleReport.get().asFile)
+                                if (source.isEmpty) emptyList() else listOf(checkstyleReport.get().asFile)
                             }
                         )
-                        task.finalizedBy(report)
+                        finalizedBy(report)
                     }
-                    gate.configure { task -> task.dependsOn(analysisTasks) }
+                    gate.configure { dependsOn(analysisTasks) }
 
                     val baselineTasks = subproject.tasks.withType(DetektCreateBaselineTask::class.java)
                         .matching { task -> task.name != "detektBaseline" && !task.name.endsWith("SourceSet") }
-                    baselineTasks.configureEach { task ->
-                        task.dependsOn(rulesJarTask)
-                        task.baseline.set(
-                            subproject.layout.buildDirectory.file("reports/detekt/baselines/${task.name}.xml")
+                    baselineTasks.configureEach {
+                        dependsOn(rulesJarTask)
+                        baseline.set(
+                            subproject.layout.buildDirectory.file("reports/detekt/baselines/$name.xml")
                         )
-                        task.exclude("**/generated/resources/**")
-                        val partialBaseline = task.baseline
-                        task.doFirst { partialBaseline.get().asFile.delete() }
-                        updateBaseline.configure { baselineTask -> baselineTask.partialBaselines.from(partialBaseline) }
+                        exclude("**/generated/resources/**")
+                        val partialBaseline = baseline
+                        doFirst { partialBaseline.get().asFile.delete() }
+                        updateBaseline.configure { partialBaselines.from(partialBaseline) }
                     }
-                    updateBaseline.configure { task -> task.dependsOn(baselineTasks) }
+                    updateBaseline.configure { dependsOn(baselineTasks) }
                 }
             }
             subproject.pluginManager.withPlugin("org.jetbrains.kotlin.jvm") { configure() }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,26 +8,6 @@ pluginManagement {
         mavenCentral()
         gradlePluginPortal()
     }
-
-    resolutionStrategy {
-        eachPlugin {
-            val version = target.version ?: requested.version ?: return@eachPlugin
-            when (requested.id.id) {
-                "org.jetbrains.kotlin.jvm",
-                "org.jetbrains.kotlin.multiplatform" ->
-                    useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:$version")
-
-                "org.jetbrains.kotlin.plugin.compose" ->
-                    useModule("org.jetbrains.kotlin:compose-compiler-gradle-plugin:$version")
-
-                "org.jetbrains.compose" ->
-                    useModule("org.jetbrains.compose:compose-gradle-plugin:$version")
-
-                "org.jetbrains.kotlinx.kover" ->
-                    useModule("org.jetbrains.kotlinx:kover-gradle-plugin:$version")
-            }
-        }
-    }
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
Reverts the temporary Gradle plugin resolution changes from:

- #694 / `dc874840` (`build: remove build-logic kotlin-dsl plugin`)
- #695 / `48b812a1` (`Bypass JetBrains Gradle plugin markers`)

The company GitLab build now resolves through the configured Nexus repositories, so this PR tests whether the marker bypasses can be removed cleanly.