### PR TITLE
Use fast RepoWise indexing in PR quality gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,8 +195,8 @@ jobs:
 
       - name: Build deterministic RepoWise indexes
         run: |
-          repowise init "$REPOWISE_BASE_CHECKOUT" --yes --no-prose --no-workspace
-          repowise init . --yes --no-prose --no-workspace
+          repowise init "$REPOWISE_BASE_CHECKOUT" --mode fast --yes --no-prose --no-workspace
+          repowise init . --mode fast --yes --no-prose --no-workspace
 
       - name: Generate PR-focused RepoWise reports
         shell: bash


### PR DESCRIPTION
## Summary

- initialize both the base and PR RepoWise indexes with `--mode fast`
- avoid history-derived blame and co-change penalties from synthetic PR merge commits
- leave the quality ratchet, KPI list, risk report, artifact upload, and other jobs unchanged

## Verification

- parsed `.github/workflows/ci.yml` successfully with Ruby YAML
- `git diff --check`

## Caveat

- `actionlint` is not installed locally, so GitHub Actions-specific semantic linting was not run