### PR TITLE
Simplify client response construction and graph execution delegate

### DIFF
--- a/agent/src/main/kotlin/ru/souz/GraphBasedAgent.kt
+++ b/agent/src/main/kotlin/ru/souz/GraphBasedAgent.kt
@@ -23,7 +23,6 @@ import ru.souz.agent.nodes.NodesSummarization
 import ru.souz.agent.nodes.SKILL_INVENTORY_NODE_NAME
 import ru.souz.agent.runtime.GraphExecutionDelegate
 import ru.souz.agent.state.AgentContext
-import ru.souz.agent.runtime.GraphExecutionDelegateImpl
 import ru.souz.llms.LLMResponse
 
 class GraphBasedAgent internal constructor(
@@ -38,7 +37,7 @@ class GraphBasedAgent internal constructor(
     private val nodesToolUseWithKnowledge: NodesToolUseWithKnowledge,
     private val nodesMemory: NodesMemory,
     coreTools: AgentCoreTools,
-    private val executionDelegate: GraphExecutionDelegate = GraphExecutionDelegateImpl(
+    private val executionDelegate: GraphExecutionDelegate = GraphExecutionDelegate(
         logObjectMapper = logObjectMapper,
         loggerClass = GraphBasedAgent::class.java,
     ),

--- a/agent/src/main/kotlin/ru/souz/SkillsGraphBasedAgent.kt
+++ b/agent/src/main/kotlin/ru/souz/SkillsGraphBasedAgent.kt
@@ -27,7 +27,6 @@ import ru.souz.agent.nodes.SKILL_INVENTORY_NODE_NAME
 import ru.souz.agent.nodes.SteerableChatNode
 import ru.souz.agent.runtime.ActiveRunInputController
 import ru.souz.agent.runtime.GraphExecutionDelegate
-import ru.souz.agent.runtime.GraphExecutionDelegateImpl
 import ru.souz.agent.state.AgentContext
 import ru.souz.llms.LLMResponse
 
@@ -45,7 +44,7 @@ class SkillsGraphBasedAgent internal constructor(
     private val nodesSkillInventory: NodesSkillInventory,
     private val nodesToolUseWithKnowledge: NodesToolUseWithKnowledge,
     coreTools: AgentCoreTools,
-    private val executionDelegate: GraphExecutionDelegate = GraphExecutionDelegateImpl(
+    private val executionDelegate: GraphExecutionDelegate = GraphExecutionDelegate(
         logObjectMapper = logObjectMapper,
         loggerClass = SkillsGraphBasedAgent::class.java,
     ),

--- a/agent/src/main/kotlin/ru/souz/agent/runtime/GraphExecutionDelegate.kt
+++ b/agent/src/main/kotlin/ru/souz/agent/runtime/GraphExecutionDelegate.kt
@@ -15,31 +15,21 @@ import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.coroutines.cancellation.CancellationException
 
-internal interface GraphExecutionDelegate {
-    fun cancelActiveJob()
+internal class GraphExecutionDelegate(
+    private val logObjectMapper: ObjectMapper,
+    loggerClass: Class<*>,
+) {
+    private val logger = LoggerFactory.getLogger(loggerClass)
+    private val runningJob = AtomicReference<Deferred<*>?>(null)
+
+    fun cancelActiveJob() {
+        runningJob.load()?.cancel(CancellationException("Cancelled by facade"))
+    }
 
     suspend fun executeWithTrace(
         graph: Graph<String, String>,
         ctx: AgentContext<String>,
         onStep: GraphStepCallback? = null,
-    ): AgentExecutionResult
-}
-
-internal class GraphExecutionDelegateImpl(
-    private val logObjectMapper: ObjectMapper,
-    loggerClass: Class<*>,
-) : GraphExecutionDelegate {
-    private val logger = LoggerFactory.getLogger(loggerClass)
-    private val runningJob = AtomicReference<Deferred<*>?>(null)
-
-    override fun cancelActiveJob() {
-        runningJob.load()?.cancel(CancellationException("Cancelled by facade"))
-    }
-
-    override suspend fun executeWithTrace(
-        graph: Graph<String, String>,
-        ctx: AgentContext<String>,
-        onStep: GraphStepCallback?,
     ): AgentExecutionResult {
         cancelActiveJob()
         val newContext = coroutineScope {

--- a/backend/docs/pain-points/public-client-websocket.md
+++ b/backend/docs/pain-points/public-client-websocket.md
@@ -19,6 +19,7 @@ Client operation definitions are backend-owned and reviewed. Do not accept runti
 ## Safe-change guidance
 
 - Keep strict JSON decoding and reject unknown fields.
+- Keep HTTP and WebSocket thread status fields identical; the WebSocket frame flattens the shared status payload and adds its envelope. Preserve explicit nulls and correlation identifiers in status and rejection frames.
 - Validate and serialize initial input before registering live thread state. Propagate startup cancellation instead of converting it to a rejected acknowledgement.
 - Lock the chat row and recheck `client_requests` before every submit or cancel mutation. Initial selection or creation, follow-up message/revision/device updates, cancellation state, and their receipts must commit atomically. Hash the client-supplied nullable thread ID rather than the selected thread, and return the stored receipt on retries even after execution completion.
 - Commit history and its receipt under the chat lock without reading or mutating execution or registry state.

--- a/backend/src/main/kotlin/ru/souz/backend/client/PublicClientContract.kt
+++ b/backend/src/main/kotlin/ru/souz/backend/client/PublicClientContract.kt
@@ -3,7 +3,9 @@ package ru.souz.backend.client
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.databind.JsonNode
+import java.time.Instant
 
 data class CreateClientChatRequest(
     val userId: String,
@@ -144,37 +146,15 @@ data class PublicThreadStatusResponse(
 
 @JsonInclude(JsonInclude.Include.ALWAYS)
 data class ThreadStatusFrame(
+    @field:JsonUnwrapped
+    val threadStatus: PublicThreadStatusResponse,
     val kind: String = "status",
     val type: String = "thread.status",
-    val chatId: String,
-    val threadId: String,
     val requestId: String? = null,
-    val status: String,
-    val alive: Boolean,
-    val acceptsInput: Boolean,
-    val revision: Long,
-    val startedAt: String,
-    val finishedAt: String? = null,
-    val runtimeLeaseExpiresAt: String? = null,
-    val error: ClientError? = null,
-    val observedAt: String,
 )
 
 internal fun PublicThreadStatusResponse.toStatusFrame(requestId: String? = null): ThreadStatusFrame =
-    ThreadStatusFrame(
-        chatId = chatId,
-        threadId = threadId,
-        requestId = requestId,
-        status = status,
-        alive = alive,
-        acceptsInput = acceptsInput,
-        revision = revision,
-        startedAt = startedAt,
-        finishedAt = finishedAt,
-        runtimeLeaseExpiresAt = runtimeLeaseExpiresAt,
-        error = error,
-        observedAt = observedAt,
-    )
+    ThreadStatusFrame(threadStatus = this, requestId = requestId)
 
 @JsonInclude(JsonInclude.Include.ALWAYS)
 data class MessageSubmitAck(
@@ -188,7 +168,15 @@ data class MessageSubmitAck(
     val thread: ThreadAck? = null,
     val error: ClientError? = null,
     val receivedAt: String,
-)
+) {
+    companion object {
+        internal fun rejected(chatId: String, requestId: String, error: ClientError, now: Instant) =
+            MessageSubmitAck(
+                chatId = chatId, requestId = requestId, status = "rejected", duplicate = false,
+                error = error, receivedAt = now.toString(),
+            )
+    }
+}
 
 @JsonInclude(JsonInclude.Include.ALWAYS)
 data class HistoryAppendAck(
@@ -199,7 +187,15 @@ data class HistoryAppendAck(
     val duplicate: Boolean,
     val error: ClientError? = null,
     val receivedAt: String,
-)
+) {
+    companion object {
+        internal fun rejected(chatId: String, requestId: String, error: ClientError, now: Instant) =
+            HistoryAppendAck(
+                chatId = chatId, requestId = requestId, status = "rejected", duplicate = false,
+                error = error, receivedAt = now.toString(),
+            )
+    }
+}
 
 @JsonInclude(JsonInclude.Include.ALWAYS)
 data class ToolResultAck(
@@ -211,7 +207,15 @@ data class ToolResultAck(
     val duplicate: Boolean,
     val error: ClientError?,
     val receivedAt: String,
-)
+) {
+    companion object {
+        internal fun rejected(chatId: String, threadId: String, toolCallId: String, error: ClientError, now: Instant) =
+            ToolResultAck(
+                chatId = chatId, threadId = threadId, toolCallId = toolCallId, status = "rejected", duplicate = false,
+                error = error, receivedAt = now.toString(),
+            )
+    }
+}
 
 @JsonInclude(JsonInclude.Include.ALWAYS)
 data class ThreadCancelAck(
@@ -223,7 +227,15 @@ data class ThreadCancelAck(
     val duplicate: Boolean,
     val error: ClientError?,
     val receivedAt: String,
-)
+) {
+    companion object {
+        internal fun rejected(chatId: String, requestId: String, threadId: String, error: ClientError, now: Instant) =
+            ThreadCancelAck(
+                chatId = chatId, requestId = requestId, threadId = threadId, status = "rejected", duplicate = false,
+                error = error, receivedAt = now.toString(),
+            )
+    }
+}
 
 internal val supportedClientTypes = setOf("backend", "mobile_app")
 internal const val MESSAGE_ROLE_USER = "user"

--- a/backend/src/main/kotlin/ru/souz/backend/client/PublicClientService.kt
+++ b/backend/src/main/kotlin/ru/souz/backend/client/PublicClientService.kt
@@ -426,15 +426,7 @@ internal class PublicClientService(
             receivedAt = now,
         )
         return HandledClientFrame(
-            response = ToolResultAck(
-                chatId = chatId.toString(),
-                toolCallId = toolCallId,
-                threadId = threadId.toString(),
-                status = "rejected",
-                duplicate = false,
-                error = error,
-                receivedAt = now.toString(),
-            ),
+            response = ToolResultAck.rejected(chatId.toString(), threadId.toString(), toolCallId, error, now),
             afterSend = {
                 if (completed != null) registry.finishTool(threadId, toolCallId, outcome)
             },
@@ -569,11 +561,7 @@ internal class PublicClientService(
         }
         key.request(
             execution?.id,
-            MessageSubmitAck(
-                chatId = key.chatId.toString(), requestId = key.requestId,
-                status = "rejected", duplicate = false, error = ClientError(code, message),
-                receivedAt = now.toString(),
-            ),
+            MessageSubmitAck.rejected(key.chatId.toString(), key.requestId, ClientError(code, message), now),
             now,
         )
     }
@@ -590,11 +578,7 @@ internal class PublicClientService(
         }
         key.request(
             execution?.id,
-            ThreadCancelAck(
-                chatId = key.chatId.toString(), requestId = key.requestId, threadId = threadId.toString(),
-                status = "rejected", duplicate = false, error = ClientError(code, message),
-                receivedAt = now.toString(),
-            ),
+            ThreadCancelAck.rejected(key.chatId.toString(), key.requestId, threadId.toString(), ClientError(code, message), now),
             now,
         )
     }
@@ -610,12 +594,7 @@ internal class PublicClientService(
     )
 
     private fun rejectedMessage(chatId: UUID, requestId: String, code: String, message: String, now: Instant) =
-        HandledClientFrame(
-            MessageSubmitAck(
-                chatId = chatId.toString(), requestId = requestId, status = "rejected", duplicate = false,
-                error = ClientError(code, message), receivedAt = now.toString(),
-            )
-        )
+        HandledClientFrame(MessageSubmitAck.rejected(chatId.toString(), requestId, ClientError(code, message), now))
 
     private fun rejectedHistory(
         chatId: UUID,
@@ -623,12 +602,7 @@ internal class PublicClientService(
         code: String,
         message: String,
         now: Instant,
-    ) = HandledClientFrame(
-        HistoryAppendAck(
-            chatId = chatId.toString(), requestId = requestId, status = "rejected", duplicate = false,
-            error = ClientError(code, message), receivedAt = now.toString(),
-        )
-    )
+    ) = HandledClientFrame(HistoryAppendAck.rejected(chatId.toString(), requestId, ClientError(code, message), now))
 
     private fun acceptedTool(chatId: UUID, threadId: UUID, toolCallId: String, duplicate: Boolean, now: Instant) =
         ToolResultAck(
@@ -638,19 +612,13 @@ internal class PublicClientService(
 
     private fun rejectedTool(chatId: UUID, threadId: UUID, toolCallId: String, code: String, message: String, now: Instant) =
         HandledClientFrame(
-            ToolResultAck(
-                chatId = chatId.toString(), toolCallId = toolCallId, threadId = threadId.toString(),
-                status = "rejected", duplicate = false, error = ClientError(code, message), receivedAt = now.toString(),
-            )
+            ToolResultAck.rejected(chatId.toString(), threadId.toString(), toolCallId, ClientError(code, message), now)
         )
 
     private fun rejectedCancel(
         chatId: UUID, requestId: String, threadId: UUID, code: String, message: String, now: Instant,
     ) = HandledClientFrame(
-        ThreadCancelAck(
-            chatId = chatId.toString(), requestId = requestId, threadId = threadId.toString(),
-            status = "rejected", duplicate = false, error = ClientError(code, message), receivedAt = now.toString(),
-        )
+        ThreadCancelAck.rejected(chatId.toString(), requestId, threadId.toString(), ClientError(code, message), now)
     )
 }
 

--- a/backend/src/main/kotlin/ru/souz/backend/http/routes/EventRoutes.kt
+++ b/backend/src/main/kotlin/ru/souz/backend/http/routes/EventRoutes.kt
@@ -257,53 +257,18 @@ private fun rejectedFor(
     code: String,
     message: String,
 ): HandledClientFrame {
-    val now = Instant.now().toString()
+    val now = Instant.now()
     val error = ClientError(code, message)
-    return when (kind) {
-        "message.submit" -> HandledClientFrame(
-            MessageSubmitAck(
-                chatId = chatId.toString(),
-                requestId = node.path("requestId").asText("invalid"),
-                status = "rejected",
-                duplicate = false,
-                error = error,
-                receivedAt = now,
-            )
-        )
-        "history.append" -> HandledClientFrame(
-            HistoryAppendAck(
-                chatId = chatId.toString(),
-                requestId = node.path("requestId").asText("invalid"),
-                status = "rejected",
-                duplicate = false,
-                error = error,
-                receivedAt = now,
-            )
-        )
-        "tool.result" -> HandledClientFrame(
-            ToolResultAck(
-                chatId = chatId.toString(),
-                toolCallId = node.path("toolCallId").asText("invalid"),
-                threadId = node.path("threadId").asText("00000000-0000-0000-0000-000000000000"),
-                status = "rejected",
-                duplicate = false,
-                error = error,
-                receivedAt = now,
-            )
-        )
-        "thread.cancel" -> HandledClientFrame(
-            ThreadCancelAck(
-                chatId = chatId.toString(),
-                requestId = node.path("requestId").asText("invalid"),
-                threadId = node.path("threadId").asText("00000000-0000-0000-0000-000000000000"),
-                status = "rejected",
-                duplicate = false,
-                error = error,
-                receivedAt = now,
-            )
-        )
+    val requestId = node.path("requestId").asText("invalid")
+    val threadId = node.path("threadId").asText("00000000-0000-0000-0000-000000000000")
+    val response = when (kind) {
+        "message.submit" -> MessageSubmitAck.rejected(chatId.toString(), requestId, error, now)
+        "history.append" -> HistoryAppendAck.rejected(chatId.toString(), requestId, error, now)
+        "tool.result" -> ToolResultAck.rejected(chatId.toString(), threadId, node.path("toolCallId").asText("invalid"), error, now)
+        "thread.cancel" -> ThreadCancelAck.rejected(chatId.toString(), requestId, threadId, error, now)
         else -> throw InvalidClientFrameException("Unsupported frame kind.")
     }
+    return HandledClientFrame(response)
 }
 
 internal fun AgentEventEnvelope.isPublicClientEvent(): Boolean =

--- a/backend/src/test/kotlin/ru/souz/backend/e2e/BackendPublicWebSocketE2eTest.kt
+++ b/backend/src/test/kotlin/ru/souz/backend/e2e/BackendPublicWebSocketE2eTest.kt
@@ -87,6 +87,17 @@ class BackendPublicWebSocketE2eTest {
                 assertTrue(firstAck["thread"]["created"].asBoolean())
                 llm.awaitPrompt("first")
 
+                val httpStatus = client.get("${BackendHttpRoutes.chatThread(chatId, threadId)}?clientType=backend").jsonBody()
+                assertEquals(
+                    httpStatus.fieldNames().asSequence().toSet() + setOf("kind", "type", "requestId"),
+                    firstStatus.fieldNames().asSequence().toSet(),
+                )
+                httpStatus.fields().forEach { (field, value) ->
+                    if (field != "observedAt") assertEquals(value, firstStatus[field], field)
+                }
+                assertTrue(firstStatus["finishedAt"].isNull)
+                assertTrue(firstStatus["error"].isNull)
+
                 session.send(
                     Frame.Text(
                         messageFrame(chatId, userId, "wrong-thread", UUID.randomUUID().toString(), "wrong", "device-1")
@@ -124,6 +135,37 @@ class BackendPublicWebSocketE2eTest {
                     listOf("first", "second", "third"),
                     messages.filter { it["role"].asText() == "user" }.map { it["content"].asText() },
                 )
+            }
+        }
+
+    @Test
+    fun `malformed frames preserve available correlation identifiers in rejection acknowledgements`() =
+        backendE2eTest("e2e_ws_rejected_identifiers") {
+            val chatId = createPublicChat(UUID.randomUUID().toString())
+            withPublicSocket(chatId) { session ->
+                for (kind in listOf("message.submit", "history.append", "tool.result", "thread.cancel")) {
+                    for (identifier in listOf(null, "not-a-uuid")) {
+                        val frame = json.createObjectNode().put("kind", kind).put("chatId", chatId)
+                        identifier?.let {
+                            frame.put("requestId", it).put("threadId", it).put("toolCallId", it)
+                        }
+                        session.send(Frame.Text(frame.toString()))
+                        val rejected = readJson(session)
+                        assertEquals("ack", rejected["kind"].asText())
+                        assertEquals(chatId, rejected["chatId"].asText())
+                        assertEquals("rejected", rejected["status"].asText())
+                        assertFalse(rejected["duplicate"].asBoolean())
+                        assertEquals("invalid_request", rejected["error"]["code"].asText())
+                        val correlationField = if (kind == "tool.result") "toolCallId" else "requestId"
+                        assertEquals(identifier ?: "invalid", rejected[correlationField].asText())
+                        if (kind == "tool.result" || kind == "thread.cancel") {
+                            assertEquals(
+                                identifier ?: "00000000-0000-0000-0000-000000000000",
+                                rejected["threadId"].asText(),
+                            )
+                        }
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Client rejection responses and HTTP/WebSocket thread status duplicated construction logic, while graph execution had an interface with only one implementation. This refactoring shares that code while preserving the wire contract and both agent modes.

- Put rejection factories in each acknowledgement class's companion object and use them from the service and WebSocket routes.
- Flatten the shared HTTP status payload into WebSocket status frames with `@JsonUnwrapped`.
- Collapse `GraphExecutionDelegate` and its sole implementation into one concrete class.
- Verify status field parity, explicit nulls, and rejection correlation identifiers in WebSocket regression tests.

Removes 67 net production lines; 24 net lines overall including tests and documentation.

Validation:
- Full JVM test and coverage graph passed before the companion-factory relocation.
- Backend tests and `souzGateFast` passed after the relocation.
- Local duplication detection remains at baseline; the authoritative duplication gate runs in GitHub Actions.
- `git diff --check` passed.
