### PR TITLE
Configure web tool User-Agent for HTTP proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,9 @@ ENABLE_BACKEND_TG_FEATURE=true
 LOG_LEVEL=INFO
 SOUZ_LOG_DIR=${HOME}/.local/state/souz/logs
 
+# Optional proxy-allowlisted User-Agent for outbound web tools.
+SOUZ_WEB_USER_AGENT=ProxyApprovedClient/1.0
+
 # Telegram bot
 SOUZ_TELEGRAM_POLLING_MAX_CONCURRENCY=4
 # Generate once with: openssl rand -base64 32
@@ -516,7 +519,7 @@ SOUZ_BACKEND_DB_MAX_POOL_SIZE=10
 SOUZ_BACKEND_DB_CONNECTION_TIMEOUT_MS=30000
 ```
 
-The server host must not be blank, and the port must be between `1` and `65535`; invalid values fail configuration validation during startup. `POSTGRES_DSN` must be a PostgreSQL JDBC URL and, when set, replaces `SOUZ_BACKEND_DB_HOST`, `SOUZ_BACKEND_DB_PORT`, and `SOUZ_BACKEND_DB_NAME`; user and password still come from `SOUZ_BACKEND_DB_USER` and `SOUZ_BACKEND_DB_PASSWORD`. `SOUZ_MASTER_KEY` is required for backend startup. Backend Logback writes human-readable console logs and rolling one-line JSON records under `SOUZ_LOG_DIR`/`LOG_DIR`, including timestamp, level, logger, thread, message, formatted message, MDC, SLF4J key-value pairs, and throwable details. `TELEGRAM_TOKEN_ENCRYPTION_KEY` is required when the Telegram bot feature is enabled and must be Base64 that decodes to exactly 32 bytes; generate one with `openssl rand -base64 32`. Without `SOUZ_BACKEND_PROXY_TOKEN`, public routes remain available but `/v1/**` requests return `backend_misconfigured`.
+The server host must not be blank, and the port must be between `1` and `65535`; invalid values fail configuration validation during startup. `POSTGRES_DSN` must be a PostgreSQL JDBC URL and, when set, replaces `SOUZ_BACKEND_DB_HOST`, `SOUZ_BACKEND_DB_PORT`, and `SOUZ_BACKEND_DB_NAME`; user and password still come from `SOUZ_BACKEND_DB_USER` and `SOUZ_BACKEND_DB_PASSWORD`. `SOUZ_MASTER_KEY` is required for backend startup. Backend Logback writes human-readable console logs and rolling one-line JSON records under `SOUZ_LOG_DIR`/`LOG_DIR`, including timestamp, level, logger, thread, message, formatted message, MDC, SLF4J key-value pairs, and throwable details. `SOUZ_WEB_USER_AGENT` overrides the browser-like default sent by web tools, including the HTTPS CONNECT request when a JVM HTTP proxy is selected. `TELEGRAM_TOKEN_ENCRYPTION_KEY` is required when the Telegram bot feature is enabled and must be Base64 that decodes to exactly 32 bytes; generate one with `openssl rand -base64 32`. Without `SOUZ_BACKEND_PROXY_TOKEN`, public routes remain available but `/v1/**` requests return `backend_misconfigured`.
 
 Backend executions snapshot each user's effective `enabledTools`. The snapshot filters compiled tool-backed Skills once and is retained when an execution resumes from an option. Built-in Client-Souz Skills are merged afterward only for public client executions. The backend model sees only Skill core tools and reaches catalog capabilities through inventory, discovery, and `RunSkillCommand`.
 

--- a/sharedLogic/src/commonJvmMain/kotlin/ru/souz/tool/web/internal/WebHttpSupport.kt
+++ b/sharedLogic/src/commonJvmMain/kotlin/ru/souz/tool/web/internal/WebHttpSupport.kt
@@ -6,10 +6,10 @@ import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.HttpRequestRetry
 import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.ktor.client.plugins.HttpTimeout
-import io.ktor.client.request.HttpRequest
-import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.plugins.timeout
+import io.ktor.client.request.HttpRequest
+import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.statement.HttpResponse
@@ -17,16 +17,20 @@ import io.ktor.client.statement.bodyAsChannel
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
-import kotlinx.coroutines.CancellationException
-import io.ktor.utils.io.ByteReadChannel
-import io.ktor.utils.io.readAvailable
-import ru.souz.tool.BadInputException
-import java.io.ByteArrayOutputStream
-import java.io.IOException
-import java.time.ZonedDateTime
-import java.time.format.DateTimeFormatter
 import io.ktor.util.AttributeKey
 import io.ktor.util.Attributes
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.readAvailable
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.net.Proxy
+import java.net.ProxySelector
+import java.net.URI
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import kotlinx.coroutines.CancellationException
+import org.slf4j.LoggerFactory
+import ru.souz.tool.BadInputException
 
 private const val WEB_HTTP_CONNECT_TIMEOUT_MILLIS = 6_000L
 private const val WEB_HTTP_INITIAL_RETRY_DELAY_MILLIS = 2_000L
@@ -35,6 +39,7 @@ private const val WEB_HTTP_MAX_RETRIES = 2
 private const val WEB_HTTP_DEFAULT_MAX_BINARY_BYTES = 20 * 1024 * 1024
 private const val WEB_HTTP_BINARY_READ_CHUNK_BYTES = 8_192
 private val WEB_HTTP_RETRY_ENABLED_KEY = AttributeKey<Boolean>("web_http_retry_enabled")
+private val webHttpLogger = LoggerFactory.getLogger(WebHttpSupport::class.java)
 private val defaultSharedWebHttpClient by lazy {
     val webToolSupport = WebToolSupport()
     HttpClient(CIO) { WebHttpSupport.applyDefaults(this, webToolSupport) }
@@ -151,8 +156,10 @@ class WebHttpSupport(
         } catch (e: CancellationException) {
             throw e
         } catch (e: HttpRequestTimeoutException) {
+            logWebRequestFailure(url, webToolSupport.userAgent, e)
             throw BadInputException("HTTP request timed out for $url")
         } catch (e: IOException) {
+            logWebRequestFailure(url, webToolSupport.userAgent, e)
             val message = e.message?.takeIf { it.isNotBlank() } ?: e.javaClass.simpleName
             throw BadInputException("HTTP request failed for $url: $message")
         } catch (e: IllegalArgumentException) {
@@ -193,6 +200,29 @@ class WebHttpSupport(
         }
     }
 }
+
+private fun logWebRequestFailure(url: String, userAgent: String, error: Exception) {
+    val host = runCatching { URI.create(url).host }
+        .getOrNull()
+        ?.takeIf { it.isNotBlank() }
+        ?: "unknown"
+    webHttpLogger.warn(
+        "Web HTTP request failed host={} route={} userAgent={}",
+        host,
+        selectedProxyRoute(url),
+        userAgent,
+        error,
+    )
+}
+
+private fun selectedProxyRoute(url: String): String = runCatching {
+    val proxy = ProxySelector.getDefault()?.select(URI.create(url))?.firstOrNull()
+    when {
+        proxy == null -> "UNKNOWN"
+        proxy.type() == Proxy.Type.DIRECT -> "DIRECT"
+        else -> "${proxy.type()} ${proxy.address() ?: "unknown"}"
+    }
+}.getOrElse { "UNKNOWN (${it.javaClass.simpleName})" }
 
 private fun isRetryEnabled(request: HttpRequest): Boolean = isRetryEnabled(request.attributes)
 

--- a/sharedLogic/src/commonJvmMain/kotlin/ru/souz/tool/web/internal/WebToolSupport.kt
+++ b/sharedLogic/src/commonJvmMain/kotlin/ru/souz/tool/web/internal/WebToolSupport.kt
@@ -2,9 +2,13 @@ package ru.souz.tool.web.internal
 
 import ru.souz.tool.BadInputException
 
-class WebToolSupport {
-    val userAgent: String =
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36"
+private const val WEB_USER_AGENT_ENV = "SOUZ_WEB_USER_AGENT"
+private const val DEFAULT_WEB_USER_AGENT =
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36"
+
+class WebToolSupport(
+    val userAgent: String = configuredWebUserAgent(),
+) {
 
     val acceptHeader: String = "text/html,application/json;q=0.9,*/*;q=0.8"
 
