### PR TITLE
Add a dedicated, message-only LLM provider for context-window compaction

### DIFF
--- a/agent/src/main/kotlin/ru/souz/agent/AgentExecutionKernel.kt
+++ b/agent/src/main/kotlin/ru/souz/agent/AgentExecutionKernel.kt
@@ -23,6 +23,7 @@ import ru.souz.agent.spi.AgentToolsFilter
 import ru.souz.agent.spi.DefaultBrowserProvider
 import ru.souz.llms.LLMChatAPI
 import ru.souz.llms.LLMToolSetup
+import ru.souz.llms.LlmMessageApi
 import ru.souz.memory.ConversationMemoryRuntime
 import ru.souz.memory.NoopConversationMemoryRuntime
 
@@ -53,6 +54,7 @@ class AgentExecutionKernelFactory(
     private val llmApi: LLMChatAPI,
     private val memoryRuntime: ConversationMemoryRuntime = NoopConversationMemoryRuntime,
     private val captureScope: CoroutineScope,
+    private val compactionLlmApi: LlmMessageApi? = null,
 ) {
     fun create(): AgentExecutionKernel {
         val agentToolExecutor = AgentToolExecutor(telemetry)
@@ -75,7 +77,11 @@ class AgentExecutionKernelFactory(
         val nodesMemory = NodesMemory(memoryRuntime = memoryRuntime, captureScope = captureScope)
         val nodesLLM = NodesLLM(llmApi = llmApi, settingsProvider = settingsProvider)
         val nodesErrorHandling = NodesErrorHandling(errorMessages)
-        val nodesSummarization = NodesSummarization(llmApi = llmApi, nodesCommon = nodesCommon)
+        val nodesSummarization = NodesSummarization(
+            llmApi = llmApi,
+            nodesCommon = nodesCommon,
+            compactionLlmApi = compactionLlmApi,
+        )
         val coreTools = AgentCoreTools(
             getSkillByName = getSkillByNameTool,
             getSkillsByCategory = getSkillsByCategoryTool,

--- a/agent/src/main/kotlin/ru/souz/agent/nodes/NodesSummarization.kt
+++ b/agent/src/main/kotlin/ru/souz/agent/nodes/NodesSummarization.kt
@@ -12,6 +12,7 @@ import ru.souz.llms.LLMRequest
 import ru.souz.llms.LLMResponse
 import ru.souz.llms.LLMChatAPI
 import ru.souz.llms.LLMResponse.FinishReason
+import ru.souz.llms.LlmMessageApi
 import ru.souz.llms.toMessage
 import ru.souz.llms.toSystemPromptMessage
 import kotlin.math.ceil
@@ -22,6 +23,7 @@ import kotlin.math.ceil
 internal class NodesSummarization(
     private val llmApi: LLMChatAPI,
     private val nodesCommon: NodesCommon,
+    private val compactionLlmApi: LlmMessageApi? = null,
 ) {
     private val l = LoggerFactory.getLogger(NodesSummarization::class.java)
 
@@ -57,7 +59,7 @@ internal class NodesSummarization(
                     )
                 }
                 val request = ctx.toGigaRequest(conversation).copy(functions = emptyList())
-                llmApi.message(request)
+                (compactionLlmApi ?: llmApi).message(request)
             }
 
             when (summaryResponse) {

--- a/backend/src/main/kotlin/ru/souz/backend/agent/runtime/conversation/BackendConversationRuntimeFactory.kt
+++ b/backend/src/main/kotlin/ru/souz/backend/agent/runtime/conversation/BackendConversationRuntimeFactory.kt
@@ -25,6 +25,7 @@ import ru.souz.db.SettingsProvider
 import ru.souz.llms.LLMChatAPI
 import ru.souz.llms.LLMResponse
 import ru.souz.llms.LLMToolSetup
+import ru.souz.llms.LlmMessageApi
 import ru.souz.llms.LlmProvider
 import ru.souz.llms.anthropic.AnthropicVisionGateway
 import ru.souz.llms.codex.CodexOAuthService
@@ -67,6 +68,7 @@ internal class BackendConversationRuntimeFactory(
     private val searchMemoryTool: LLMToolSetup,
     private val knowledgeStore: ConversationKnowledgeStore,
     private val agentBackgroundScope: CoroutineScope,
+    private val compactionLlmApi: LlmMessageApi? = null,
     private val testLlmApiFactory: (suspend (SettingsProvider) -> LLMChatAPI)? = null,
 ) {
     internal suspend fun create(
@@ -191,6 +193,7 @@ internal class BackendConversationRuntimeFactory(
             errorMessages = BackendAgentErrorMessages,
             llmApi = executionApi,
             captureScope = agentBackgroundScope,
+            compactionLlmApi = compactionLlmApi,
         ).create()
         return BackendConversationRuntime(
             key = key,

--- a/backend/src/main/kotlin/ru/souz/backend/app/BackendAppConfig.kt
+++ b/backend/src/main/kotlin/ru/souz/backend/app/BackendAppConfig.kt
@@ -63,6 +63,13 @@ data class BackendProviderRetryPolicy(
     }
 }
 
+data class BackendSummarizationLlmConfig(
+    val apiUrl: String,
+    val apiKey: String,
+    val model: String,
+    val reasoningEffort: String? = null,
+)
+
 data class BackendServerConfig(
     val host: String,
     val port: Int,
@@ -139,6 +146,7 @@ data class BackendAppConfig(
     val telegramPollingMaxConcurrency: Int = 4,
     val skillOAuthTokenEncryptionKey: String? = null,
     val skillOAuthProviderCredentials: Map<String, SkillOAuthProviderCredentials> = emptyMap(),
+    val summarizationLlm: BackendSummarizationLlmConfig? = null,
     val llmLimits: BackendLlmLimits = BackendLlmLimits(),
     val providerRetryPolicy: BackendProviderRetryPolicy = BackendProviderRetryPolicy(),
 ) {
@@ -223,6 +231,7 @@ data class BackendAppConfig(
                         null
                     }
                 }.toMap(),
+                summarizationLlm = source.summarizationLlmConfig(),
                 llmLimits = BackendLlmLimits(
                     perUserConcurrentExecutions = source.intValue(
                         envKey = "SOUZ_BACKEND_LIMIT_PER_USER_CONCURRENT_EXECUTIONS",
@@ -326,6 +335,35 @@ private fun BackendConfigSource.postgresConfig(): BackendPostgresConfig {
         ),
         dsn = dsn,
     )
+}
+
+private fun BackendConfigSource.summarizationLlmConfig(): BackendSummarizationLlmConfig? {
+    val apiUrl = value(
+        envKey = "SUMMARIZATION_LLM_API_URL",
+        propertyKey = "souz.summarizationLlm.apiUrl",
+    )?.trim()?.takeIf { it.isNotEmpty() }
+    val apiKey = value(
+        envKey = "SUMMARIZATION_LLM_API_KEY",
+        propertyKey = "souz.summarizationLlm.apiKey",
+    )?.trim()?.takeIf { it.isNotEmpty() }
+    val model = value(
+        envKey = "SUMMARIZATION_LLM_MODEL",
+        propertyKey = "souz.summarizationLlm.model",
+    )?.trim()?.takeIf { it.isNotEmpty() }
+    val reasoningEffort = value(
+        envKey = "SUMMARIZATION_LLM_REASONING_EFFORT",
+        propertyKey = "souz.summarizationLlm.reasoningEffort",
+    )?.trim()?.takeIf { it.isNotEmpty() }
+
+    if (apiUrl == null && apiKey == null && model == null) return null
+    if (apiUrl == null || apiKey == null || model == null) {
+        throw BackendConfigurationException(
+            "SUMMARIZATION_LLM_API_URL / souz.summarizationLlm.apiUrl, " +
+                "SUMMARIZATION_LLM_API_KEY / souz.summarizationLlm.apiKey and " +
+                "SUMMARIZATION_LLM_MODEL / souz.summarizationLlm.model must be set together."
+        )
+    }
+    return BackendSummarizationLlmConfig(apiUrl, apiKey, model, reasoningEffort)
 }
 
 private fun BackendConfigSource.stringValue(

--- a/backend/src/main/kotlin/ru/souz/backend/app/BackendDiModule.kt
+++ b/backend/src/main/kotlin/ru/souz/backend/app/BackendDiModule.kt
@@ -55,6 +55,7 @@ import ru.souz.backend.http.BackendHttpDependencies
 import ru.souz.backend.keys.repository.UserProviderKeyRepository
 import ru.souz.backend.keys.service.UserProviderKeyService
 import ru.souz.backend.llm.ProviderCredentialResolver
+import ru.souz.backend.llm.RetryingLlmMessageApi
 import ru.souz.backend.llm.StoredProviderCredentialResolver
 import ru.souz.backend.llm.quota.ExecutionQuotaManager
 import ru.souz.backend.onboarding.BackendOnboardingService
@@ -81,10 +82,12 @@ import ru.souz.backend.storage.postgres.PostgresUserSettingsRepository
 import ru.souz.backend.toolcall.repository.ToolCallRepository
 import ru.souz.backend.user.repository.UserRepository
 import ru.souz.db.SettingsProvider
+import ru.souz.llms.LlmMessageApi
 import ru.souz.llms.codex.CodexOAuthService
 import ru.souz.llms.http.ProviderHttpClients
 import ru.souz.llms.local.LocalChatAPI
 import ru.souz.llms.local.LocalProviderAvailability
+import ru.souz.llms.openai.OpenAICompatibleMessageAPI
 import ru.souz.runtime.di.runtimeCoreDiModule
 import ru.souz.runtime.di.runtimeLocalLlmDiModule
 import ru.souz.runtime.di.runtimeProviderHttpDiModule
@@ -104,9 +107,10 @@ import ru.souz.tool.portableSkillRuntimeToolsDiModule
 import ru.souz.tool.skills.SkillCommandExecutor
 import ru.souz.tool.web.internal.WebResearchClient
 
-private object BackendDiTags {
+internal object BackendDiTags {
     const val LOG_OBJECT_MAPPER = "backendLogObjectMapper"
     const val MERGED_TOOL_CATALOG = "backendMergedToolCatalog"
+    const val COMPACTION_LLM_API = "backendCompactionLlmApi"
 }
 
 /** Backend Kodein module that wires HTTP services to the shared JVM runtime. */
@@ -242,6 +246,20 @@ fun backendDiModule(
             eventService = instance(),
         )
     }
+    appConfig.summarizationLlm?.let { summarizationLlm ->
+        bindSingleton<LlmMessageApi>(tag = BackendDiTags.COMPACTION_LLM_API) {
+            RetryingLlmMessageApi(
+                delegate = OpenAICompatibleMessageAPI(
+                    client = instance<ProviderHttpClients>().standard,
+                    apiKey = summarizationLlm.apiKey,
+                    baseUrl = summarizationLlm.apiUrl,
+                    model = summarizationLlm.model,
+                    reasoningEffort = summarizationLlm.reasoningEffort,
+                ),
+                retryPolicy = appConfig.providerRetryPolicy,
+            )
+        }
+    }
     bindSingleton {
         BackendConversationRuntimeFactory(
             baseSettingsProvider = instance(),
@@ -265,6 +283,7 @@ fun backendDiModule(
             searchMemoryTool = instance(tag = SkillToolBindingTags.SEARCH_MEMORY_TOOL),
             knowledgeStore = instance<ConversationKnowledgeStore>(),
             agentBackgroundScope = instance<BackendApplicationScope>(),
+            compactionLlmApi = instanceOrNull<LlmMessageApi>(tag = BackendDiTags.COMPACTION_LLM_API),
         )
     }
     bindSingleton {

--- a/backend/src/main/kotlin/ru/souz/backend/llm/BackendExecutionLlmChatApi.kt
+++ b/backend/src/main/kotlin/ru/souz/backend/llm/BackendExecutionLlmChatApi.kt
@@ -1,7 +1,6 @@
 package ru.souz.backend.llm
 
 import java.io.File
-import kotlin.math.min
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -51,7 +50,9 @@ internal class BackendExecutionLlmChatApi(
             is ModelResolution.Resolved -> resolution.value
             else -> return unsupportedChatModel(resolution)
         }
-        val response = retryChat { apiFor(model.provider).message(body.copy(model = model.alias)) }
+        val response = retryChat(retryPolicy, delayMillis) {
+            apiFor(model.provider).message(body.copy(model = model.alias))
+        }
         recordUsage(response)
         return response
     }
@@ -160,19 +161,6 @@ internal class BackendExecutionLlmChatApi(
             ?: error("Missing configured credential for provider $provider.")
     }
 
-    private suspend fun retryChat(request: suspend () -> LLMResponse.Chat): LLMResponse.Chat {
-        var attempt = 0
-        while (true) {
-            val response = request()
-            if (response !is LLMResponse.Chat.Error || response.status != TOO_MANY_REQUESTS) {
-                return response
-            }
-            if (attempt == retryPolicy.max429Retries) return response
-            delayMillis(backoffForAttempt(attempt, response.message))
-            attempt += 1
-        }
-    }
-
     private fun retryingStream(api: LLMChatAPI, body: LLMRequest.Chat): Flow<LLMResponse.Chat> = flow {
         var attempt = 0
         while (true) {
@@ -183,7 +171,7 @@ internal class BackendExecutionLlmChatApi(
                     if (
                         !emitted &&
                         response is LLMResponse.Chat.Error &&
-                        response.status == TOO_MANY_REQUESTS &&
+                        response.status == HTTP_TOO_MANY_REQUESTS &&
                         attempt < retryPolicy.max429Retries
                     ) {
                         throw RetryFirstStreaming429(response)
@@ -193,7 +181,7 @@ internal class BackendExecutionLlmChatApi(
                 }
                 return@flow
             } catch (retry: RetryFirstStreaming429) {
-                delayMillis(backoffForAttempt(attempt, retry.error.message))
+                delayMillis(backoffForAttempt(retryPolicy, attempt, retry.error.message))
                 attempt += 1
             }
         }
@@ -218,12 +206,6 @@ internal class BackendExecutionLlmChatApi(
         usageMutex.withLock { usage = usage.plus(response.usage) }
     }
 
-    private fun backoffForAttempt(attempt: Int, message: String): Long {
-        val retryAfter = RETRY_AFTER.find(message)?.groupValues?.getOrNull(1)?.toLongOrNull()
-        if (retryAfter != null) return min(retryAfter, retryPolicy.backoffMaxMs)
-        return min(retryPolicy.backoffBaseMs * (attempt + 1), retryPolicy.backoffMaxMs)
-    }
-
     private fun unsupportedChatModel(resolution: ModelResolution<*>): LLMResponse.Chat.Error =
         LLMResponse.Chat.Error(-1, "Unsupported backend chat model: ${resolution.description()}.")
 
@@ -231,8 +213,6 @@ internal class BackendExecutionLlmChatApi(
         LLMResponse.Embeddings.Error(-1, "Unsupported backend embeddings model: ${resolution.description()}.")
 
     private companion object {
-        const val TOO_MANY_REQUESTS = 429
-        val RETRY_AFTER = Regex("""retry-after=(\d+)""", RegexOption.IGNORE_CASE)
         val ZERO_USAGE = LLMResponse.Usage(0, 0, 0, 0)
     }
 }

--- a/backend/src/main/kotlin/ru/souz/backend/llm/RetryChat.kt
+++ b/backend/src/main/kotlin/ru/souz/backend/llm/RetryChat.kt
@@ -1,0 +1,46 @@
+package ru.souz.backend.llm
+
+import kotlin.math.min
+import kotlinx.coroutines.delay
+import ru.souz.backend.app.BackendProviderRetryPolicy
+import ru.souz.llms.LLMRequest
+import ru.souz.llms.LLMResponse
+import ru.souz.llms.LlmMessageApi
+
+internal const val HTTP_TOO_MANY_REQUESTS = 429
+
+private val RETRY_AFTER = Regex("""retry-after=(\d+)""", RegexOption.IGNORE_CASE)
+
+/** Retries [request] on HTTP 429 per [retryPolicy], honoring a `retry-after=<seconds>` hint in the error message. */
+internal suspend fun retryChat(
+    retryPolicy: BackendProviderRetryPolicy,
+    delayMillis: suspend (Long) -> Unit,
+    request: suspend () -> LLMResponse.Chat,
+): LLMResponse.Chat {
+    var attempt = 0
+    while (true) {
+        val response = request()
+        if (response !is LLMResponse.Chat.Error || response.status != HTTP_TOO_MANY_REQUESTS) {
+            return response
+        }
+        if (attempt == retryPolicy.max429Retries) return response
+        delayMillis(backoffForAttempt(retryPolicy, attempt, response.message))
+        attempt += 1
+    }
+}
+
+internal fun backoffForAttempt(retryPolicy: BackendProviderRetryPolicy, attempt: Int, message: String): Long {
+    val retryAfter = RETRY_AFTER.find(message)?.groupValues?.getOrNull(1)?.toLongOrNull()
+    if (retryAfter != null) return min(retryAfter, retryPolicy.backoffMaxMs)
+    return min(retryPolicy.backoffBaseMs * (attempt + 1), retryPolicy.backoffMaxMs)
+}
+
+/** Wraps a message-only LLM client with the same 429 retry/backoff as [BackendExecutionLlmChatApi]. */
+internal class RetryingLlmMessageApi(
+    private val delegate: LlmMessageApi,
+    private val retryPolicy: BackendProviderRetryPolicy,
+    private val delayMillis: suspend (Long) -> Unit = { delay(it) },
+) : LlmMessageApi {
+    override suspend fun message(body: LLMRequest.Chat): LLMResponse.Chat =
+        retryChat(retryPolicy, delayMillis) { delegate.message(body) }
+}

--- a/backend/src/test/kotlin/ru/souz/backend/app/BackendDiModuleTest.kt
+++ b/backend/src/test/kotlin/ru/souz/backend/app/BackendDiModuleTest.kt
@@ -32,6 +32,7 @@ import ru.souz.llms.http.ProviderHttpClients
 import ru.souz.llms.http.GigaHttpClientResource
 import ru.souz.llms.giga.GigaAuth
 import ru.souz.llms.giga.GigaRestChatAPI
+import ru.souz.backend.llm.RetryingLlmMessageApi
 import ru.souz.backend.llm.quota.ExecutionQuotaManager
 import ru.souz.backend.settings.repository.BackendServerPreferenceStore
 import ru.souz.backend.settings.repository.UserSettingsRepository
@@ -51,6 +52,7 @@ import ru.souz.backend.telegram.TelegramBotBindingRepository
 import ru.souz.backend.telegram.TelegramBotBindingService
 import ru.souz.backend.user.repository.UserRepository
 import ru.souz.llms.LLMToolSetup
+import ru.souz.llms.LlmMessageApi
 import ru.souz.skills.registry.FileSystemSkillRegistryRepository
 import ru.souz.tool.ToolCategory
 import ru.souz.tool.skills.SkillCommandExecutor
@@ -161,6 +163,39 @@ class BackendDiModuleTest {
             )
         } finally {
             di.direct.instance<BackendRuntimeResources>().close()
+        }
+    }
+
+    @Test
+    fun `compaction llm api is not bound when summarization llm is not configured`() {
+        val dataSource = HikariDataSource()
+        val di = testDi(testAppConfig(), dataSource)
+
+        try {
+            assertNull(di.direct.instanceOrNull<LlmMessageApi>(tag = BackendDiTags.COMPACTION_LLM_API))
+        } finally {
+            dataSource.close()
+        }
+    }
+
+    @Test
+    fun `compaction llm api is bound with retry when summarization llm is configured`() {
+        val appConfig = testAppConfig().copy(
+            summarizationLlm = BackendSummarizationLlmConfig(
+                apiUrl = "https://openrouter.ai/api/v1",
+                apiKey = "test-summarization-key",
+                model = "google/gemini-3.7-flash",
+            ),
+        )
+        val dataSource = HikariDataSource()
+        val di = testDi(appConfig, dataSource)
+
+        try {
+            assertIs<RetryingLlmMessageApi>(
+                di.direct.instance<LlmMessageApi>(tag = BackendDiTags.COMPACTION_LLM_API)
+            )
+        } finally {
+            dataSource.close()
         }
     }
 

--- a/backend/src/test/kotlin/ru/souz/backend/config/BackendFeatureFlagsTest.kt
+++ b/backend/src/test/kotlin/ru/souz/backend/config/BackendFeatureFlagsTest.kt
@@ -11,6 +11,7 @@ import ru.souz.backend.app.BackendLlmLimits
 import ru.souz.backend.app.BackendPostgresConfig
 import ru.souz.backend.app.BackendProviderRetryPolicy
 import ru.souz.backend.app.BackendServerConfig
+import ru.souz.backend.app.BackendSummarizationLlmConfig
 import ru.souz.backend.common.BackendConfigurationException
 
 class BackendFeatureFlagsTest {
@@ -319,6 +320,76 @@ class BackendAppConfigTest {
 
         assertTrue(invalidLimit.message.orEmpty().contains("requests"))
         assertTrue(invalidRetry.message.orEmpty().contains("429"))
+    }
+
+    @Test
+    fun `summarization llm config is absent when unset`() {
+        val config = BackendAppConfig.load(
+            MapBackendConfigSource(
+                env = mapOf("SOUZ_MASTER_KEY" to "test-master-key"),
+            )
+        ).validate()
+
+        assertNull(config.summarizationLlm)
+    }
+
+    @Test
+    fun `summarization llm config reads url, key, model and optional reasoning effort together`() {
+        val config = BackendAppConfig.load(
+            MapBackendConfigSource(
+                env = mapOf(
+                    "SOUZ_MASTER_KEY" to "test-master-key",
+                    "SUMMARIZATION_LLM_API_URL" to "https://openrouter.ai/api/v1",
+                    "SUMMARIZATION_LLM_API_KEY" to "test-summarization-key",
+                    "SUMMARIZATION_LLM_MODEL" to "google/gemini-3.7-flash",
+                    "SUMMARIZATION_LLM_REASONING_EFFORT" to "low",
+                ),
+            )
+        ).validate()
+
+        assertEquals(
+            BackendSummarizationLlmConfig(
+                apiUrl = "https://openrouter.ai/api/v1",
+                apiKey = "test-summarization-key",
+                model = "google/gemini-3.7-flash",
+                reasoningEffort = "low",
+            ),
+            config.summarizationLlm,
+        )
+    }
+
+    @Test
+    fun `summarization llm config omits reasoning effort when not set`() {
+        val config = BackendAppConfig.load(
+            MapBackendConfigSource(
+                env = mapOf(
+                    "SOUZ_MASTER_KEY" to "test-master-key",
+                    "SUMMARIZATION_LLM_API_URL" to "https://openrouter.ai/api/v1",
+                    "SUMMARIZATION_LLM_API_KEY" to "test-summarization-key",
+                    "SUMMARIZATION_LLM_MODEL" to "google/gemini-3.7-flash",
+                ),
+            )
+        ).validate()
+
+        assertNull(config.summarizationLlm?.reasoningEffort)
+    }
+
+    @Test
+    fun `summarization llm config requires url, key and model together`() {
+        val error = assertFailsWith<BackendConfigurationException> {
+            BackendAppConfig.load(
+                MapBackendConfigSource(
+                    env = mapOf(
+                        "SOUZ_MASTER_KEY" to "test-master-key",
+                        "SUMMARIZATION_LLM_API_URL" to "https://openrouter.ai/api/v1",
+                    ),
+                )
+            )
+        }
+
+        assertTrue(error.message.orEmpty().contains("SUMMARIZATION_LLM_API_URL"))
+        assertTrue(error.message.orEmpty().contains("SUMMARIZATION_LLM_API_KEY"))
+        assertTrue(error.message.orEmpty().contains("SUMMARIZATION_LLM_MODEL"))
     }
 }
 

--- a/llms/src/main/kotlin/ru/souz/llms/LLMChatAPI.kt
+++ b/llms/src/main/kotlin/ru/souz/llms/LLMChatAPI.kt
@@ -3,8 +3,7 @@ package ru.souz.llms
 import java.io.File
 import kotlinx.coroutines.flow.Flow
 
-interface LLMChatAPI {
-    suspend fun message(body: LLMRequest.Chat): LLMResponse.Chat
+interface LLMChatAPI : LlmMessageApi {
     suspend fun messageStream(body: LLMRequest.Chat): Flow<LLMResponse.Chat>
     suspend fun embeddings(body: LLMRequest.Embeddings): LLMResponse.Embeddings
     suspend fun uploadFile(file: File): LLMResponse.UploadFile

--- a/llms/src/main/kotlin/ru/souz/llms/LlmMessageApi.kt
+++ b/llms/src/main/kotlin/ru/souz/llms/LlmMessageApi.kt
@@ -1,0 +1,6 @@
+package ru.souz.llms
+
+/** Minimal chat capability: a single non-streaming request/response call. */
+interface LlmMessageApi {
+    suspend fun message(body: LLMRequest.Chat): LLMResponse.Chat
+}

--- a/sharedLogic/src/commonJvmMain/kotlin/ru/souz/llms/openai/OpenAICompatibleMessageAPI.kt
+++ b/sharedLogic/src/commonJvmMain/kotlin/ru/souz/llms/openai/OpenAICompatibleMessageAPI.kt
@@ -1,0 +1,103 @@
+package ru.souz.llms.openai
+
+import com.fasterxml.jackson.databind.JsonNode
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.ClientRequestException
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.contentType
+import io.ktor.http.isSuccess
+import kotlinx.coroutines.CancellationException
+import org.slf4j.LoggerFactory
+import ru.souz.llms.LLMMessageRole
+import ru.souz.llms.LLMRequest
+import ru.souz.llms.LLMResponse
+import ru.souz.llms.LlmMessageApi
+
+/**
+ * Narrow OpenAI-compatible client pinned to a single fixed model on a single fixed endpoint —
+ * message-only, no streaming/tools/embeddings. Used as the optional dedicated LLM for
+ * context-window compaction (see `NodesSummarization`), never for general conversation, so it
+ * deliberately stays outside the LlmProvider/OpenAICompatibleChatAPI machinery, which is scoped
+ * per-conversation-provider and not meant for a fixed background task.
+ */
+class OpenAICompatibleMessageAPI(
+    private val client: HttpClient,
+    private val apiKey: String,
+    baseUrl: String,
+    private val model: String,
+    private val reasoningEffort: String? = null,
+) : LlmMessageApi {
+    private val l = LoggerFactory.getLogger(OpenAICompatibleMessageAPI::class.java)
+    private val baseUrl = baseUrl.trimEnd('/')
+
+    override suspend fun message(body: LLMRequest.Chat): LLMResponse.Chat = try {
+        val response = client.post("$baseUrl/chat/completions") {
+            header(HttpHeaders.Authorization, "Bearer $apiKey")
+            contentType(ContentType.Application.Json)
+            setBody(buildRequestBody(body))
+        }
+        if (!response.status.isSuccess()) {
+            LLMResponse.Chat.Error(response.status.value, response.bodyAsText())
+        } else {
+            parseResponse(response.body<JsonNode>())
+        }
+    } catch (e: ClientRequestException) {
+        LLMResponse.Chat.Error(e.response.status.value, e.response.bodyAsText())
+    } catch (cancellation: CancellationException) {
+        throw cancellation
+    } catch (e: Exception) {
+        l.error("OpenAI-compatible message call failed", e)
+        LLMResponse.Chat.Error(-1, "OpenAI-compatible API error: ${e.message}")
+    }
+
+    private fun buildRequestBody(body: LLMRequest.Chat): Map<String, Any?> = buildMap {
+        put("model", model)
+        put("messages", body.messages.map { it.toOpenAiMessage() })
+        reasoningEffort?.let { put("reasoning", mapOf("effort" to it)) }
+        put("stream", false)
+    }
+
+    private fun LLMRequest.Message.toOpenAiMessage(): Map<String, String> = when (role) {
+        LLMMessageRole.system -> mapOf("role" to "system", "content" to content)
+        LLMMessageRole.user -> mapOf("role" to "user", "content" to content)
+        LLMMessageRole.assistant, LLMMessageRole.function_in_progress ->
+            mapOf("role" to "assistant", "content" to content)
+        // Compaction is a one-shot text call, never a tool loop — fold tool output into a
+        // plain assistant-authored note instead of dealing with tool_call_id bookkeeping.
+        LLMMessageRole.function ->
+            mapOf("role" to "assistant", "content" to "[${name ?: "tool"}]\n$content")
+    }
+
+    private fun parseResponse(node: JsonNode): LLMResponse.Chat {
+        val choiceNode = node.path("choices").firstOrNull()
+            ?: return LLMResponse.Chat.Error(-1, "No choices in response: $node")
+        val usageNode = node.path("usage")
+        return LLMResponse.Chat.Ok(
+            choices = listOf(
+                LLMResponse.Choice(
+                    message = LLMResponse.Message(
+                        content = choiceNode.path("message").path("content").asText(""),
+                        role = LLMMessageRole.assistant,
+                        functionsStateId = null,
+                    ),
+                    index = 0,
+                    finishReason = LLMResponse.FinishReason.stop,
+                )
+            ),
+            created = node.path("created").asLong(System.currentTimeMillis() / 1000),
+            model = model,
+            usage = LLMResponse.Usage(
+                promptTokens = usageNode.path("prompt_tokens").asInt(0),
+                completionTokens = usageNode.path("completion_tokens").asInt(0),
+                totalTokens = usageNode.path("total_tokens").asInt(0),
+                precachedTokens = 0,
+            ),
+        )
+    }
+}

--- a/sharedLogic/src/test/kotlin/ru/souz/llms/openai/OpenAICompatibleMessageAPITest.kt
+++ b/sharedLogic/src/test/kotlin/ru/souz/llms/openai/OpenAICompatibleMessageAPITest.kt
@@ -1,0 +1,125 @@
+package ru.souz.llms.openai
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.toByteArray
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.headersOf
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
+import ru.souz.llms.LLMMessageRole
+import ru.souz.llms.LLMRequest
+import ru.souz.llms.http.providerHttpClientDefaults
+import ru.souz.llms.restJsonMapper
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class OpenAICompatibleMessageAPITest {
+
+    @Test
+    fun `trailing slash in base url does not produce a double slash path`() = runTest {
+        var requestedUrl: String? = null
+        val client = HttpClient(
+            MockEngine { request ->
+                requestedUrl = request.url.toString()
+                respond(OK_RESPONSE, headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()))
+            },
+        ) {
+            providerHttpClientDefaults()
+        }
+        val api = OpenAICompatibleMessageAPI(
+            client = client,
+            apiKey = "test-key",
+            baseUrl = "https://openrouter.ai/api/v1/",
+            model = "google/gemini-3.7-flash",
+        )
+
+        api.message(chatRequest())
+
+        assertEquals("https://openrouter.ai/api/v1/chat/completions", requestedUrl)
+        client.close()
+    }
+
+    @Test
+    fun `reasoning field is omitted by default`() = runTest {
+        var requestBody: String? = null
+        val client = HttpClient(
+            MockEngine { request ->
+                requestBody = String(request.body.toByteArray())
+                respond(OK_RESPONSE, headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()))
+            },
+        ) {
+            providerHttpClientDefaults()
+        }
+        val api = OpenAICompatibleMessageAPI(
+            client = client,
+            apiKey = "test-key",
+            baseUrl = "https://example.test/v1",
+            model = "some-model",
+        )
+
+        api.message(chatRequest())
+
+        val node = restJsonMapper.readTree(requestBody)
+        assertFalse(node.has("reasoning"))
+        client.close()
+    }
+
+    @Test
+    fun `reasoning field is included when configured`() = runTest {
+        var requestBody: String? = null
+        val client = HttpClient(
+            MockEngine { request ->
+                requestBody = String(request.body.toByteArray())
+                respond(OK_RESPONSE, headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()))
+            },
+        ) {
+            providerHttpClientDefaults()
+        }
+        val api = OpenAICompatibleMessageAPI(
+            client = client,
+            apiKey = "test-key",
+            baseUrl = "https://example.test/v1",
+            model = "some-model",
+            reasoningEffort = "low",
+        )
+
+        api.message(chatRequest())
+
+        val node = restJsonMapper.readTree(requestBody)
+        assertTrue(node.has("reasoning"))
+        assertEquals("low", node.path("reasoning").path("effort").asText())
+        client.close()
+    }
+
+    @Test
+    fun `message propagates cancellation instead of returning an error`() = runTest {
+        val client = HttpClient(MockEngine { throw CancellationException("cancelled") }) {
+            providerHttpClientDefaults()
+        }
+        val api = OpenAICompatibleMessageAPI(
+            client = client,
+            apiKey = "test-key",
+            baseUrl = "https://example.test/v1",
+            model = "some-model",
+        )
+
+        assertFailsWith<CancellationException> { api.message(chatRequest()) }
+        client.close()
+    }
+
+    private fun chatRequest() = LLMRequest.Chat(
+        model = "unused",
+        messages = listOf(LLMRequest.Message(LLMMessageRole.user, "hello")),
+    )
+
+    private companion object {
+        const val OK_RESPONSE =
+            """{"choices":[{"message":{"content":"hi"}}],"created":1,"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}"""
+    }
+}


### PR DESCRIPTION
NodesSummarization currently reuses the same LLMChatAPI as the ongoing conversation for its "MEMORY DUMP" compaction call, so compaction latency and cost track whatever provider the user happens to be chatting through.

Adds LlmMessageApi, a minimal one-method chat interface split out of LLMChatAPI, and OpenAICompatibleMessageAPI, a message-only OpenAI-compatible client with no fixed provider defaults (base URL, model and optional reasoning effort all come from config). NodesSummarization and AgentExecutionKernelFactory take it as an optional second LLM, defaulting to the primary llmApi so behavior is unchanged unless SUMMARIZATION_LLM_* is configured on the backend. The compaction call goes through the same 429 retry/backoff as regular conversation calls (extracted from BackendExecutionLlmChatApi into a shared retryChat helper), it just isn't folded into per-user cumulativeUsage since it's billed under its own operator-provided key rather than the user's own provider quota.