### PR TITLE
Fix RepoWise base SHA for PR merge checkouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,6 @@ jobs:
       PYTHONDONTWRITEBYTECODE: "1"
       REPOWISE_NO_SAVE_KEY: "1"
       REPOWISE_SKIP_EDITOR_SETUP: "1"
-      SOUZ_PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
       SOUZ_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
     steps:
@@ -169,7 +168,8 @@ jobs:
       - name: Treat PR merge as one commit
         shell: bash
         run: |
-          test "$(git rev-parse HEAD^1)" = "$SOUZ_PR_BASE_SHA"
+          SOUZ_PR_BASE_SHA="$(git rev-parse HEAD^1)"
+          echo "SOUZ_PR_BASE_SHA=$SOUZ_PR_BASE_SHA" >> "$GITHUB_ENV"
           test "$(git rev-parse HEAD^2)" = "$SOUZ_PR_HEAD_SHA"
           git replace --graft HEAD "$SOUZ_PR_BASE_SHA"
           test "$(git rev-list --count "$SOUZ_PR_BASE_SHA..HEAD")" = "1"

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -131,10 +131,11 @@ Pull-request CI installs the version of RepoWise pinned in
 checks out full Git history, and builds deterministic indexes for the PR base
 and head without an LLM, saved credentials, editor integration, or telemetry.
 
-Pull requests are squash-merged. CI checks out GitHub's PR merge commit, verifies
-that its parents match the event's base and head, then grafts it onto the base as
-one commit. The merge tree includes base changes missing from a stale PR branch,
-while intermediate PR commits do not affect RepoWise health scores.
+Pull requests are squash-merged. CI checks out GitHub's PR merge commit, uses its
+first parent as the base, verifies its second parent against the event's PR head,
+then grafts it onto the base as one commit. The merge tree includes base changes
+missing from a stale PR branch, while intermediate PR commits do not affect
+RepoWise health scores.
 
 The advisory comparison reports base-to-head changes in average and hotspot
 defect health, worst-performer health, average and hotspot maintainability,


### PR DESCRIPTION
The PR event's base SHA can differ from the checked-out merge commit's first parent, causing RepoWise to fail before analysis. Derive `SOUZ_PR_BASE_SHA` from `HEAD^1` before grafting and persist it through `GITHUB_ENV` so the graft, base checkout, comparisons, and reports all use the same base. Keep the `HEAD^2` validation against the expected PR head SHA and align the quality-gate documentation.

Validation passed:
- Actionlint 1.7.7 (ShellCheck disabled), YAML parsing, and Bash syntax checks.
- Temporary Git fixture covering a stale event base, downstream checkout/comparison/report arguments, and rejection of an unexpected PR head before grafting; RepoWise and report-rendering commands were stubbed.
- `python3 -m unittest quality.repowise_quality_gate_test`.
- `./gradlew souzGateFast :build-logic:check --console=plain`.
- Documentation local links and `git diff --check`.