### PR TITLE
Support device.mcp.* tool-call contract

### DIFF
--- a/backend/src/main/resources/skills/client/device-mcp-call-tool/SKILL.md
+++ b/backend/src/main/resources/skills/client/device-mcp-call-tool/SKILL.md
@@ -34,7 +34,8 @@ The result preserves MCP's own two-level error model exactly:
   {"content":[{"type":"text","text":"level must be between 0 and 10"}],"isError":true}
   ```
   Treat this exactly like a normal tool response: read `content[]` (each item's `type` is `text`,
-  `image`, or `resource`; non-text items carry `data`/`mimeType`) and `isError`, and tell the user
+  `image`, or `resource`; `image` items carry `data`/`mimeType` directly, `resource` items carry a
+  nested `resource` object with `uri` and either `text` or `blob`) and `isError`, and tell the user
   what actually happened — don't report this as a Skill/tool-call failure.
 - **The call itself never reached the operation** (target unreachable, tool name doesn't exist,
   arguments don't satisfy `inputSchema`, timeout) → `RunSkillCommand` reports a `ClientError`:

--- a/backend/src/main/resources/skills/client/device-mcp-call-tool/SKILL.md
+++ b/backend/src/main/resources/skills/client/device-mcp-call-tool/SKILL.md
@@ -40,8 +40,8 @@ The result preserves MCP's own two-level error model exactly:
 - **The call itself never reached the operation** (target unreachable, tool name doesn't exist,
   arguments don't satisfy `inputSchema`, timeout) → `RunSkillCommand` reports a `ClientError`:
   `device_not_connected`, `device_disconnected`, `device_timeout`, `mcp_target_not_found`,
-  `mcp_tool_not_found`, `mcp_invalid_arguments`. If the Skill reports missing client context, no
-  active public WebSocket device is available for this execution.
+  `mcp_server_unreachable`, `mcp_tool_not_found`, `mcp_invalid_arguments`. If the Skill reports
+  missing client context, no active public WebSocket device is available for this execution.
 
 Only claim the operation succeeded when you see `isError: false` (or absent) in the result — a
 `ClientError` here means the operation's actual outcome is unknown, not that it failed to run.

--- a/backend/src/main/resources/skills/client/device-mcp-call-tool/SKILL.md
+++ b/backend/src/main/resources/skills/client/device-mcp-call-tool/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: device-mcp-call-tool
+description: Perform an action or read a setting on a device (its own OS/app function — e.g. set the volume, read a network setting), reachable via the user's active client device. Use for any request to control or query a specific device once you know (or have looked up with device.mcp.list_tools) which function to use and its arguments.
+metadata:
+  souz.skill-id: device.mcp.call_tool
+  souz.transport: client-websocket
+  souz.category: APPLICATIONS
+  souz.timeout: PT1M
+---
+
+# Call an MCP tool on a device
+
+Invoke `RunSkillCommand` with `skillId` set to `device.mcp.call_tool`. Arguments:
+- `target`: optional device `id` from `device.mcp.list_devices`. Omit it to mean "the device
+  currently on the call".
+- `name`: required, the exact MCP tool name (from `device.mcp.list_tools`).
+- `arguments`: object matching that tool's `inputSchema` exactly.
+
+```json
+{"skillId":"device.mcp.call_tool","arguments":{"target":"a1b2c3","name":"set_volume","arguments":{"level":7}}}
+```
+
+Souz sends a durable `tool.call.started` event named `device.mcp.call_tool` to the active client
+device and waits up to one minute for `tool.result`. Don't pass a timeout — there is none to give;
+the emulator applies its own internal budget for this call.
+
+## Two kinds of failure — don't collapse them
+
+The result preserves MCP's own two-level error model exactly:
+
+- **The tool ran but the operation itself failed** (e.g. requested volume out of range, file not
+  found) → `RunSkillCommand` succeeds and returns the raw MCP `CallToolResult`, with `isError: true`:
+  ```json
+  {"content":[{"type":"text","text":"level must be between 0 and 10"}],"isError":true}
+  ```
+  Treat this exactly like a normal tool response: read `content[]` (each item's `type` is `text`,
+  `image`, or `resource`; non-text items carry `data`/`mimeType`) and `isError`, and tell the user
+  what actually happened — don't report this as a Skill/tool-call failure.
+- **The call itself never reached the operation** (target unreachable, tool name doesn't exist,
+  arguments don't satisfy `inputSchema`, timeout) → `RunSkillCommand` reports a `ClientError`:
+  `device_not_connected`, `device_disconnected`, `device_timeout`, `mcp_target_not_found`,
+  `mcp_tool_not_found`, `mcp_invalid_arguments`. If the Skill reports missing client context, no
+  active public WebSocket device is available for this execution.
+
+Only claim the operation succeeded when you see `isError: false` (or absent) in the result — a
+`ClientError` here means the operation's actual outcome is unknown, not that it failed to run.

--- a/backend/src/main/resources/skills/client/device-mcp-list-devices/SKILL.md
+++ b/backend/src/main/resources/skills/client/device-mcp-list-devices/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: device-mcp-list-devices
+description: List the smart devices reachable on the local network of the user's active client device, including the device itself. Call before device.mcp.list_tools or device.mcp.call_tool when targeting a device other than the one currently on the call.
+metadata:
+  souz.skill-id: device.mcp.list_devices
+  souz.transport: client-websocket
+  souz.category: APPLICATIONS
+  souz.timeout: PT30S
+---
+
+# List devices reachable on the network
+
+Invoke `RunSkillCommand` with `skillId` set to `device.mcp.list_devices`. Takes no arguments:
+
+```json
+{"skillId":"device.mcp.list_devices","arguments":{}}
+```
+
+Result:
+
+```json
+{"devices":[{"id":"device-4471","name":"Кухонная станция","self":true},{"id":"a1b2c3","name":"home-server.local","self":false}]}
+```
+
+- `id` is stable across calls, conversations, and days — safe to reuse once seen.
+- `self: true` marks the device currently on the call; other entries are neighbors on its local network.
+- No address or reachability field is included — use `id` only. A stale `id` surfaces later as
+  `mcp_target_not_found`/`mcp_server_unreachable` from `device.mcp.list_tools`/`device.mcp.call_tool`.
+
+To address the device currently on the call, skip this Skill — just omit `target` in
+`device.mcp.list_tools`/`device.mcp.call_tool`.
+
+If the Skill reports missing client context, no active public WebSocket device is available for this
+execution. Other failures surface as `ClientError` codes: `device_not_connected`,
+`device_disconnected`, `device_timeout`, `mcp_discovery_failed`.

--- a/backend/src/main/resources/skills/client/device-mcp-list-tools/SKILL.md
+++ b/backend/src/main/resources/skills/client/device-mcp-list-tools/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: device-mcp-list-tools
+description: List what a device can actually do — its available functions (e.g. volume control, network info) — reachable via the user's active client device. Call before device.mcp.call_tool for the exact tool name and input schema; don't guess either.
+metadata:
+  souz.skill-id: device.mcp.list_tools
+  souz.transport: client-websocket
+  souz.category: APPLICATIONS
+  souz.timeout: PT30S
+---
+
+# List what a device can do
+
+Invoke `RunSkillCommand` with `skillId` set to `device.mcp.list_tools`. Arguments:
+- `target`: optional device `id` from `device.mcp.list_devices`. Omit it to mean "the device
+  currently on the call" — exactly like omitting `target` on `device.mcp.call_tool`.
+
+```json
+{"skillId":"device.mcp.list_tools","arguments":{"target":"a1b2c3"}}
+```
+
+Souz sends a durable `tool.call.started` event named `device.mcp.list_tools` to the active client
+device and waits up to 30 seconds for `tool.result`. The result is the target's raw MCP
+`ListToolsResult`, unchanged:
+
+```json
+{"tools":[{"name":"set_volume","description":"Set the device's output volume","inputSchema":{"type":"object","properties":{"level":{"type":"integer"}},"required":["level"]}}]}
+```
+
+`inputSchema` is the tool's real MCP JSON Schema — build `device.mcp.call_tool`'s `arguments` to
+satisfy it exactly, don't guess a shape.
+
+If the Skill reports missing client context, no active public WebSocket device is available for this
+execution. Other failures surface as `ClientError` codes: `device_not_connected`,
+`device_disconnected`, `device_timeout`, `mcp_target_not_found` (the `target` id is unknown or has
+gone stale since discovery), `mcp_server_unreachable`, `mcp_protocol_error`.

--- a/backend/src/main/resources/skills/client/index.txt
+++ b/backend/src/main/resources/skills/client/index.txt
@@ -1,2 +1,5 @@
 user-ask
 device-media-open
+device-mcp-list-devices
+device-mcp-list-tools
+device-mcp-call-tool

--- a/backend/src/test/kotlin/ru/souz/backend/e2e/BackendPublicWebSocketE2eTest.kt
+++ b/backend/src/test/kotlin/ru/souz/backend/e2e/BackendPublicWebSocketE2eTest.kt
@@ -263,6 +263,113 @@ class BackendPublicWebSocketE2eTest {
         }
 
     @Test
+    fun `device mcp list_devices reaches the client device and returns discovered devices`() =
+        backendE2eTest(
+            schemaPrefix = "e2e_ws_device_mcp_list_devices",
+            llm = E2eLlmApi().apply {
+                requestSkill("device.mcp.list_devices", emptyMap())
+            },
+        ) {
+            val userId = UUID.randomUUID().toString()
+            val chatId = createPublicChat(userId)
+            val wsClient = webSocketClient()
+            val session = wsClient.webSocketSession("${BackendHttpRoutes.chatWebSocket(chatId)}?clientType=backend")
+
+            session.send(Frame.Text(messageFrame(chatId, userId, "message-mcp-devices", null, "list mcp devices", "device-mcp")))
+            val messageAck = readJson(session)
+            readJson(session)
+            val started = readJson(session)
+            val threadId = messageAck["thread"]["id"].asText()
+            val toolCallId = started["payload"]["toolCallId"].asText()
+
+            assertEquals("tool.call.started", started["type"].asText())
+            assertEquals("device.mcp.list_devices", started["payload"]["name"].asText())
+            assertEquals("device-mcp", started["payload"]["deviceId"].asText())
+            assertTrue(started["payload"]["arguments"].isEmpty)
+
+            val resultFrame = """
+                {"kind":"tool.result","chatId":"$chatId","threadId":"$threadId","toolCallId":"$toolCallId",
+                 "status":"succeeded","result":{"devices":[{"id":"device-4471","name":"Кухонная станция","self":true}]}}
+            """.trimIndent()
+            session.send(Frame.Text(resultFrame))
+            val accepted = readJson(session)
+            val terminal = readJson(session)
+            assertEquals("accepted", accepted["status"].asText())
+            assertEquals("thread.completed", terminal["type"].asText())
+
+            session.close()
+            wsClient.close()
+        }
+
+    @Test
+    fun `device mcp call_tool forwards the target tool name and arguments to the device`() =
+        backendE2eTest(
+            schemaPrefix = "e2e_ws_device_mcp_call_tool_success",
+            llm = E2eLlmApi().apply {
+                requestSkill("device.mcp.call_tool", mapOf("name" to "set_volume", "arguments" to mapOf("level" to 7)))
+            },
+        ) {
+            val userId = UUID.randomUUID().toString()
+            val chatId = createPublicChat(userId)
+            val wsClient = webSocketClient()
+            val session = wsClient.webSocketSession("${BackendHttpRoutes.chatWebSocket(chatId)}?clientType=backend")
+
+            session.send(Frame.Text(messageFrame(chatId, userId, "message-mcp-call", null, "set the volume", "device-mcp")))
+            val messageAck = readJson(session)
+            readJson(session)
+            val started = readJson(session)
+            val threadId = messageAck["thread"]["id"].asText()
+            val toolCallId = started["payload"]["toolCallId"].asText()
+
+            assertEquals("device.mcp.call_tool", started["payload"]["name"].asText())
+            assertEquals("set_volume", started["payload"]["arguments"]["name"].asText())
+            assertEquals(7, started["payload"]["arguments"]["arguments"]["level"].asInt())
+
+            val resultFrame =
+                """{"kind":"tool.result","chatId":"$chatId","threadId":"$threadId","toolCallId":"$toolCallId","status":"succeeded","result":{"content":[{"type":"text","text":"Volume set to 7"}],"isError":false}}"""
+            session.send(Frame.Text(resultFrame))
+            val accepted = readJson(session)
+            val terminal = readJson(session)
+            assertEquals("accepted", accepted["status"].asText())
+            assertEquals("thread.completed", terminal["type"].asText())
+
+            session.close()
+            wsClient.close()
+        }
+
+    @Test
+    fun `device mcp call_tool completes normally when the MCP tool itself reports isError`() =
+        backendE2eTest(
+            schemaPrefix = "e2e_ws_device_mcp_call_tool_is_error",
+            llm = E2eLlmApi().apply {
+                requestSkill("device.mcp.call_tool", mapOf("name" to "set_volume", "arguments" to mapOf("level" to 500)))
+            },
+        ) {
+            val userId = UUID.randomUUID().toString()
+            val chatId = createPublicChat(userId)
+            val wsClient = webSocketClient()
+            val session = wsClient.webSocketSession("${BackendHttpRoutes.chatWebSocket(chatId)}?clientType=backend")
+
+            session.send(Frame.Text(messageFrame(chatId, userId, "message-mcp-call-error", null, "set an invalid volume", "device-mcp")))
+            val messageAck = readJson(session)
+            readJson(session)
+            val started = readJson(session)
+            val threadId = messageAck["thread"]["id"].asText()
+            val toolCallId = started["payload"]["toolCallId"].asText()
+
+            val resultFrame =
+                """{"kind":"tool.result","chatId":"$chatId","threadId":"$threadId","toolCallId":"$toolCallId","status":"succeeded","result":{"content":[{"type":"text","text":"level must be between 0 and 10"}],"isError":true}}"""
+            session.send(Frame.Text(resultFrame))
+            val accepted = readJson(session)
+            val terminal = readJson(session)
+            assertEquals("accepted", accepted["status"].asText())
+            assertEquals("thread.completed", terminal["type"].asText())
+
+            session.close()
+            wsClient.close()
+        }
+
+    @Test
     fun `thread cancellation cancels a pending client tool and rejects a later result`() =
         backendE2eTest(
             schemaPrefix = "e2e_ws_client_tool_cancel",

--- a/docs/device-mcp-call/mcp-tool-call-contract.md
+++ b/docs/device-mcp-call/mcp-tool-call-contract.md
@@ -257,7 +257,7 @@ WebSocket-соединению (`ru.souz.orion.deviceclient.DeviceExecArguments`
   ```
 
 Ошибки для второго случая: `device_not_connected`, `device_disconnected`, `device_timeout`,
