### PR TITLE
Avoid buildList allocations in SandboxFileOperations.movePath

### DIFF
--- a/sharedLogic/src/jvmMain/kotlin/ru/souz/runtime/sandbox/SandboxFileOperations.kt
+++ b/sharedLogic/src/jvmMain/kotlin/ru/souz/runtime/sandbox/SandboxFileOperations.kt
@@ -15,17 +15,20 @@ internal fun movePath(
     replaceExisting: Boolean,
     logger: Logger?,
 ) {
-    val atomicOptions = buildList {
-        add(StandardCopyOption.ATOMIC_MOVE)
-        if (replaceExisting) add(StandardCopyOption.REPLACE_EXISTING)
-    }.toTypedArray()
-    val fallbackOptions = buildList {
-        if (replaceExisting) add(StandardCopyOption.REPLACE_EXISTING)
-    }.toTypedArray()
+    val atomicOptions = if (replaceExisting) {
+        arrayOf(StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+    } else {
+        arrayOf(StandardCopyOption.ATOMIC_MOVE)
+    }
     try {
         Files.move(sourcePath, destinationPath, *atomicOptions)
     } catch (exception: AtomicMoveNotSupportedException) {
         logger?.warn("Failed to make an atomic move", exception)
+        val fallbackOptions = if (replaceExisting) {
+            arrayOf(StandardCopyOption.REPLACE_EXISTING)
+        } else {
+            emptyArray()
+        }
         Files.move(sourcePath, destinationPath, *fallbackOptions)
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #747

## Summary
- build `CopyOption` arrays directly in `movePath` instead of `buildList { ... }.toTypedArray()`
- construct fallback options only inside the `AtomicMoveNotSupportedException` catch path

## Verification
- `./gradlew :sharedLogic:jvmTest --tests 'ru.souz.runtime.sandbox.*'`
- `./gradlew souzGateFast`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f296f54c-4f4d-47af-bb74-5bef98d207ae?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f296f54c-4f4d-47af-bb74-5bef98d207ae&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

