### PR TITLE
Optimize web response header mapping

### DIFF
--- a/sharedLogic/src/commonJvmMain/kotlin/ru/souz/tool/web/internal/WebHttpSupport.kt
+++ b/sharedLogic/src/commonJvmMain/kotlin/ru/souz/tool/web/internal/WebHttpSupport.kt
@@ -241,7 +241,10 @@ private fun oversizeBinaryBodyError(url: String, maxBytes: Int): BadInputExcepti
     return BadInputException("HTTP response body is larger than ${maxMegabytes}MB for $url")
 }
 
-private fun Headers.toMap(): Map<String, List<String>> = entries().associate { it.key to it.value }
+private fun Headers.toMap(): Map<String, List<String>> =
+    buildMap(names().size) {
+        names().forEach { name -> put(name, getAll(name).orEmpty()) }
+    }
 
 private fun exponentialRetryDelayMillis(retry: Int): Long {
     val factor = 1L shl retry.coerceAtLeast(0)

--- a/sharedLogic/src/commonJvmMain/kotlin/ru/souz/tool/web/internal/WebHttpSupport.kt
+++ b/sharedLogic/src/commonJvmMain/kotlin/ru/souz/tool/web/internal/WebHttpSupport.kt
@@ -242,8 +242,8 @@ private fun oversizeBinaryBodyError(url: String, maxBytes: Int): BadInputExcepti
 }
 
 private fun Headers.toMap(): Map<String, List<String>> =
-    buildMap(names().size) {
-        names().forEach { name -> put(name, getAll(name).orEmpty()) }
+    buildMap(this@toMap.names().size) {
+        this@toMap.forEach { name, values -> put(name, values) }
     }
 
 private fun exponentialRetryDelayMillis(retry: Int): Long {


### PR DESCRIPTION
Closes #748

## Summary
- build the response-header map directly from header names
- avoid the intermediate entry set created by `entries().associate`
- preserve the non-null response header value contract

## Verification
- `./gradlew :sharedLogic:jvmTest --tests 'ru.souz.tool.web.*'`\n- `./gradlew souzGateFast`