### PR TITLE
Pre-size OpenAI-compatible request maps for tool serialization

### DIFF
--- a/sharedLogic/src/commonJvmMain/kotlin/ru/souz/llms/JsonSchemaPropertyMaps.kt
+++ b/sharedLogic/src/commonJvmMain/kotlin/ru/souz/llms/JsonSchemaPropertyMaps.kt
@@ -1,0 +1,19 @@
+package ru.souz.llms
+
+internal fun LLMRequest.Property.toJsonSchemaMap(
+    unconstrainedArrayItems: Boolean = false,
+): Map<String, Any> {
+    val includeItems = unconstrainedArrayItems && type == "array"
+    val capacity = 1 +
+        (if (description != null) 1 else 0) +
+        (if (enum != null) 1 else 0) +
+        (if (includeItems) 1 else 0)
+    return buildMap(capacity) {
+        put("type", type)
+        description?.let { put("description", it) }
+        enum?.let { put("enum", it) }
+        if (includeItems) {
+            put("items", emptyMap<String, Any>())
+        }
+    }
+}

--- a/sharedLogic/src/commonJvmMain/kotlin/ru/souz/llms/anthropic/AnthropicChatAPI.kt
+++ b/sharedLogic/src/commonJvmMain/kotlin/ru/souz/llms/anthropic/AnthropicChatAPI.kt
@@ -32,6 +32,7 @@ import ru.souz.llms.LLMResponse
 import ru.souz.llms.LlmProvider
 import ru.souz.llms.restJsonMapper
 import ru.souz.llms.toFinishReason
+import ru.souz.llms.toJsonSchemaMap
 import ru.souz.llms.toSystemPromptMessage
 import java.io.File
 import java.nio.file.Files