-`mcp_target_not_found`, `mcp_tool_not_found`, `mcp_invalid_arguments`.
+`mcp_target_not_found`, `mcp_server_unreachable`, `mcp_tool_not_found`, `mcp_invalid_arguments`.
 
 ## Незакрытая зависимость (вне рамок этого этапа)
 

--- a/docs/device-mcp-call/mcp-tool-call-contract.md
+++ b/docs/device-mcp-call/mcp-tool-call-contract.md
@@ -1,0 +1,281 @@
+# Контракт tool.call для MCP (Souz WebSocket API) — черновик этапа 1
+
+Статус: черновик, для согласования с souz-backend перед реализацией.
+
+## Зачем
+
+Сейчас единственный поддерживаемый эмулятором tool-call клиентского скилла — `device.exec`:
+произвольная shell/process-команда, которая пушится на физическое устройство по его
+WebSocket-соединению (`ru.souz.orion.deviceclient.DeviceExecArguments`, см.
+`BackendChatSession.handleToolCallStarted`). Это заглушка вместо целевой интеграции: клиентское
+устройство (и/или другие устройства в его локальной сети) поднимает MCP-сервер, который даёт
+бэкенду вызывать структурированные, обнаруживаемые инструменты — включая функции ОС — вместо
+произвольных shell-команд.
+
+Этот документ описывает **только контракт со стороны бэкенда**: три новых имени `tool.call`, их
+аргументы и результаты, передаваемые поверх существующего Public Client WebSocket-контракта
+(`clientType=backend`). Он не описывает, как эмулятор будет релеить эти вызовы на физическое
+устройство по `/salute/ws` — это отдельный, более поздний этап (сейчас у протокола `DeviceMessage`
+есть только `exec`/`exec_result`; ему понадобятся аналогичные типы фреймов).
+
+## Конверт (без изменений)
+
+Новых kind-ов фреймов не вводится. Все три инструмента используют тот же конверт
+`tool.call.started` / `tool.result`, что уже использует `device.exec`
+(`publicclient/PublicClientContract.kt`):
+
+- Backend → эмулятор: `event`-фрейм, `type: "tool.call.started"`, `payload: { toolCallId, name,
+  arguments }`.
+- Эмулятор → backend: `ToolResultFrame` (`kind: "tool.result"`, `chatId`, `threadId`, `toolCallId`,
+  `status`, `result`, `error`).
+
+`status` остаётся одним из тех же трёх значений, что уже использует `device.exec`:
+`"succeeded"` | `"failed"` | `"timed_out"`.
+
+Целевое *Salute*-устройство (физическая колонка/станция, привязанная к чату) остаётся неявным и
+берётся из привязки устройства к чату — точно как у `device.exec`. Оно никогда не передаётся как
+аргумент tool-вызова.
+
+Таймауты в аргументы tool-вызовов **не выносятся**. У агента нет данных, чтобы осмысленно выбрать
+бюджет времени на discovery/list_tools/call_tool — это знание про сеть, устройство и конкретную
+операцию, то есть зона ответственности исполняющего кода (эмулятор → устройство → MCP-хост), а не
+входной параметр от бэкенда. Каждый из трёх вызовов получает свой внутренний дефолт (по аналогии с
+`DEFAULT_EXEC_TIMEOUT_MS` у `device.exec`), настраиваемый на стороне эмулятора, а не в теле
+запроса. Агент по-прежнему видит исход через `status: "timed_out"` — он просто им не управляет.
+
+## Именование
+
+Три новых имени инструментов в неймспейсе `device.mcp.*`:
+
+- `device.mcp.list_devices`
+- `device.mcp.list_tools`
+- `device.mcp.call_tool`
+
+## 1. `device.mcp.list_devices`
+
+Список MCP-хостов, откликнувшихся при discovery в локальной сети клиентского устройства,
+**включая само устройство**.
+
+```jsonc
+// backend → эмулятор
+{
+  "kind": "event",
+  "chatId": "chat-9f2e",
+  "threadId": "thread-771a",
+  "type": "tool.call.started",
+  "payload": {
+    "toolCallId": "call-3d1c",
+    "name": "device.mcp.list_devices",
+    "arguments": {}
+  }
+}
+```
+
+```jsonc
+// эмулятор → backend
+{
+  "kind": "tool.result",
+  "chatId": "chat-9f2e",
+  "threadId": "thread-771a",
+  "toolCallId": "call-3d1c",
+  "status": "succeeded",
+  "result": {
+    "devices": [
+      {
+        "id": "device-4471",       // тот же deviceId, что уже уходит в ClientDevice.deviceId при message.submit
+        "name": "Кухонная станция",
+        "self": true
+      },
+      {
+        "id": "a1b2c3",
+        "name": "home-server.local",
+        "self": false
+      }
+    ]
+  },
+  "error": null
+}
+```
+
+`id` каждой записи — стабильный идентификатор, а не одноразовый токен на время сессии: один и тот
+же физический прибор должен отдавать один и тот же `id` при повторных вызовах `list_devices`, в
+том числе в других разговорах/днях. Это принципиально в доме с несколькими станциями — если бы
+собственная запись устройства всегда возвращалась под общим литералом вроде `"self"`, две разные
+колонки в одном хозяйстве отдавали бы один и тот же id, и по контексту (истории чатов,
+кросс-канальным пушам и т.п.) их легко было бы перепутать как один прибор. Поэтому специального
+зарезервированного значения нет — собственная запись устройства получает такой же настоящий
+устойчивый `id`, как и любой сосед по сети, просто помечена `self: true`. Для устройства, которое
+сейчас на связи, это тот же `deviceId`, что уже передаётся бэкенду в `ClientDevice.deviceId` при
+каждом `message.submit` — новой сущности не заводим.
+
+Обращаться к «себе», не проходя через `list_devices`, всё ещё можно — но не магической строкой, а
+просто не указывая `target` в `list_tools`/`call_tool`: отсутствие `target` означает «устройство,
+которое сейчас на связи», ровно как сегодня неявно работает `device.exec`.
+
+Ни сетевой адрес, ни статус доступности в результат не выносятся — агент никогда не обращается по
+адресу напрямую, только по `id`, а доступность по своей природе устаревает мгновенно (сеть могла
+измениться между discovery и следующим вызовом). `list_devices` просто не включает в список
+устройства, не откликнувшиеся на discovery; актуальность конкретного `id` перепроверяется в момент
+реального обращения — `device.mcp.list_tools`/`device.mcp.call_tool` вернут `mcp_target_not_found`
+(id не найден вовсе) либо `mcp_server_unreachable` (устройство есть, но недоступно сейчас), если
+оно успело пропасть.
+
+Ошибки (`ClientError.code`): `device_not_connected`, `device_disconnected`, `device_timeout`,
+`mcp_discovery_failed`.
+
+## 2. `device.mcp.list_tools`
+
+Список MCP-инструментов, которые предоставляет заданное устройство (`id` из
+`device.mcp.list_devices`).
+
+```jsonc
+// backend → эмулятор
+{
+  "kind": "event",
+  "chatId": "chat-9f2e",
+  "threadId": "thread-771a",
+  "type": "tool.call.started",
+  "payload": {
+    "toolCallId": "call-5e7b",
+    "name": "device.mcp.list_tools",
+    "arguments": {
+      "target": "a1b2c3"   // опционально; id из device.mcp.list_devices — если опущен, значит устройство, которое сейчас на связи
+    }
+  }
+}
+```
+
+```jsonc
+// эмулятор → backend — result 1:1 повторяет ListToolsResult самого MCP, без трансформаций
+{
+  "kind": "tool.result",
+  "chatId": "chat-9f2e",
+  "threadId": "thread-771a",
+  "toolCallId": "call-5e7b",
+  "status": "succeeded",
+  "result": {
+    "tools": [
+      {
+        "name": "set_volume",
+        "description": "Set the device's output volume",
+        "inputSchema": { "type": "object", "properties": { "level": { "type": "integer" } }, "required": ["level"] }
+      }
+    ]
+  },
+  "error": null
+}
+```
+
+`inputSchema` — это сырая MCP JSON Schema, без преобразований, чтобы бэкенд мог напрямую
+валидировать/собирать аргументы по ней.
+
+Ошибки: `device_not_connected`, `device_disconnected`, `device_timeout`, а также
+`mcp_target_not_found` (id неизвестен/устарел с момента discovery), `mcp_server_unreachable`,
+`mcp_protocol_error` (некорректный MCP-ответ).
+
+## 3. `device.mcp.call_tool`
+
+Вызов конкретного инструмента на конкретном устройстве.
+
+```jsonc
+// backend → эмулятор
+{
+  "kind": "event",
+  "chatId": "chat-9f2e",
+  "threadId": "thread-771a",
+  "type": "tool.call.started",
+  "payload": {
+    "toolCallId": "call-8a2f",
+    "name": "device.mcp.call_tool",
+    "arguments": {
+      "target": "a1b2c3",   // опционально, та же семантика, что у list_tools
+      "name": "set_volume",
+      "arguments": { "level": 7 }
+    }
+  }
+}
+```
+
+```jsonc
+// эмулятор → backend — result повторяет CallToolResult самого MCP
+{
+  "kind": "tool.result",
+  "chatId": "chat-9f2e",
+  "threadId": "thread-771a",
+  "toolCallId": "call-8a2f",
+  "status": "succeeded",
+  "result": {
+    "content": [
+      { "type": "text", "text": "Volume set to 7" }
+    ],
+    "isError": false
+  },
+  "error": null
+}
+```
+
+`content[].type` соответствует типам контента самого MCP (`text` | `image` | `resource`);
+`data` (base64) и `mimeType` сопровождают не-текстовые элементы.
+
+**Разделение ошибок (важно):** здесь сохраняется двухуровневая модель ошибок самого MCP, и её
+стоит пронести сквозь весь стек, а не схлопывать в одно:
+
+- **Ошибка выполнения инструмента** (сама ОС-функция не выполнилась — например, запрошенная
+  громкость вне диапазона, файл не найден) → `tool.result` со `status: "succeeded"` и
+  `result.isError: true`, ровно как это репортит сам MCP. Вызов *как протокольный обмен* прошёл
+  успешно; не выполнилась сама операция.
+
+  ```jsonc
+  {
+    "kind": "tool.result",
+    "chatId": "chat-9f2e",
+    "threadId": "thread-771a",
+    "toolCallId": "call-8a2f",
+    "status": "succeeded",
+    "result": {
+      "content": [
+        { "type": "text", "text": "level must be between 0 and 10" }
+      ],
+      "isError": true
+    },
+    "error": null
+  }
+  ```
+
+- **Ошибка протокола/транспорта** (не удалось достучаться до цели вообще, инструмент с таким
+  именем не существует, аргументы не проходят `inputSchema`, таймаут) → `tool.result` со
+  `status: "failed"` и `ClientError`.
+
+  ```jsonc
+  {
+    "kind": "tool.result",
+    "chatId": "chat-9f2e",
+    "threadId": "thread-771a",
+    "toolCallId": "call-8a2f",
+    "status": "failed",
+    "result": null,
+    "error": {
+      "code": "mcp_tool_not_found",
+      "message": "Tool 'set_volume' is not exposed by device a1b2c3."
+    }
+  }
+  ```
+
+Ошибки для второго случая: `device_not_connected`, `device_disconnected`, `device_timeout`,
+`mcp_target_not_found`, `mcp_tool_not_found`, `mcp_invalid_arguments`.
+
+## Незакрытая зависимость (вне рамок этого этапа)
+
+Чтобы эмулятор реально мог выполнить эти три вызова, ему всё равно нужен способ достучаться до
+MCP-хоста — либо in-process на самом клиентском устройстве, либо релеем по локальной сети
+клиентского устройства. Для этого понадобится расширить протокол `/salute/ws`
+(`ru.souz.orion.protocol.DeviceMessage`, сейчас только `exec`/`exec_result`) аналогичными парами
+запрос/ответ, коррелируемыми так же, как `DeviceExecRegistry` сегодня коррелирует
+`exec`/`exec_result`. Оставлено на следующий этап.
+
+Отдельно нужно решить (на той же следующей стадии), откуда для устройств-соседей по сети (не
+`self`) брать `id`, устойчивый не только в рамках сессии, но и между отдельными discovery-сканами —
+контракт требует такой стабильности, но сам её не обеспечивает. Кандидаты: собственный устойчивый
+идентификатор, который отдаёт сам MCP-сервер соседа при handshake, либо аппаратный fingerprint
+(например, MAC), к которому клиентское устройство привязывает и кеширует сгенерированный `id`
+локально.

