### PR TITLE
Publish Qodana results in CI run summaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ permissions:
   contents: read
 
 jobs:
+  qodana:
+    uses: ./.github/workflows/qodana.yml
+
   quality-fast:
     name: Quality Gate
     runs-on: ubuntu-latest

--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -1,7 +1,7 @@
 name: Qodana
 
 on:
-  pull_request:
+  workflow_call:
   push:
     branches:
       - main
@@ -9,8 +9,6 @@ on:
 
 permissions:
   contents: read
-  checks: write
-  pull-requests: write
 
 concurrency:
   group: qodana-${{ github.workflow }}-${{ github.ref }}
@@ -44,8 +42,18 @@ jobs:
             --linter qodana-jvm-community
             --within-docker false
           pr-mode: true
-          use-annotations: true
-          post-pr-comment: true
+          use-annotations: false
+          post-pr-comment: false
           upload-result: true
           artifact-name: qodana-report-${{ github.run_id }}
           cache-default-branch-only: true
+
+      - name: Verify Qodana report
+        if: always()
+        shell: bash
+        run: |
+          if [[ ! -s "$RUNNER_TEMP/qodana/results/qodana.sarif.json" ]]; then
+            echo '### Qodana report missing' >> "$GITHUB_STEP_SUMMARY"
+            echo 'Analysis did not produce a nonempty SARIF report. See the Qodana step logs.' >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -154,18 +154,21 @@ targets are intentionally excluded from PR runs.
 Qodana Community provides an independent advisory analyzer alongside the
 repository's blocking quality gates. Its configuration lives at
 [`quality/qodana.yaml`](../quality/qodana.yaml), and GitHub Actions runs it
-through [`Qodana`](../.github/workflows/qodana.yml).
+through the reusable [`Qodana`](../.github/workflows/qodana.yml) workflow.
 
-The workflow runs on pull requests, pushes to `main`, and manual dispatch. It
-uses the Qodana JVM Community linter with JDK 21, enables pull-request mode,
-publishes GitHub annotations and a pull-request summary, uploads the full
-Qodana result artifact, passes the non-root configuration with `--config`, and
-uses GitHub cache support.
+[`CI-Tests`](../.github/workflows/ci.yml) calls Qodana for pull requests, placing
+its built-in summary and full report artifact on the same Actions run page.
+Qodana also runs on pushes to `main` and manual dispatch. It uses the JVM
+Community linter with JDK 21, pull-request mode, `--config quality/qodana.yaml`,
+and GitHub caches. Comments and API annotations are disabled; reporting uses
+read-only repository permissions and supports fork PRs after any required
+workflow approval.
 
 Qodana findings are advisory. The configuration has no baseline,
 `failureConditions`, fail threshold, or aggregate quality-score gate. Analyzer
-failures, invalid configuration, and infrastructure failures still fail the
-workflow. The workflow does not apply or push automatic fixes.
+failures, invalid configuration, infrastructure failures, and missing or empty
+SARIF reports still fail the workflow. Missing reports are noted in the run
+summary. The workflow does not apply or push automatic fixes.
 
 Qodana does not require a `QODANA_TOKEN`, Qodana Cloud account, or paid
 features. It relies on the repository `.gitignore` for generated and ignored


### PR DESCRIPTION
Publish Qodana results on the CI-Tests run page by calling the Qodana workflow as a reusable job. Reuse its built-in job summary and uploaded report; disable PR comments and API annotations and retain only read-only repository permissions for fork PRs.

Keep standalone main-branch and manual runs. Report missing or empty SARIF files in the summary and fail the job. Update the quality-gate documentation.

Validation:
- Workflow wiring, permissions, documentation links, and missing/empty/present report checks passed.
- `./gradlew :build-logic:check souzGateFast --console=plain --stacktrace` passed.
- `git diff --check` passed.

GitHub execution remains to be verified by this PR's CI run.
