### PR TITLE
Make RepoWise advisory in PR CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
           python -m pip install --disable-pip-version-check
           --requirement quality/repowise-requirements.txt
 
-      - name: Test RepoWise quality ratchet
+      - name: Test RepoWise quality advisory
         run: python -m unittest quality.repowise_quality_gate_test
 
       - name: Prepare pull-request base checkout
@@ -210,7 +210,7 @@ jobs:
           repowise health . --no-workspace --format json \
             > build/reports/repowise/pr-health.json
 
-      - name: Enforce RepoWise code quality
+      - name: Render RepoWise quality advisory
         shell: bash
         run: |
           quality_report=build/reports/repowise/quality-ratchet.md

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -29,8 +29,8 @@ Fast checks have `local-safe` authority. The three coroutine checks are
 advisory and produce warnings; the other fast checks are blocking. Duplicate
 code is blocking with `ci-exact-checkout` authority. An unexpected checker
 failure is reported as `error`, not as a pass or policy failure.
-The RepoWise ratchet is blocking only in pull-request CI and compares the base
-with the squash-equivalent PR head.
+RepoWise pull-request quality is advisory and compares the base with the
+squash-equivalent PR head.
 
 Project dependencies declared in an unclassified configuration fail closed.
 Test-only edges should use a standard test source-set configuration so the
@@ -136,18 +136,17 @@ that its parents match the event's base and head, then grafts it onto the base a
 one commit. The merge tree includes base changes missing from a stale PR branch,
 while intermediate PR commits do not affect RepoWise health scores.
 
-The blocking ratchet requires the head to keep every RepoWise repository KPI at
-or above its base value: average and hotspot defect health, worst-performer
-health, average and hotspot maintainability, and average and hotspot
-performance. Equal and improved values pass; any decrease, analysis failure, or
-missing report fails. The comparison uses the PR base directly, so each merged
-improvement becomes the baseline for following pull requests.
+The advisory comparison reports base-to-head changes in average and hotspot
+defect health, worst-performer health, average and hotspot maintainability,
+and average and hotspot performance. KPI regressions appear in the job summary
+and uploaded artifacts but do not fail CI. Only execution errors, invalid
+reports, or missing or empty artifacts fail the RepoWise job.
 
 The same job runs `repowise risk` over the grafted base-to-merge revision range
 and publishes the PR's change-risk classification, percentile, size, spread,
-and main risk drivers. Change risk is advisory; only a code-health regression
-is blocking. The risk model keeps a 200-commit baseline. Global refactoring
-targets are intentionally excluded from PR runs.
+and main risk drivers. Change risk is advisory. The risk model keeps a
+200-commit baseline. Global refactoring targets are intentionally excluded
+from PR runs.
 
 ## Qodana advisory analysis
 