@@ -497,11 +498,7 @@ class AnthropicChatAPI(
     private fun buildTools(functions: List<LLMRequest.Function>): List<Map<String, Any>> {
         return functions.map { fn ->
             val properties = fn.parameters.properties.mapValues { (_, prop) ->
-                buildMap {
-                    put("type", prop.type)
-                    prop.description?.let { put("description", it) }
-                    prop.enum?.let { put("enum", it) }
-                }
+                prop.toJsonSchemaMap()
             }
 
             val inputSchema = mutableMapOf<String, Any>(

--- a/sharedLogic/src/commonJvmMain/kotlin/ru/souz/llms/codex/CodexChatAPI.kt
+++ b/sharedLogic/src/commonJvmMain/kotlin/ru/souz/llms/codex/CodexChatAPI.kt
@@ -25,6 +25,7 @@ import ru.souz.llms.LLMMessageRole
 import ru.souz.llms.LLMRequest
 import ru.souz.llms.LLMResponse
 import ru.souz.llms.restJsonMapper
+import ru.souz.llms.toJsonSchemaMap
 import java.io.File
 
 class CodexChatAPI(
@@ -171,21 +172,14 @@ class CodexChatAPI(
                 "parameters" to mapOf(
                     "type" to fn.parameters.type,
                     "properties" to fn.parameters.properties.mapValues { (_, prop) ->
-                        buildMap {
-                            put("type", prop.type)
-                            if (!prop.description.isNullOrBlank()) put("description", prop.description)
-                            if (!prop.enum.isNullOrEmpty()) put("enum", prop.enum)
-                            if (prop.type == "array") {
-                                put("items", emptyMap<String, Any>())
-                            }
-                        }
+                        prop.toJsonSchemaMap(unconstrainedArrayItems = true)
                     },
                     "required" to fn.parameters.required,
                 )
             )
         }
 
-        return buildMap {
+        return buildMap(6) {
             put("model", body.model)
             put("input", inputItems)
             if (!instructions.isNullOrBlank()) put("instructions", instructions)

--- a/sharedLogic/src/commonJvmMain/kotlin/ru/souz/llms/openai/OpenAICompatibleChatAPI.kt
+++ b/sharedLogic/src/commonJvmMain/kotlin/ru/souz/llms/openai/OpenAICompatibleChatAPI.kt
@@ -28,6 +28,7 @@ import ru.souz.llms.LLMResponse
 import ru.souz.llms.LlmProvider
 import ru.souz.llms.restJsonMapper
 import ru.souz.llms.toFinishReason
+import ru.souz.llms.toJsonSchemaMap
 import java.io.File
 
 class OpenAICompatibleChatAPI(
@@ -208,8 +209,9 @@ class OpenAICompatibleChatAPI(
 
     private fun buildChatRequest(body: LLMRequest.Chat, stream: Boolean): Map<String, Any> {
         val tools = buildTools(body.functions)
-        return buildMap {
-            requestParameters?.let { putAll(restJsonMapper.readValue<Map<String, Any>>(it)) }
+        val extraParameters = requestParameters?.let { restJsonMapper.readValue<Map<String, Any>>(it) }
+        return buildMap((extraParameters?.size ?: 0) + CHAT_REQUEST_FIELD_CAPACITY) {
+            extraParameters?.let { putAll(it) }
             put("model", modelOverride ?: resolveChatModel(body.model))
             put("messages", buildMessages(body.messages))
             put("stream", stream)
@@ -241,7 +243,7 @@ class OpenAICompatibleChatAPI(
         }
     }
 
-    private fun buildEmbeddingsRequest(body: LLMRequest.Embeddings): Map<String, Any> = buildMap {
+    private fun buildEmbeddingsRequest(body: LLMRequest.Embeddings): Map<String, Any> = buildMap(3) {
         put("model", resolveEmbeddingsModel(body.model))
         if (body.input.size == 1) {
             put("input", body.input.first())
@@ -315,10 +317,10 @@ class OpenAICompatibleChatAPI(
                         remainingToolResultNames[requestFunctionCall.name] = nameBudget - 1
                     }
                     pendingToolCallIdsByName.getOrPut(requestFunctionCall.name) { ArrayDeque() }.addLast(functionsStateId)
-                    buildMap {
+                    buildMap(3) {
                         put("id", functionsStateId)
                         put("type", "function")
-                        put("function", buildMap {
+                        put("function", buildMap(2) {
                             put("name", requestFunctionCall.name)
                             put("arguments", requestFunctionCall.arguments)
                         })
@@ -430,27 +432,21 @@ class OpenAICompatibleChatAPI(
     private fun buildTools(functions: List<LLMRequest.Function>): List<Map<String, Any>> {
         return functions.map { fn ->
             val properties = fn.parameters.properties.mapValues { (_, prop) ->
-                buildMap {
-                    put("type", prop.type)
-                    prop.description?.let { put("description", it) }
-                    prop.enum?.let { put("enum", it) }
-                    if (prop.type == "array") {
-                        // OpenAI tool schemas require `items` for every array type.
-                        // Keep items unconstrained so existing tools can pass arrays of strings, objects, or mixed payloads.
-                        put("items", emptyMap<String, Any>())
-                    }
-                }
+                // OpenAI tool schemas require `items` for every array type.
+                // Keep items unconstrained so existing tools can pass arrays of strings, objects, or mixed payloads.
+                prop.toJsonSchemaMap(unconstrainedArrayItems = true)
             }
-            buildMap {
+            val parametersCapacity = 2 + if (fn.parameters.required.isNotEmpty()) 1 else 0
+            buildMap(2) {
                 put("type", "function")
                 put(
                     "function",
-                    buildMap {
+                    buildMap(3) {
                         put("name", fn.name)
                         put("description", fn.description)
                         put(
                             "parameters",
-                            buildMap {
+                            buildMap(parametersCapacity) {
                                 put("type", fn.parameters.type)
                                 put("properties", properties)
                                 if (fn.parameters.required.isNotEmpty()) {
@@ -762,6 +758,8 @@ class OpenAICompatibleChatAPI(
         private const val EMBEDDINGS_PATH = "embeddings"
         private const val AI_TUNNEL_BASE_URL = "https://api.aitunnel.ru/v1"
         private const val QWEN_BASE_URL = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+        // model, messages, stream, plus optional reasoning/stream/temperature/max/parallel/tools/choice
+        private const val CHAT_REQUEST_FIELD_CAPACITY = 10
     }
 
     private val chatCompletionsUrl: String

--- a/sharedLogic/src/test/kotlin/ru/souz/llms/JsonSchemaPropertyMapsTest.kt
+++ b/sharedLogic/src/test/kotlin/ru/souz/llms/JsonSchemaPropertyMapsTest.kt
@@ -1,0 +1,34 @@
+package ru.souz.llms
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class JsonSchemaPropertyMapsTest {
+
+    @Test
+    fun `array properties include unconstrained items only when requested`() {
+        val property = LLMRequest.Property(
+            type = "array",
+            description = "ids",
+            enum = listOf("a", "b"),
+        )
+
+        val withoutItems = property.toJsonSchemaMap()
+        assertEquals("array", withoutItems["type"])
+        assertEquals("ids", withoutItems["description"])
+        assertEquals(listOf("a", "b"), withoutItems["enum"])
+        assertFalse("items" in withoutItems)
+
+        val withItems = property.toJsonSchemaMap(unconstrainedArrayItems = true)
+        assertEquals(emptyMap<String, Any>(), withItems["items"])
+        assertEquals(4, withItems.size)
+    }
+
+    @Test
+    fun `optional fields are omitted when absent`() {
+        val schema = LLMRequest.Property(type = "string").toJsonSchemaMap()
+        assertEquals(mapOf("type" to "string"), schema)
+        assertEquals(1, schema.size)
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #744.

Unsized `buildMap {}` calls in OpenAI-compatible request serialization allocate `HashMap(16)` for maps that hold a handful of known fields. That adds up on every LLM request when the tool catalog is 15–20 functions with nested property/function/parameter maps.

## Changes
- Size `buildChatRequest`, `buildEmbeddingsRequest`, tool-call, and nested tool maps from their known or bounded entry counts.
- Extract `toJsonSchemaMap()` so OpenAI, Codex, and Anthropic share property-schema construction instead of repeating unsized maps.

## Verification
- `./gradlew :sharedLogic:jvmTest --tests 'ru.souz.llms.OpenAICompatibleChatAPIRequestTest' --tests 'ru.souz.llms.CodexChatAPIRequestTest' --tests 'ru.souz.llms.JsonSchemaPropertyMapsTest' --tests 'ru.souz.llms.AnthropicChatAPICacheTest'`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7a2aea0-68c7-45e0-a1bc-4a2aa2960b71?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7a2aea0-68c7-45e0-a1bc-4a2aa2960b71&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

