### PR TITLE
Fix Kaniko snapshots of backend build JVM files

### DIFF
--- a/backend.Dockerfile
+++ b/backend.Dockerfile
@@ -5,7 +5,9 @@ WORKDIR /src
 
 COPY . .
 
-RUN ./gradlew :backend:installDist --no-daemon
+# Keep temporary JVM perfdata files out of Kaniko's post-build snapshot.
+RUN JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS:-} -XX:-UsePerfData" \
+    ./gradlew :backend:installDist --no-daemon
 
 FROM eclipse-temurin:21-jre
 WORKDIR /app

--- a/backend/docs/pain-points.md
+++ b/backend/docs/pain-points.md
@@ -10,6 +10,7 @@ Read the topics relevant to the code you plan to change in `:backend`.
 - [Distributed backend boundary](pain-points/distributed-backend-boundary.md) — which backend entry points have distributed runtime ownership and recovery.
 - [Telegram bindings](pain-points/telegram-bindings.md) — token custody, private-account linking, polling leases, and checkpoint safety.
 - [Testing](pain-points/testing.md) — production-wired E2E coverage, Docker requirement, and allowed test doubles.
+- [Container builds](pain-points/container-builds.md) — JVM temporary files and Kaniko snapshots.
 - [External memory](pain-points/external-memory.md) — Hindsight owner isolation, scope tags, grounded capture, and safe mutation boundaries.
 
 Add a focused topic only for a lasting, non-obvious constraint. Keep each topic current-state and operational.

--- a/backend/docs/pain-points/container-builds.md
+++ b/backend/docs/pain-points/container-builds.md
@@ -1,0 +1,7 @@
+# Container builds
+
+Kaniko must snapshot a stable filesystem after the Gradle build. JVM shutdown can delete `/tmp/hsperfdata_<user>/<pid>` during that scan, failing image creation even when `:backend:installDist` succeeds. Gradle can launch a single-use daemon with `--no-daemon`.
+
+The Gradle invocation in [backend.Dockerfile](../../../backend.Dockerfile) sets `-XX:-UsePerfData` through `JAVA_TOOL_OPTIONS`, preserving existing options and propagating the flag to child JVMs. Keep this setting scoped to the image build; Helm environment values only affect deployed containers and cannot fix image creation. Company-specific Dockerfiles must apply the flag to their build JVMs too.
+
+Verify by rerunning the Kaniko image-build job and checking that its post-Gradle snapshot and image push succeed. A successful Gradle or Docker BuildKit build alone does not exercise this race.


### PR DESCRIPTION
Kaniko can fail after a successful `:backend:installDist` when a build JVM removes `/tmp/hsperfdata_<user>/<pid>` during the filesystem snapshot. Pass `-XX:-UsePerfData` through `JAVA_TOOL_OPTIONS` on the Dockerfile's Gradle command to prevent those temporary files, preserve existing JVM options, and propagate the setting to child JVMs. The setting is scoped to the build command, leaving the runtime image's JVM monitoring unchanged.

Document the build constraint and the need to apply it to customized build Dockerfiles.

Validation:
- Java 21 smoke check confirmed `UsePerfData=false` and preservation of an existing `JAVA_TOOL_OPTIONS` property.
- `./gradlew souzGateFast` completed successfully with an existing advisory `SuspendFunSwallowedCancellation` warning in unchanged `AgentEventService.kt:143`.
- `npm ci --prefix quality` and `./gradlew souzDuplicationCheck` completed; production and test duplication totals match their baselines. Exact-checkout authority is reserved for GitHub Actions.
- Documentation links resolve; `git diff --check` passed.

The Kaniko image-build job still needs to be rerun to verify the snapshot and image push. Application runtime tests were not run locally for this Dockerfile-only behavior change.