--- a/quality/repowise_quality_gate.py
+++ b/quality/repowise_quality_gate.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Fail when RepoWise repository health decreases from a PR base."""
+"""Render the advisory RepoWise pull-request quality comparison."""
 
 from __future__ import annotations
 
@@ -85,13 +85,13 @@ def _score(kpis: dict[str, Any], key: str, side: str) -> float:
 def render_markdown(
     comparisons: list[Comparison], base_sha: str, head_sha: str
 ) -> str:
-    failed = [comparison for comparison in comparisons if comparison.regressed]
-    status = "FAIL" if failed else "PASS"
+    regressions = any(comparison.regressed for comparison in comparisons)
+    status = "REGRESSION" if regressions else "PASS"
     lines = [
-        f"# RepoWise code-quality ratchet: {status}",
+        f"# RepoWise PR code-quality advisory: {status}",
         "",
-        "Every repository-level health score must stay equal to or improve over "
-        "the pull-request base. Higher scores are better.",
+        "RepoWise KPI regressions are reported for review but do not fail "
+        "pull-request CI. Higher scores are better.",
         "",
         f"Base: `{base_sha}` · PR: `{head_sha}`",
         "",
@@ -103,13 +103,6 @@ def render_markdown(
         lines.append(
             f"| {comparison.label} | {comparison.base:.2f} | "
             f"{comparison.head:.2f} | {comparison.delta:+.2f} | {result} |"
-        )
-    if failed:
-        lines.extend(
-            [
-                "",
-                "The PR decreases at least one RepoWise code-quality KPI.",
-            ]
         )
     return "\n".join(lines) + "\n"
 
@@ -127,8 +120,7 @@ def render_risk_markdown(risk: dict[str, Any]) -> str:
     lines = [
         "## PR change risk",
         "",
-        "This advisory score analyzes the PR diff itself; it does not affect the "
-        "quality-ratchet result.",
+        "This advisory score analyzes the PR diff itself.",
         "",
         "| Classification | Review priority | Percentile | Model score | Baseline |",
         "| --- | --- | ---: | ---: | ---: |",
@@ -199,7 +191,7 @@ def _write_report(path: Path, markdown: str) -> None:
     path.write_text(markdown, encoding="utf-8")
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--base", required=True, type=Path)
     parser.add_argument("--head", required=True, type=Path)
@@ -207,7 +199,7 @@ def main() -> int:
     parser.add_argument("--markdown", required=True, type=Path)
     parser.add_argument("--base-sha", required=True)
     parser.add_argument("--head-sha", required=True)
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     try:
         comparisons = compare_health(
@@ -219,13 +211,13 @@ def main() -> int:
             + render_risk_markdown(load_json_object(args.risk))
         )
     except (KeyError, ValueError) as error:
-        markdown = f"# RepoWise code-quality ratchet: ERROR\n\n{error}\n"
+        markdown = f"# RepoWise PR code-quality advisory: ERROR\n\n{error}\n"
         _write_report(args.markdown, markdown)
         print(error, file=sys.stderr)
         return 2
 
     _write_report(args.markdown, markdown)
-    return 1 if any(comparison.regressed for comparison in comparisons) else 0
+    return 0
 
 
 if __name__ == "__main__":

--- a/quality/repowise_quality_gate_test.py
+++ b/quality/repowise_quality_gate_test.py
@@ -1,65 +1,49 @@
+import contextlib
+import io
+import json
+import tempfile
 import unittest
+from pathlib import Path
 
-from quality.repowise_quality_gate import (
-    QUALITY_KPIS,
-    compare_health,
-    render_markdown,
-    render_risk_markdown,
-)
-
-
-def report(score: float, **overrides: float) -> dict:
-    kpis = {key: score for key, _ in QUALITY_KPIS}
-    kpis.update(overrides)
-    return {"kpis": kpis}
+from quality.repowise_quality_gate import QUALITY_KPIS, main
 
 
 class RepoWiseQualityGateTest(unittest.TestCase):
-    def test_equal_and_improved_scores_pass(self) -> None:
-        comparisons = compare_health(
-            report(8.0), report(8.0, average_health=8.1)
-        )
-
-        self.assertFalse(any(comparison.regressed for comparison in comparisons))
-        self.assertIn("ratchet: PASS", render_markdown(comparisons, "base", "head"))
-
-    def test_any_decrease_fails(self) -> None:
-        comparisons = compare_health(
-            report(8.0), report(8.0, maintainability_hotspot=7.99)
-        )
-
-        self.assertTrue(any(comparison.regressed for comparison in comparisons))
-        markdown = render_markdown(comparisons, "base", "head")
-        self.assertIn("ratchet: FAIL", markdown)
-        self.assertIn("| Maintainability · hotspots | 8.00 | 7.99 | -0.01 | regressed |", markdown)
-
-    def test_missing_kpi_is_rejected(self) -> None:
-        head = report(8.0)
-        del head["kpis"]["performance_average"]
-
-        with self.assertRaisesRegex(ValueError, "performance_average"):
-            compare_health(report(8.0), head)
-
-    def test_pr_risk_is_rendered_from_the_diff_metrics(self) -> None:
-        risk = {
-            "classification": "Typical",
-            "review_priority": "moderate",
-            "score": 7.2,
-            "risk_percentile": 61.5,
-            "baseline_sample_size": 200,
-            "features": {"la": 30, "ld": 12, "nf": 4, "nd": 2, "ns": 1, "entropy": 1.25},
-            "drivers": [
-                {"label": "more lines added", "value": 30, "contribution": 0.5},
-                {"label": "experienced author", "value": 10, "contribution": -0.1},
-            ],
-        }
-
-        markdown = render_risk_markdown(risk)
-
-        self.assertIn("## PR change risk", markdown)
-        self.assertIn("| 30 | 12 | 4 | 2 | 1 | 1.25 |", markdown)
-        self.assertIn("more lines added", markdown)
-        self.assertIn("-0.100", markdown)
+    def test_main_exit_status(self) -> None:
+        for score, expected_exit, result in [
+            (7.5, 0, "REGRESSION"),
+            ("bad", 2, "ERROR"),
+        ]:
+            with self.subTest(result=result), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                reports = {
+                    "base": {"kpis": {key: 8.0 for key, _ in QUALITY_KPIS}},
+                    "head": {"kpis": {key: score for key, _ in QUALITY_KPIS}},
+                    "risk": {
+                        "classification": "Typical",
+                        "review_priority": "moderate",
+                        "score": 7.2,
+                        "risk_percentile": 61.5,
+                        "baseline_sample_size": 200,
+                        "features": {"la": 30, "ld": 12, "nf": 4, "nd": 2, "ns": 1, "entropy": 1.25},
+                    },
+                }
+                for name, data in reports.items():
+                    (root / name).write_text(json.dumps(data), encoding="utf-8")
+                markdown = root / "quality-ratchet.md"
+                with contextlib.redirect_stderr(io.StringIO()):
+                    exit_code = main([
+                        "--base", str(root / "base"),
+                        "--head", str(root / "head"),
+                        "--risk", str(root / "risk"),
+                        "--markdown", str(markdown),
+                        "--base-sha", "base", "--head-sha", "head",
+                    ])
+                self.assertEqual(expected_exit, exit_code)
+                summary = markdown.read_text(encoding="utf-8")
+                self.assertIn(f"advisory: {result}", summary)
+                if expected_exit == 0:
+                    self.assertIn("PR change risk", summary)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
RepoWise KPI regressions are reported as advisory and no longer fail PR CI. Base/head health reports, PR risk, the Markdown summary, and uploaded artifacts remain required; execution errors, invalid reports, and missing artifacts still fail. Other quality gates are unchanged.

Remove redundant report text and keep one test covering regression success and invalid-report failure. Update workflow labels and quality-gate documentation.

Validation:
- `python3 -B -m unittest quality.repowise_quality_gate_test`
- `./gradlew :build-logic:check souzGateFast --console=plain --stacktrace`
- `git diff --check`