--- a/docs/device-mcp-call/mcp-tool-call-contract.md
+++ b/docs/device-mcp-call/mcp-tool-call-contract.md
@@ -92,8 +92,7 @@ WebSocket-соединению (`ru.souz.orion.deviceclient.DeviceExecArguments`
         "self": false
       }
     ]
-  },
-  "error": null
+  }
 }
 ```
 
@@ -161,8 +160,7 @@ WebSocket-соединению (`ru.souz.orion.deviceclient.DeviceExecArguments`
         "inputSchema": { "type": "object", "properties": { "level": { "type": "integer" } }, "required": ["level"] }
       }
     ]
-  },
-  "error": null
+  }
 }
 ```
 
@@ -209,8 +207,7 @@ WebSocket-соединению (`ru.souz.orion.deviceclient.DeviceExecArguments`
       { "type": "text", "text": "Volume set to 7" }
     ],
     "isError": false
-  },
-  "error": null
+  }
 }
 ```
 
@@ -237,8 +234,7 @@ WebSocket-соединению (`ru.souz.orion.deviceclient.DeviceExecArguments`
         { "type": "text", "text": "level must be between 0 and 10" }
       ],
       "isError": true
-    },
-    "error": null
+    }
   }
   ```
 
@@ -253,7 +249,6 @@ WebSocket-соединению (`ru.souz.orion.deviceclient.DeviceExecArguments`
     "threadId": "thread-771a",
     "toolCallId": "call-8a2f",
     "status": "failed",
-    "result": null,
     "error": {
       "code": "mcp_tool_not_found",
       "message": "Tool 'set_volume' is not exposed by device a1b2c3."

--- a/docs/public-souz-contract/openapi.yaml
+++ b/docs/public-souz-contract/openapi.yaml
@@ -801,6 +801,17 @@ components:
         - message_rejected
         - client_tool_timed_out
         - internal_error
+        # Reported by the client device itself inside a tool.result's error (device.exec,
+        # device.media.open, device.mcp.*) — not produced by the backend.
+        - device_not_connected
+        - device_disconnected
+        - device_timeout
+        - mcp_discovery_failed
+        - mcp_target_not_found
+        - mcp_server_unreachable
+        - mcp_protocol_error
+        - mcp_tool_not_found
+        - mcp_invalid_arguments
     Error:
       type: object
       additionalProperties: false


### PR DESCRIPTION
Adds three backend client-websocket Skills (device.mcp.list_devices, device.mcp.list_tools, device.mcp.call_tool) per
docs/device-mcp-call/mcp-tool-call-contract.md. No Kotlin changes needed — BackendClientSkills/ClientWebSocketSkill is already generic over manifest-declared skill-ids.

Also documents the previously-undeclared device/mcp ClientError codes in the public WS OpenAPI schema, and adds backend e2e coverage for the new Skills' tool.call round trip, including the MCP two-tier error model (isError vs ClientError).

Skill descriptions were rewritten to lead with user intent instead of MCP terminology ("what devices are on the network?", not "MCP"), and trimmed to drop internal reasoning prose from the "When to use" sections that belonged in the description wording, not as prose for the model to read through.