@@ -24,3 +28,7 @@ class WebToolSupport {
 
     fun toSafeHttpUrl(raw: String): String = raw.replace(" ", "%20")
 }
+
+private fun configuredWebUserAgent(): String =
+    System.getenv(WEB_USER_AGENT_ENV)?.trim()?.takeIf { it.isNotEmpty() }
+        ?: DEFAULT_WEB_USER_AGENT

--- a/sharedLogic/src/test/kotlin/ru/souz/tool/web/WebHttpSupportTest.kt
+++ b/sharedLogic/src/test/kotlin/ru/souz/tool/web/WebHttpSupportTest.kt
@@ -1,16 +1,43 @@
 package ru.souz.tool.web
 
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
 import io.ktor.utils.io.ByteReadChannel
 import kotlinx.coroutines.test.runTest
 import ru.souz.tool.BadInputException
 import ru.souz.tool.web.internal.WebHttpSupport
+import ru.souz.tool.web.internal.WebToolSupport
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class WebHttpSupportTest {
     private val webHttpSupport = WebHttpSupport()
+
+    @Test
+    fun `configured user agent is sent by the web client`() = runTest {
+        var observedUserAgent: String? = null
+        val webToolSupport = WebToolSupport(userAgent = "ProxyApprovedClient/1.0")
+        val client = HttpClient(
+            MockEngine { request ->
+                observedUserAgent = request.headers[HttpHeaders.UserAgent]
+                respond("ok")
+            },
+        ) {
+            WebHttpSupport.applyDefaults(this, webToolSupport)
+        }
+
+        try {
+            WebHttpSupport(webToolSupport, client).getText("https://example.com", timeoutMillis = 1_000L)
+            assertEquals("ProxyApprovedClient/1.0", observedUserAgent)
+        } finally {
+            client.close()
+        }
+    }
 
     @Test
     fun `read limited binary body returns bytes within limit`() = runTest {


### PR DESCRIPTION
## Summary

- allow overriding the web-tool User-Agent with `SOUZ_WEB_USER_AGENT`
- retain the existing browser-like User-Agent when the variable is unset
- log the destination host, selected proxy route, configured agent, and throwable when web transport fails
- cover the configured request header with a focused test

## Motivation

Some HTTP proxies require an approved User-Agent on HTTPS CONNECT requests. Ktor CIO forwards the web request's User-Agent to CONNECT, but Souz previously used a fixed browser agent.

## Deployment

Set `SOUZ_WEB_USER_AGENT` to the proxy-approved value in the deployment configuration. Deployment-specific Helm values are maintained outside this tracked diff.

## Verification

- `./gradlew :sharedLogic:jvmTest --tests 'ru.souz.tool.web.*'`
- `./gradlew :sharedLogic:jvmTest`
- `./gradlew souzGateFast`
- `git diff --check`