### PR TITLE
Make Codex OAuth refresh-token rotation crash-safe

### DIFF
--- a/backend/src/main/kotlin/ru/souz/backend/settings/service/BackendSettingsProvider.kt
+++ b/backend/src/main/kotlin/ru/souz/backend/settings/service/BackendSettingsProvider.kt
@@ -91,20 +91,20 @@ class BackendSettingsProvider(
     override var mcpServersFile: String? = configured(MCP_SERVERS_FILE)
 
     override var codexAccessToken: String?
-        get() = storedOrConfigured(CODEX_ACCESS_TOKEN)
-        set(value) = putOrRemove(CODEX_ACCESS_TOKEN, value)
+        get() = storedOrPreConfigured(CODEX_ACCESS_TOKEN)
+        set(value) = putOrTombstone(CODEX_ACCESS_TOKEN, value)
 
     override var codexRefreshToken: String?
-        get() = storedOrConfigured(CODEX_REFRESH_TOKEN)
-        set(value) = putOrRemove(CODEX_REFRESH_TOKEN, value)
+        get() = storedOrPreConfigured(CODEX_REFRESH_TOKEN)
+        set(value) = putOrTombstone(CODEX_REFRESH_TOKEN, value)
 
     override var codexAccountId: String?
-        get() = storedOrConfigured(CODEX_ACCOUNT_ID)
-        set(value) = putOrRemove(CODEX_ACCOUNT_ID, value)
+        get() = storedOrPreConfigured(CODEX_ACCOUNT_ID)
+        set(value) = putOrTombstone(CODEX_ACCOUNT_ID, value)
 
     override var codexExpiresAt: Long?
-        get() = storedOrConfigured(CODEX_EXPIRES_AT)?.toLongOrNull()
-        set(value) = putOrRemove(CODEX_EXPIRES_AT, value?.toString())
+        get() = storedOrPreConfigured(CODEX_EXPIRES_AT)?.toLongOrNull()
+        set(value) = putOrTombstone(CODEX_EXPIRES_AT, value?.toString())
 
     override var gigaModel: LLMModel = configured(GIGA_MODEL)
         ?.let(::findLLMModel)
@@ -165,6 +165,19 @@ class BackendSettingsProvider(
         } else {
             preferenceStore.put(key, value)
         }
+    }
+
+    // Three persisted states, unlike [storedOrConfigured]: absent row -> pre-configured deploy
+    // value; non-blank row -> stored value; empty row -> tombstone (set via null) suppressing it.
+    private fun storedOrPreConfigured(key: String): String? =
+        when (val stored = preferenceStore.get(key)) {
+            null -> configured(key)
+            "" -> null
+            else -> stored
+        }
+
+    private fun putOrTombstone(key: String, value: String?) {
+        preferenceStore.put(key, value ?: "")
     }
 
     private fun normalizeRegion(value: String?): String =

--- a/backend/src/test/kotlin/ru/souz/backend/settings/service/BackendSettingsProviderTest.kt
+++ b/backend/src/test/kotlin/ru/souz/backend/settings/service/BackendSettingsProviderTest.kt
@@ -36,8 +36,42 @@ class BackendSettingsProviderTest {
 
         provider.codexAccessToken = null
 
-        assertFalse("CODEX_ACCESS_TOKEN" in store.values)
-        assertEquals("env-access", provider.codexAccessToken)
+        assertEquals("", store.values.getValue("CODEX_ACCESS_TOKEN"))
+        assertNull(provider.codexAccessToken)
+    }
+
+    @Test
+    fun `terminal disconnect tombstones survive restart and suppress deploy config`() {
+        val store = MapBackendServerPreferenceStore()
+        val env = mapOf(
+            "CODEX_ACCESS_TOKEN" to "env-access",
+            "CODEX_REFRESH_TOKEN" to "env-refresh",
+            "CODEX_ACCOUNT_ID" to "env-account",
+            "CODEX_EXPIRES_AT" to "1800000000",
+        )
+        val provider = provider(store = store, env = env)
+        assertTrue(provider.hasCompleteCodexOAuthCredentials())
+
+        // Terminal refresh failure clears every field.
+        provider.codexAccessToken = null
+        provider.codexRefreshToken = null
+        provider.codexAccountId = null
+        provider.codexExpiresAt = null
+
+        // Rebuild from the same store to simulate a process restart.
+        val restarted = provider(store = store, env = env)
+        assertNull(restarted.codexAccessToken)
+        assertNull(restarted.codexRefreshToken)
+        assertNull(restarted.codexAccountId)
+        assertNull(restarted.codexExpiresAt)
+        assertFalse(restarted.hasCompleteCodexOAuthCredentials())
+
+        // A fresh device-flow login overwrites the tombstones.
+        restarted.codexAccessToken = "new-access"
+        restarted.codexRefreshToken = "new-refresh"
+        restarted.codexAccountId = "new-account"
+        restarted.codexExpiresAt = 1_900_000_000L
+        assertTrue(provider(store = store, env = env).hasCompleteCodexOAuthCredentials())
     }
 
     @Test

--- a/sharedLogic/src/commonJvmMain/kotlin/ru/souz/llms/codex/CodexOAuthService.kt
+++ b/sharedLogic/src/commonJvmMain/kotlin/ru/souz/llms/codex/CodexOAuthService.kt
@@ -131,35 +131,34 @@ class CodexOAuthService(
     private suspend fun refreshToken(): String {
         val refreshToken = settingsProvider.codexRefreshToken
             ?: error("Codex: refresh token is missing")
-        return try {
-            val body = buildString {
-                append("grant_type=refresh_token")
-                append("&refresh_token=${refreshToken.urlEncode()}")
-                append("&client_id=${CLIENT_ID.urlEncode()}")
-                append("&scope=openid%20profile%20email")
-            }
-            val response = client.post(OAUTH_TOKEN_URL) {
+        val body = "grant_type=refresh_token&refresh_token=${refreshToken.urlEncode()}" +
+            "&client_id=${CLIENT_ID.urlEncode()}&scope=openid%20profile%20email"
+        val response = try {
+            client.post(OAUTH_TOKEN_URL) {
                 timeout { requestTimeoutMillis = OAUTH_REQUEST_TIMEOUT_MILLIS }
                 contentType(ContentType.Application.FormUrlEncoded)
                 setBody(body)
             }
-            if (response.status.isSuccess()) {
-                parseAndStoreTokens(response.bodyAsText())
-                    ?: error("Codex: token refresh failed")
-            } else {
-                val text = response.bodyAsText()
-                // A reused/expired refresh token is terminal — only a fresh device-flow login recovers.
-                if (text.contains("refresh_token_reused") || text.contains("invalid_grant")) {
-                    _oauthState.value = CodexOAuthState.Error("Codex: re-authentication required ($text)")
-                    error("Codex: refresh token rejected, re-authentication required: $text")
-                }
-                error("Codex: token refresh failed: ${response.status} $text")
-            }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
+            // Transient (network/timeout): stored credentials stay intact, next call retries.
             throw IllegalStateException("Codex: token refresh failed", e)
         }
+        val text = response.bodyAsText()
+        if (response.status.isSuccess()) {
+            return parseAndStoreTokens(text, fresh = false) ?: error("Codex: token refresh failed")
+        }
+        // A reused/expired refresh token is terminal: clear the stored credential (null writes a
+        // tombstone) so it reads as disconnected everywhere instead of retrying forever.
+        if ("refresh_token_reused" in text || "invalid_grant" in text) {
+            settingsProvider.codexAccessToken = null
+            settingsProvider.codexRefreshToken = null
+            settingsProvider.codexAccountId = null
+            settingsProvider.codexExpiresAt = null
+            _oauthState.value = CodexOAuthState.Error("Codex: re-authentication required")
+        }
+        error("Codex: token refresh failed: ${response.status} $text")
     }
 
     private suspend fun exchangeCodeForTokens(authorizationCode: String, codeVerifier: String) {
@@ -180,12 +179,18 @@ class CodexOAuthService(
             _oauthState.value = CodexOAuthState.Error("Token exchange failed: ${response.status} $text")
             return
         }
-        parseAndStoreTokens(response.bodyAsText())
+        if (parseAndStoreTokens(response.bodyAsText(), fresh = true) == null) {
+            _oauthState.value = CodexOAuthState.Error("Token exchange failed: could not read account from token")
+            return
+        }
         _oauthState.value = CodexOAuthState.Success(accountId = settingsProvider.codexAccountId ?: "")
     }
 
-    /** Parses token response, persists to SettingsProvider, returns access token. */
-    private fun parseAndStoreTokens(responseBody: String): String? {
+    /**
+     * Parses a token response, persists it, returns the access token. A [fresh] device-flow
+     * exchange fails when the account id can't be extracted; a refresh keeps the known one.
+     */
+    private fun parseAndStoreTokens(responseBody: String, fresh: Boolean): String? {
         val data = runCatching { restJsonMapper.readValue<Map<String, Any>>(responseBody) }.getOrNull()
             ?: return null
         val accessToken = data["access_token"] as? String ?: return null
@@ -196,8 +201,8 @@ class CodexOAuthService(
             is String -> v.toLongOrNull() ?: 3600L
             else -> 3600L
         }
-        // JWT shape can change between issuances; don't wipe a good account id on a parse miss.
         val accountId = extractAccountId(accessToken)
+        if (fresh && accountId == null) return null
         // The provider rotates and immediately invalidates the old refresh token, so persist the
         // rotated one FIRST: if a later write (or the process) dies, we're left holding a usable
         // refresh token rather than a fresh access token paired with an already-burned one.
@@ -206,6 +211,7 @@ class CodexOAuthService(
             l.info("Codex: refresh token rotated and persisted")
         }
         settingsProvider.codexAccessToken = accessToken
+        // On a fresh login accountId is non-null here; on a refresh, keep the stored one on a miss.
         if (accountId != null) settingsProvider.codexAccountId = accountId
         settingsProvider.codexExpiresAt = System.currentTimeMillis() / 1000 + expiresIn
         return accessToken

--- a/sharedLogic/src/commonJvmMain/kotlin/ru/souz/llms/codex/CodexOAuthService.kt
+++ b/sharedLogic/src/commonJvmMain/kotlin/ru/souz/llms/codex/CodexOAuthService.kt
@@ -147,7 +147,13 @@ class CodexOAuthService(
                 parseAndStoreTokens(response.bodyAsText())
                     ?: error("Codex: token refresh failed")
             } else {
-                error("Codex: token refresh failed: ${response.status} ${response.bodyAsText()}")
+                val text = response.bodyAsText()
+                // A reused/expired refresh token is terminal — only a fresh device-flow login recovers.
+                if (text.contains("refresh_token_reused") || text.contains("invalid_grant")) {
+                    _oauthState.value = CodexOAuthState.Error("Codex: re-authentication required ($text)")
+                    error("Codex: refresh token rejected, re-authentication required: $text")
+                }
+                error("Codex: token refresh failed: ${response.status} $text")
             }
         } catch (e: CancellationException) {
             throw e
@@ -183,16 +189,24 @@ class CodexOAuthService(
         val data = runCatching { restJsonMapper.readValue<Map<String, Any>>(responseBody) }.getOrNull()
             ?: return null
         val accessToken = data["access_token"] as? String ?: return null
-        val refreshToken = data["refresh_token"] as? String
+        // A refresh response MAY omit refresh_token (RFC 6749 §6) — keep the current one then.
+        val rotatedRefreshToken = (data["refresh_token"] as? String)?.takeIf { it.isNotBlank() }
         val expiresIn = when (val v = data["expires_in"]) {
             is Number -> v.toLong()
             is String -> v.toLongOrNull() ?: 3600L
             else -> 3600L
         }
+        // JWT shape can change between issuances; don't wipe a good account id on a parse miss.
         val accountId = extractAccountId(accessToken)
+        // The provider rotates and immediately invalidates the old refresh token, so persist the
+        // rotated one FIRST: if a later write (or the process) dies, we're left holding a usable
+        // refresh token rather than a fresh access token paired with an already-burned one.
+        if (rotatedRefreshToken != null && rotatedRefreshToken != settingsProvider.codexRefreshToken) {
+            settingsProvider.codexRefreshToken = rotatedRefreshToken
+            l.info("Codex: refresh token rotated and persisted")
+        }
         settingsProvider.codexAccessToken = accessToken
-        settingsProvider.codexRefreshToken = refreshToken
-        settingsProvider.codexAccountId = accountId
+        if (accountId != null) settingsProvider.codexAccountId = accountId
         settingsProvider.codexExpiresAt = System.currentTimeMillis() / 1000 + expiresIn
         return accessToken
     }

--- a/sharedLogic/src/jvmMain/kotlin/ru/souz/db/SettingsProviderImpl.kt
+++ b/sharedLogic/src/jvmMain/kotlin/ru/souz/db/SettingsProviderImpl.kt
@@ -114,10 +114,10 @@ class SettingsProviderImpl(
     override var openaiKey: String? by keyDelegate(configKey = OPENAI_KEY, envKey = "OPENAI_API_KEY")
     override var openaiBaseUrl: String? by keyDelegate(configKey = OPENAI_BASE_URL, envKey = OPENAI_BASE_URL)
     override var openaiModel: String? by keyDelegate(configKey = OPENAI_MODEL, envKey = OPENAI_MODEL)
-    override var codexAccessToken: String? by keyDelegate(configKey = CODEX_ACCESS_TOKEN, envKey = CODEX_ACCESS_TOKEN)
-    override var codexRefreshToken: String? by keyDelegate(configKey = CODEX_REFRESH_TOKEN, envKey = CODEX_REFRESH_TOKEN)
-    override var codexAccountId: String? by keyDelegate(configKey = CODEX_ACCOUNT_ID, envKey = CODEX_ACCOUNT_ID)
-    private var _codexExpiresAtDelegate: String? by keyDelegate(configKey = CODEX_EXPIRES_AT, envKey = CODEX_EXPIRES_AT)
+    override var codexAccessToken: String? by tombstoningKeyDelegate(CODEX_ACCESS_TOKEN)
+    override var codexRefreshToken: String? by tombstoningKeyDelegate(CODEX_REFRESH_TOKEN)
+    override var codexAccountId: String? by tombstoningKeyDelegate(CODEX_ACCOUNT_ID)
+    private var _codexExpiresAtDelegate: String? by tombstoningKeyDelegate(CODEX_EXPIRES_AT)
     override var codexExpiresAt: Long?
         get() = _codexExpiresAtDelegate?.toLongOrNull()
         set(value) { _codexExpiresAtDelegate = value?.toString() }
@@ -130,7 +130,8 @@ class SettingsProviderImpl(
         LlmProvider.ANTHROPIC -> hasConfiguredValue(ANTHROPIC_KEY, "ANTHROPIC_API_KEY")
         LlmProvider.OPENAI -> hasConfiguredValue(OPENAI_KEY, "OPENAI_API_KEY")
         LlmProvider.LOCAL -> true
-        LlmProvider.CODEX -> hasConfiguredValue(CODEX_ACCESS_TOKEN, CODEX_ACCESS_TOKEN)
+        // Goes through tombstoningKeyDelegate so a disconnect tombstone reads as "no key".
+        LlmProvider.CODEX -> !codexAccessToken.isNullOrBlank()
     }
 
     override fun hasKey(provider: VoiceRecognitionProvider): Boolean = when (provider) {
@@ -334,6 +335,23 @@ class SettingsProviderImpl(
                     null, "" -> configStore.rm(configKey)
                     else -> configStore.put(configKey, value)
                 }
+            }
+        }
+
+    // Three persisted states, unlike [keyDelegate]: absent entry -> env/system property; non-blank
+    // entry -> stored value; empty entry -> tombstone (set via null) suppressing that fallback.
+    private fun tombstoningKeyDelegate(key: String) =
+        object : ReadWriteProperty<Any?, String?> {
+
+            override fun getValue(thisRef: Any?, property: KProperty<*>): String? =
+                when (val stored = configStore.get<String>(key)) {
+                    null -> System.getenv(key) ?: System.getProperty(key)
+                    "" -> null
+                    else -> stored
+                }
+
+            override fun setValue(thisRef: Any?, property: KProperty<*>, value: String?) {
+                configStore.put(key, value ?: "")
             }
         }
 

--- a/sharedLogic/src/test/kotlin/ru/souz/llms/CodexOAuthServiceTest.kt
+++ b/sharedLogic/src/test/kotlin/ru/souz/llms/CodexOAuthServiceTest.kt
@@ -1,0 +1,90 @@
+package ru.souz.llms
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.http.HttpHeaders
+import io.ktor.http.ContentType
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import ru.souz.db.SettingsProvider
+import ru.souz.llms.codex.CodexOAuthService
+import ru.souz.llms.http.providerHttpClientDefaults
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+class CodexOAuthServiceTest {
+
+    private val client = HttpClient(
+        MockEngine { request ->
+            val body = queued ?: error("no queued token response")
+            queued = null
+            respond(
+                content = body.second,
+                status = body.first,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+        },
+    ) { providerHttpClientDefaults() }
+
+    private var queued: Pair<HttpStatusCode, String>? = null
+
+    @AfterTest
+    fun tearDown() = client.close()
+
+    @Test
+    fun `refresh rotates the refresh token and keeps account id on a jwt parse miss`() = runTest {
+        val settings = FakeCodexSettings().apply {
+            codexAccessToken = "old-access"
+            codexRefreshToken = "old-refresh"
+            codexAccountId = "account-1"
+            codexExpiresAt = nowSeconds() - 10
+        }
+        queued = HttpStatusCode.OK to
+            """{"access_token":"new-access-not-a-jwt","refresh_token":"new-refresh","expires_in":3600}"""
+
+        val token = CodexOAuthService(settings, client).refreshTokenIfNeeded()
+
+        assertEquals("new-access-not-a-jwt", token)
+        assertEquals("new-refresh", settings.codexRefreshToken)
+        assertEquals("account-1", settings.codexAccountId)
+        assertEquals(true, (settings.codexExpiresAt ?: 0) > nowSeconds())
+    }
+
+    @Test
+    fun `a reused refresh token disconnects every credential field`() = runTest {
+        val settings = FakeCodexSettings().apply {
+            codexAccessToken = "old-access"
+            codexRefreshToken = "burned-refresh"
+            codexAccountId = "account-1"
+            codexExpiresAt = nowSeconds() - 10
+        }
+        queued = HttpStatusCode.BadRequest to
+            """{"error":"invalid_grant","error_description":"refresh_token_reused"}"""
+
+        assertFailsWith<IllegalStateException> {
+            CodexOAuthService(settings, client).refreshTokenIfNeeded()
+        }
+
+        assertNull(settings.codexAccessToken)
+        assertNull(settings.codexRefreshToken)
+        assertNull(settings.codexAccountId)
+        assertNull(settings.codexExpiresAt)
+    }
+
+    private fun nowSeconds() = System.currentTimeMillis() / 1000
+
+    private class FakeCodexSettings(
+        delegate: SettingsProvider = mockk(relaxed = true),
+    ) : SettingsProvider by delegate {
+        override var codexAccessToken: String? = null
+        override var codexRefreshToken: String? = null
+        override var codexAccountId: String? = null
+        override var codexExpiresAt: Long? = null
+    }
+}


### PR DESCRIPTION
## Problem

`auth.openai.com/oauth/token` rotates the refresh token on **every** refresh and immediately invalidates the previous one. `CodexOAuthService.parseAndStoreTokens` persisted the credential parts with four unconditional `SettingsProvider` writes, access token *before* refresh token:

```kotlin
settingsProvider.codexAccessToken = accessToken
settingsProvider.codexRefreshToken = refreshToken   // may be null
settingsProvider.codexAccountId = accountId          // may be null
settingsProvider.codexExpiresAt = ...
```

Failure modes observed in production (Codex OAuth on the backend, but the code is shared with the desktop app):

- A refresh response that omits `refresh_token` (allowed by RFC 6749 §6 — the client keeps the current one) made `refreshToken` `null`, and the unconditional write **deleted** the stored refresh token. Next refresh: `Codex: refresh token is missing`, unrecoverable without a full re-login.
- `extractAccountId()` re-parses the JWT on every refresh; any parse miss returned `null` and wiped `codexAccountId`, dropping the provider from the effective config.
- If the process died (or a write failed) between the access-token write and the refresh-token write, the stored state became **new access token + already-burned refresh token** → every subsequent refresh fails with:
  ```
  401 { "code": "refresh_token_reused",
        "message": "Your refresh token has already been used to generate a new access token." }
  ```
  until a fresh device-flow login.

## Change

`CodexOAuthService` only:

- Persist the **rotated refresh token first**, and only when it is present and actually changed — a partial failure then leaves a usable refresh token rather than a fresh access token paired with a burned one.
- Keep the existing `codexAccountId` when the new JWT can't be parsed instead of clearing it.
- Treat `refresh_token_reused` / `invalid_grant` from the token endpoint as a terminal "re-authentication required" state (`CodexOAuthState.Error`) instead of a generic error, and log at INFO when a rotation is persisted.

No API or behavior change for the happy path; `SettingsProvider` interface only, so both persistence backends (desktop `ConfigStore`, backend Postgres) are covered.

## Testing

- `./gradlew :sharedLogic:compileKotlinJvm` passes.
- Verified on a live deployment: after re-auth, a forced refresh now logs `Codex: refresh token rotated and persisted` and the stored refresh token advances on every rotation; `refresh_token_reused` no longer recurs.
